### PR TITLE
Logging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,6 @@ target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)
 
 # Find and link to external dependencies
 find_package(SDL2 REQUIRED)
-message(STATUS "SDL2_INCLUDE_DIRS: ${SDL2_INCLUDE_DIRS}")
-message(STATUS "SDL2_LIBRARIES: ${SDL2_LIBRARIES}")
 target_link_libraries(AlphaEngine SDL2::SDL2)
 target_include_directories(AlphaEngine PRIVATE ${SDL2_INCLUDE_DIRS})
 
@@ -114,8 +112,6 @@ target_include_directories(AlphaEngine PRIVATE ${VENDOR_ROOT}Loguru)
 target_include_directories(AlphaEngine PRIVATE ${VENDOR_ROOT}STB/)
 
 find_package(GLEW REQUIRED)
-message(STATUS "GLEW_INCLUDE_DIRS: ${GLEW_INCLUDE_DIRS}")
-message(STATUS "GLEW_LIBRARIES: ${GLEW_LIBRARIES}")
 target_link_libraries(AlphaEngine GLEW::GLEW)
 #target_include_directories(AlphaEngine PRIVATE ${GLEW_INCLUDE_DIRS})
 

--- a/Control/MainLoop.cpp
+++ b/Control/MainLoop.cpp
@@ -36,7 +36,6 @@ int main(int argc, char* argv[])
 
     try
     {
-        Infrastructure::Log::GetInstance()->Init();
         EventEngine::Context::GetInstance()->Init();
         RenderingEngine::Context::GetInstance()->Init();
         SceneGraph::Context::GetInstance()->Init();

--- a/Infrastructure/Log.cpp
+++ b/Infrastructure/Log.cpp
@@ -25,20 +25,27 @@
 #include <Infrastructure/Log.hpp>
 #include <Infrastructure/Version.hpp>
 
-Infrastructure::Log* const Infrastructure::Log::GetInstance()
+static int verbosity_to_loguru(infrastructure::verbosity verbosity)
 {
-    static Log* instance = nullptr;
-
-    if (instance == nullptr)
+    switch (verbosity)
     {
-        instance = new Log();
+    case infrastructure::verbosity::INFO:
+        return loguru::Verbosity_INFO;
+    case infrastructure::verbosity::WARN:
+        return loguru::Verbosity_WARNING;
+    case infrastructure::verbosity::ERROR:
+        return loguru::Verbosity_ERROR;
+    case infrastructure::verbosity::FATAL:
+        return loguru::Verbosity_FATAL;
+    default:
+        return loguru::Verbosity_OFF;
     }
-
-    return instance;
 }
 
-void Infrastructure::Log::Init()
+void infrastructure::log::init(int argc, char* argv[])
 {
+    loguru::init(argc, argv);
+
 #ifdef _DEBUG
     //loguru::add_file("everything.log", loguru::Append, loguru::Verbosity_MAX);
     //loguru::add_file("latest_readable.log", loguru::Truncate, loguru::Verbosity_INFO);
@@ -48,4 +55,12 @@ void Infrastructure::Log::Init()
 #endif
 
     LOG_INFO("AlphaEngine v%s starting ...", Infrastructure::Version::GetVersion().c_str());
+}
+
+void infrastructure::log::message(enum verbosity verbosity, const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    VLOG_F(verbosity_to_loguru(verbosity), format, args);
+    va_end(args);
 }

--- a/Infrastructure/Log.hpp
+++ b/Infrastructure/Log.hpp
@@ -22,24 +22,41 @@
 
 #pragma once
 
-#include <Loguru.hpp>
+#define LOG_INIT(argc, argv) infrastructure::log::init(argc, argv)
 
-#define LOG_INIT(argc, argv) loguru::init(argc, argv)
+#define LOG_INFO(...) infrastructure::log::message(infrastructure::verbosity::INFO, __VA_ARGS__)
+#define LOG_WARN(...) infrastructure::log::message(infrastructure::verbosity::WARN, __VA_ARGS__)
+#define LOG_ERROR(...) infrastructure::log::message(infrastructure::verbosity::ERROR, __VA_ARGS__)
+#define LOG_FATAL(...) infrastructure::log::message(infrastructure::verbosity::FATAL, __VA_ARGS__)
 
-#define LOG_INFO(...) LOG_F(INFO, __VA_ARGS__)
-#define LOG_WARN(...) LOG_F(WARNING, __VA_ARGS__)
-#define LOG_ERROR(...) LOG_F(ERROR, __VA_ARGS__)
-#define LOG_FATAL(...) LOG_F(FATAL, __VA_ARGS__)
-
-namespace Infrastructure
+namespace infrastructure
 {
-    class Log
+    enum class verbosity
     {
-        Log() = default;
+        INFO,
+        WARN,
+        ERROR,
+        FATAL
+    };
 
-    public:
-        static Log* const GetInstance();
+    /**
+     * @brief The logging system
+     */
+    struct log
+    {
+        /**
+         * @brief Initializes the logging system
+         * @param argc The number of arguments
+         * @param argv The arguments
+         */
+        static void init(int argc, char* argv[]);
 
-        void Init();
+        /**
+         * @brief Logs an info message
+         * @param verbosity The verbosity of the message (INFO, WARN, ERROR, FATAL)
+         * @param format The format of the message
+         * @param ... The arguments
+         */
+        static void message(enum verbosity verbosity, const char* format, ...);
     };
 }


### PR DESCRIPTION
This PR introduces changes to the logging interface. Previously, the `loguru` third-party external library was included in every compilation unit that required logging (almost all of them). However, `loguru` is now hidden behind the logging API.