### PR TITLE
Move rendering utilities from infrastructure to rendering engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ file(GLOB RENDERING_ENGINE_FILES
         "RenderingEngine/Renderables/Premade3D/*.hpp" "RenderingEngine/Renderables/Premade3D/*.cpp"
         "RenderingEngine/Renderers/*.hpp" "RenderingEngine/Renderers/*.cpp"
         "RenderingEngine/Camera/*.hpp" "RenderingEngine/Camera/*.cpp"
-        "RenderingEngine/OpenGL/*.hpp" "RenderingEngine/OpenGL/*.cpp")
+        "RenderingEngine/OpenGL/*.hpp" "RenderingEngine/OpenGL/*.cpp"
+        "RenderingEngine/Util/*.hpp" "RenderingEngine/Util/*.cpp")
 file(GLOB EXTERNAL_FILES
         "External/*.hpp" "External/*.cpp"
         "External/API/*.hpp" "External/API/*.cpp")

--- a/RenderingEngine/Camera/Camera.hpp
+++ b/RenderingEngine/Camera/Camera.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <glm.hpp>
-#include <Infrastructure/Transform.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
 
 namespace RenderingEngine
 {
@@ -37,7 +37,7 @@ namespace RenderingEngine
 
         static Camera *GetCurrentCamera();
 
-        Infrastructure::Transform transform;
+        RenderingEngine::Util::Transform transform;
 
         void InvalidateViewMatrix();
         const glm::mat4 GetViewMatrix() const;

--- a/RenderingEngine/OpenGL/OpenGL.cpp
+++ b/RenderingEngine/OpenGL/OpenGL.cpp
@@ -136,7 +136,7 @@ void RenderingEngine::OpenGL::Context::Disable(const RenderingEngine::OpenGL::Ca
     glDisable((GLenum)capability);
 }
 
-void RenderingEngine::OpenGL::Context::ClearColor(const Infrastructure::Color& color)
+void RenderingEngine::OpenGL::Context::ClearColor(const RenderingEngine::Util::Color& color)
 {
     glClearColor(color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, color.a / 255.0f);
 }

--- a/RenderingEngine/OpenGL/OpenGL.hpp
+++ b/RenderingEngine/OpenGL/OpenGL.hpp
@@ -29,7 +29,7 @@
 #include <RenderingEngine/OpenGL/Typedef.hpp>
 #include <RenderingEngine/OpenGL/VertexArray.hpp>
 #include <RenderingEngine/OpenGL/VertexBuffer.hpp>
-#include <Infrastructure/Color.hpp>
+#include <RenderingEngine/Util/Color.hpp>
 
 namespace RenderingEngine
 {
@@ -59,7 +59,7 @@ namespace RenderingEngine
             void Enable(OpenGL::Capability capability);
             void Disable(OpenGL::Capability capability);
 
-            void ClearColor(const Infrastructure::Color& color);
+            void ClearColor(const RenderingEngine::Util::Color& color);
             void Clear(OpenGL::Buffer buffers);
             void DepthMask(bool writeEnabled);
 

--- a/RenderingEngine/Renderables/Model.hpp
+++ b/RenderingEngine/Renderables/Model.hpp
@@ -24,7 +24,7 @@
 
 #include <RenderingEngine/Renderables/Renderable.hpp>
 #include <RenderingEngine/Mesh/Mesh.hpp>
-#include <Infrastructure/Transform.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
 
 #include <RenderingEngine/OpenGL/OpenGL.hpp>
 
@@ -34,7 +34,7 @@ namespace RenderingEngine
     {
         Model();
 
-        Infrastructure::Transform transform;
+        RenderingEngine::Util::Transform transform;
 
         void UploadMesh(const RenderingEngine::Mesh& mesh);
 

--- a/RenderingEngine/Renderables/Premade2D/Label.cpp
+++ b/RenderingEngine/Renderables/Premade2D/Label.cpp
@@ -25,9 +25,9 @@
 #include <RenderingEngine/RenderingEngine.hpp>
 #include <RenderingEngine/Mesh/Vertex.hpp>
 #include <Infrastructure/Log.hpp>
-#include <Infrastructure/Image.hpp>
+#include <RenderingEngine/Util/Image.hpp>
 
-RenderingEngine::Label::Label(Infrastructure::Font* font, float size, const std::string& text) :
+RenderingEngine::Label::Label(RenderingEngine::Util::Font* font, float size, const std::string& text) :
     m_Font{ font },
     m_Text{ text }
 {
@@ -42,7 +42,7 @@ RenderingEngine::Label::Label(Infrastructure::Font* font, float size, const std:
         }
 
         int x0, y0, x1, y1;
-        const Infrastructure::Image* image = font->GetImage(c, &x0, &y0, &x1, &y1);
+        const RenderingEngine::Util::Image* image = font->GetImage(c, &x0, &y0, &x1, &y1);
         LOG_INFO("%c - %i %i %i %i", c, x0, y0, x1, y1);
         const float width = ((float)image->GetWidth() / image->GetHeight()) * size;
         RenderingEngine::Pane *pane = new RenderingEngine::Pane(glm::vec2{ width, size });

--- a/RenderingEngine/Renderables/Premade2D/Label.hpp
+++ b/RenderingEngine/Renderables/Premade2D/Label.hpp
@@ -26,23 +26,23 @@
 #include <RenderingEngine/Renderables/Premade2D/Pane.hpp>
 
 #include <RenderingEngine/OpenGL/OpenGL.hpp>
-#include <Infrastructure/Transform.hpp>
-#include <Infrastructure/Image.hpp>
-#include <Infrastructure/Font.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
+#include <RenderingEngine/Util/Image.hpp>
+#include <RenderingEngine/Util/Font.hpp>
 
 namespace RenderingEngine
 {
     struct Label : public Renderable
     {
-        Label(Infrastructure::Font *font, float size, const std::string& text);
+        Label(RenderingEngine::Util::Font *font, float size, const std::string& text);
 
-        Infrastructure::Transform transform;
+        RenderingEngine::Util::Transform transform;
 
         void Upload() final;
         void Render() final;
 
     private:
-        Infrastructure::Font* m_Font;
+        RenderingEngine::Util::Font* m_Font;
         std::string m_Text;
         std::vector<RenderingEngine::Pane *> m_Panes;
     };

--- a/RenderingEngine/Renderables/Premade2D/Pane.cpp
+++ b/RenderingEngine/Renderables/Premade2D/Pane.cpp
@@ -36,12 +36,12 @@ RenderingEngine::Pane::Pane(const glm::vec2& size) :
     m_Texture { nullptr }
 {}
 
-void RenderingEngine::Pane::SetColor(const Infrastructure::Color& color)
+void RenderingEngine::Pane::SetColor(const RenderingEngine::Util::Color& color)
 {
     m_Color = color;
 }
 
-void RenderingEngine::Pane::SetImage(const Infrastructure::Image& image)
+void RenderingEngine::Pane::SetImage(const RenderingEngine::Util::Image& image)
 {
     m_Texture = RenderingEngine::OpenGL::Context::GetInstance()->CreateTexture();
     m_Texture->Image2D(

--- a/RenderingEngine/Renderables/Premade2D/Pane.hpp
+++ b/RenderingEngine/Renderables/Premade2D/Pane.hpp
@@ -25,8 +25,8 @@
 #include <RenderingEngine/Renderables/Renderable.hpp>
 
 #include <RenderingEngine/OpenGL/OpenGL.hpp>
-#include <Infrastructure/Transform.hpp>
-#include <Infrastructure/Image.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
+#include <RenderingEngine/Util/Image.hpp>
 
 namespace RenderingEngine
 {
@@ -34,10 +34,10 @@ namespace RenderingEngine
     {
         Pane(const glm::vec2& size);
 
-        void SetColor(const Infrastructure::Color& color);
-        void SetImage(const Infrastructure::Image& image);
+        void SetColor(const RenderingEngine::Util::Color& color);
+        void SetImage(const RenderingEngine::Util::Image& image);
 
-        Infrastructure::Transform transform;
+        RenderingEngine::Util::Transform transform;
 
         void Upload() final;
         void Render() final;
@@ -50,7 +50,7 @@ namespace RenderingEngine
         unsigned int m_VertexCount;
 
         glm::vec2 m_Size;
-        Infrastructure::Color m_Color;
+        RenderingEngine::Util::Color m_Color;
         RenderingEngine::OpenGL::Texture* m_Texture;
     };
 }

--- a/RenderingEngine/Renderables/Premade3D/Cube.hpp
+++ b/RenderingEngine/Renderables/Premade3D/Cube.hpp
@@ -25,7 +25,7 @@
 #include <RenderingEngine/Renderables/Renderable.hpp>
 
 #include <RenderingEngine/OpenGL/OpenGL.hpp>
-#include <Infrastructure/Transform.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
 
 namespace RenderingEngine
 {
@@ -33,7 +33,7 @@ namespace RenderingEngine
     {
         Cube();
 
-        Infrastructure::Transform transform;
+        RenderingEngine::Util::Transform transform;
 
         void Upload() final;
         void Render() final;

--- a/RenderingEngine/Renderers/RenderOptions.hpp
+++ b/RenderingEngine/Renderers/RenderOptions.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <map>
 
-#include <Infrastructure/Color.hpp>
+#include <RenderingEngine/Util/Color.hpp>
 #include <RenderingEngine/OpenGL/Texture.hpp>
 
 namespace RenderingEngine
@@ -34,6 +34,6 @@ namespace RenderingEngine
     {
         std::map<std::string, float> Coefficients;
         std::map<std::string, OpenGL::Texture*> Textures;
-        std::map<std::string, Infrastructure::Color> Colors;
+        std::map<std::string, RenderingEngine::Util::Color> Colors;
     };
 }

--- a/RenderingEngine/Util/Color.hpp
+++ b/RenderingEngine/Util/Color.hpp
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <cstdint>
 
-namespace Infrastructure
+namespace RenderingEngine::Util
 {
     struct alignas(1) Color
     {

--- a/RenderingEngine/Util/Font.cpp
+++ b/RenderingEngine/Util/Font.cpp
@@ -21,13 +21,13 @@
  */
 
 #define STB_TRUETYPE_IMPLEMENTATION
-#include <Infrastructure/Font.hpp>
+#include <RenderingEngine/Util/Font.hpp>
 #include <Infrastructure/Log.hpp>
 
 #include <vector>
 #include <fstream>
 
-Infrastructure::Font::Font(const std::string& filename, float fontSize)
+RenderingEngine::Util::Font::Font(const std::string& filename, float fontSize)
 {
     std::ifstream file(filename, std::ios::binary | std::ios::ate);
     std::streamsize size = file.tellg();
@@ -60,7 +60,7 @@ Infrastructure::Font::Font(const std::string& filename, float fontSize)
     LOG_INFO("Loaded font \"%s\"", filename.c_str());
 }
 
-const Infrastructure::Image* Infrastructure::Font::GetImage(char letter, int *x0, int *y0, int* x1, int* y1)
+const RenderingEngine::Util::Image* RenderingEngine::Util::Font::GetImage(char letter, int *x0, int *y0, int* x1, int* y1)
 {
     stbtt_GetCodepointBitmapBoxSubpixel(&m_Font, letter, m_Scale, m_Scale, 0, 0, x0, y0, x1, y1);
     return m_Images[letter];

--- a/RenderingEngine/Util/Font.hpp
+++ b/RenderingEngine/Util/Font.hpp
@@ -22,30 +22,25 @@
 
 #pragma once
 
-#include <glm.hpp>
+#include <string>
+#include <map>
+#include <vector>
 
-namespace Infrastructure
+#include <RenderingEngine/Util/Image.hpp>
+#include <stb_truetype.hpp>
+
+namespace RenderingEngine::Util
 {
-    struct Transform
+    struct Font
     {
-        Transform();
+        Font(const std::string& filename, float fontSize);
 
-        void SetPosition(const glm::vec3& position);
-        void SetRotation(const glm::vec3& rotation);
-        void SetScale(const glm::vec3& scale);
-
-        glm::vec3 GetPosition() const;
-        glm::vec3 GetRotation() const;
-        glm::vec3 GetScale() const;
-
-        glm::mat4 GetTransformMatrix() const;
+        const RenderingEngine::Util::Image* GetImage(char letter, int* x0, int* y0, int* x1, int* y1);
 
     private:
-        mutable glm::mat4 m_TransformMatrix;
-        mutable bool m_IsTransformMatrixDirty;
-
-        glm::vec3 m_Position;
-        glm::vec3 m_Rotation;
-        glm::vec3 m_Scale;
+        std::map<char, RenderingEngine::Util::Image *> m_Images;
+        std::vector<unsigned char> m_Buffer;
+        stbtt_fontinfo m_Font;
+        float m_Scale;
     };
 }

--- a/RenderingEngine/Util/Image.cpp
+++ b/RenderingEngine/Util/Image.cpp
@@ -28,13 +28,13 @@
 #include "stb_image.hpp"
 #include <Infrastructure/Log.hpp>
 
-Infrastructure::Image::Image() :
+RenderingEngine::Util::Image::Image() :
         m_ImageData { nullptr },
         m_Width { 0u },
         m_Height { 0u }
 {}
 
-Infrastructure::Image::Image(const std::string& filename) :
+RenderingEngine::Util::Image::Image(const std::string& filename) :
         m_ImageData { nullptr },
         m_Width { 0u },
         m_Height { 0u }
@@ -51,7 +51,7 @@ Infrastructure::Image::Image(const std::string& filename) :
     LOG_INFO("Loaded image (%s)", filename.c_str());
 }
 
-Infrastructure::Image::Image(const Image& image) :
+RenderingEngine::Util::Image::Image(const Image& image) :
         m_Width { image.m_Width },
         m_Height { image.m_Height },
         m_ImageData { new Color[image.m_Width * image.m_Height] }
@@ -59,7 +59,7 @@ Infrastructure::Image::Image(const Image& image) :
     memcpy(m_ImageData, image.m_ImageData, m_Width * m_Height * sizeof(Color));
 }
 
-Infrastructure::Image::Image(Image&& image) noexcept :
+RenderingEngine::Util::Image::Image(Image&& image) noexcept :
         m_Width { image.m_Width },
         m_Height { image.m_Height },
         m_ImageData { image.m_ImageData }
@@ -69,7 +69,7 @@ Infrastructure::Image::Image(Image&& image) noexcept :
     image.m_ImageData = nullptr;
 }
 
-Infrastructure::Image::Image(uint32_t width, uint32_t height, const Color& background) :
+RenderingEngine::Util::Image::Image(uint32_t width, uint32_t height, const Color& background) :
         m_ImageData { new Color[width * height] },
         m_Width { width },
         m_Height { height }
@@ -80,19 +80,19 @@ Infrastructure::Image::Image(uint32_t width, uint32_t height, const Color& backg
     }
 }
 
-Infrastructure::Image::Image(uint32_t width, uint32_t height, Color* data) :
+RenderingEngine::Util::Image::Image(uint32_t width, uint32_t height, Color* data) :
         m_ImageData { data },
         m_Width { width },
         m_Height { height }
 {}
 
-Infrastructure::Image::~Image()
+RenderingEngine::Util::Image::~Image()
 {
     if (m_ImageData == nullptr) return;
     delete[] m_ImageData;
 }
 
-Infrastructure::Image& Infrastructure::Image::operator=(const Infrastructure::Image& image)
+RenderingEngine::Util::Image& RenderingEngine::Util::Image::operator=(const RenderingEngine::Util::Image& image)
 {
     m_Width = image.m_Width;
     m_Height = image.m_Height;
@@ -100,7 +100,7 @@ Infrastructure::Image& Infrastructure::Image::operator=(const Infrastructure::Im
     return *this;
 }
 
-Infrastructure::Image& Infrastructure::Image::operator=(Image&& image) noexcept
+RenderingEngine::Util::Image& RenderingEngine::Util::Image::operator=(Image&& image) noexcept
 {
     m_Width = image.m_Width;
     m_Height = image.m_Height;
@@ -112,28 +112,28 @@ Infrastructure::Image& Infrastructure::Image::operator=(Image&& image) noexcept
     return *this;
 }
 
-const unsigned int Infrastructure::Image::GetWidth() const
+const unsigned int RenderingEngine::Util::Image::GetWidth() const
 {
     return m_Width;
 }
 
-const unsigned int Infrastructure::Image::GetHeight() const
+const unsigned int RenderingEngine::Util::Image::GetHeight() const
 {
     return m_Height;
 }
 
-const Infrastructure::Color* const Infrastructure::Image::GetPixels() const
+const RenderingEngine::Util::Color* const RenderingEngine::Util::Image::GetPixels() const
 {
     return m_ImageData;
 }
 
-Infrastructure::Color Infrastructure::Image::GetPixel(uint32_t x, uint32_t y) const
+RenderingEngine::Util::Color RenderingEngine::Util::Image::GetPixel(uint32_t x, uint32_t y) const
 {
     if (x >= m_Width || y >= m_Height) return Color();
     return m_ImageData[x + y * m_Width];
 }
 
-void Infrastructure::Image::SetPixel(uint32_t x, uint32_t y, const Color& color)
+void RenderingEngine::Util::Image::SetPixel(uint32_t x, uint32_t y, const Color& color)
 {
     if (x >= m_Width || y >= m_Height) return;
     m_ImageData[x + y * m_Width] = color;

--- a/RenderingEngine/Util/Image.hpp
+++ b/RenderingEngine/Util/Image.hpp
@@ -22,25 +22,35 @@
 
 #pragma once
 
+#include <RenderingEngine/Util/Color.hpp>
 #include <string>
-#include <map>
-#include <vector>
 
-#include <Infrastructure/Image.hpp>
-#include <stb_truetype.hpp>
-
-namespace Infrastructure
+namespace RenderingEngine::Util
 {
-    struct Font
+    struct Image
     {
-        Font(const std::string& filename, float fontSize);
+        Image();
+        explicit Image(const std::string& filename);
+        Image(const Image& image);
+        Image(Image&& image) noexcept;
 
-        const Infrastructure::Image* GetImage(char letter, int* x0, int* y0, int* x1, int* y1);
+        Image(uint32_t width, uint32_t height, const Color& background);
+        Image(uint32_t width, uint32_t height, Color* data);
+
+        virtual ~Image();
+
+        Image& operator=(const Image& image);
+        Image& operator=(Image&& image) noexcept;
+
+        const uint32_t GetWidth() const;
+        const uint32_t GetHeight() const;
+        const Color* const GetPixels() const;
+
+        Color GetPixel(uint32_t x, uint32_t y) const;
+        void SetPixel(uint32_t x, uint32_t y, const Color& color);
 
     private:
-        std::map<char, Infrastructure::Image *> m_Images;
-        std::vector<unsigned char> m_Buffer;
-        stbtt_fontinfo m_Font;
-        float m_Scale;
+        Color* m_ImageData;
+        uint32_t m_Width, m_Height;
     };
 }

--- a/RenderingEngine/Util/Transform.cpp
+++ b/RenderingEngine/Util/Transform.cpp
@@ -20,51 +20,51 @@
  * SOFTWARE.
  */
 
-#include <Infrastructure/Transform.hpp>
+#include <RenderingEngine/Util/Transform.hpp>
 #define GLM_ENABLE_EXPERIMENTAL
 #include <gtx/transform.hpp>
 
-Infrastructure::Transform::Transform() :
+RenderingEngine::Util::Transform::Transform() :
         m_IsTransformMatrixDirty { true },
         m_Position { 0.0f, 0.0f, 0.0f },
         m_Rotation { 0.0f, 0.0f, 0.0f },
         m_Scale { 1.0f, 1.0f, 1.0f }
 {}
 
-void Infrastructure::Transform::SetPosition(const glm::vec3& position)
+void RenderingEngine::Util::Transform::SetPosition(const glm::vec3& position)
 {
     m_Position = position;
     m_IsTransformMatrixDirty = true;
 }
 
-void Infrastructure::Transform::SetRotation(const glm::vec3& rotation)
+void RenderingEngine::Util::Transform::SetRotation(const glm::vec3& rotation)
 {
     m_Rotation = rotation;
     m_IsTransformMatrixDirty = true;
 }
 
-void Infrastructure::Transform::SetScale(const glm::vec3& scale)
+void RenderingEngine::Util::Transform::SetScale(const glm::vec3& scale)
 {
     m_Scale = scale;
     m_IsTransformMatrixDirty = true;
 }
 
-glm::vec3 Infrastructure::Transform::GetPosition() const
+glm::vec3 RenderingEngine::Util::Transform::GetPosition() const
 {
     return m_Position;
 }
 
-glm::vec3 Infrastructure::Transform::GetRotation() const
+glm::vec3 RenderingEngine::Util::Transform::GetRotation() const
 {
     return m_Rotation;
 }
 
-glm::vec3 Infrastructure::Transform::GetScale() const
+glm::vec3 RenderingEngine::Util::Transform::GetScale() const
 {
     return m_Scale;
 }
 
-glm::mat4 Infrastructure::Transform::GetTransformMatrix() const
+glm::mat4 RenderingEngine::Util::Transform::GetTransformMatrix() const
 {
     if (!m_IsTransformMatrixDirty)
     {

--- a/RenderingEngine/Util/Transform.hpp
+++ b/RenderingEngine/Util/Transform.hpp
@@ -22,35 +22,30 @@
 
 #pragma once
 
-#include <Infrastructure/Color.hpp>
-#include <string>
+#include <glm.hpp>
 
-namespace Infrastructure
+namespace RenderingEngine::Util
 {
-    struct Image
+    struct Transform
     {
-        Image();
-        explicit Image(const std::string& filename);
-        Image(const Image& image);
-        Image(Image&& image) noexcept;
+        Transform();
 
-        Image(uint32_t width, uint32_t height, const Color& background);
-        Image(uint32_t width, uint32_t height, Color* data);
+        void SetPosition(const glm::vec3& position);
+        void SetRotation(const glm::vec3& rotation);
+        void SetScale(const glm::vec3& scale);
 
-        virtual ~Image();
+        glm::vec3 GetPosition() const;
+        glm::vec3 GetRotation() const;
+        glm::vec3 GetScale() const;
 
-        Image& operator=(const Image& image);
-        Image& operator=(Image&& image) noexcept;
-
-        const uint32_t GetWidth() const;
-        const uint32_t GetHeight() const;
-        const Color* const GetPixels() const;
-
-        Color GetPixel(uint32_t x, uint32_t y) const;
-        void SetPixel(uint32_t x, uint32_t y, const Color& color);
+        glm::mat4 GetTransformMatrix() const;
 
     private:
-        Color* m_ImageData;
-        uint32_t m_Width, m_Height;
+        mutable glm::mat4 m_TransformMatrix;
+        mutable bool m_IsTransformMatrixDirty;
+
+        glm::vec3 m_Position;
+        glm::vec3 m_Rotation;
+        glm::vec3 m_Scale;
     };
 }

--- a/RenderingEngine/Window.cpp
+++ b/RenderingEngine/Window.cpp
@@ -26,7 +26,7 @@
 #include <RenderingEngine/OpenGL/OpenGL.hpp>
 #include <SDL.h>
 #include <Infrastructure/Settings.hpp>
-#include <Infrastructure/Color.hpp>
+#include <RenderingEngine/Util/Color.hpp>
 #include <Infrastructure/Log.hpp>
 
 namespace RenderingEngine
@@ -107,7 +107,7 @@ namespace RenderingEngine
 
     void Window::Clear()
     {
-        OpenGL::Context::GetInstance()->ClearColor(Infrastructure::Color{ 0, 0, 0, 255 });
+        OpenGL::Context::GetInstance()->ClearColor(RenderingEngine::Util::Color{ 0, 0, 0, 255 });
         OpenGL::Context::GetInstance()->Clear(OpenGL::Buffer::Color);
         OpenGL::Context::GetInstance()->Clear(OpenGL::Buffer::Depth);
     }


### PR DESCRIPTION
Infrastructure utilities like Image, Font, Color, and so on will never be used outside the rendering engine. Therefore, this PR contains commits that move the necessary files from the infrastructure to the rendering engine.