### PR TITLE
repo: fix build on windows

### DIFF
--- a/Infrastructure/Buffer.hpp
+++ b/Infrastructure/Buffer.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/Infrastructure/Log.cpp
+++ b/Infrastructure/Log.cpp
@@ -25,17 +25,17 @@
 #include <Infrastructure/log.hpp>
 #include <Infrastructure/Version.hpp>
 
-static int verbosity_to_loguru(infrastructure::verbosity verbosity)
+static int verbosity_to_loguru(infrastructure::logging::verbosity verbosity)
 {
     switch (verbosity)
     {
-    case infrastructure::verbosity::INFO:
+    case infrastructure::logging::verbosity::INFO:
         return loguru::Verbosity_INFO;
-    case infrastructure::verbosity::WARN:
+    case infrastructure::logging::verbosity::WARN:
         return loguru::Verbosity_WARNING;
-    case infrastructure::verbosity::ERROR:
+    case infrastructure::logging::verbosity::ERROR:
         return loguru::Verbosity_ERROR;
-    case infrastructure::verbosity::FATAL:
+    case infrastructure::logging::verbosity::FATAL:
         return loguru::Verbosity_FATAL;
     default:
         return loguru::Verbosity_OFF;

--- a/Infrastructure/Log.hpp
+++ b/Infrastructure/Log.hpp
@@ -22,6 +22,12 @@
 
 #pragma once
 
+// wingdi.h (pulled in by windows.h) defines ERROR as a preprocessor macro,
+// which collides with the verbosity::ERROR enumerator below.
+#ifdef ERROR
+#undef ERROR
+#endif
+
 #define LOG_INIT(argc, argv) infrastructure::logging::init(argc, argv)
 
 #define LOG_INF(...) infrastructure::logging::message(infrastructure::logging::verbosity::INFO, __VA_ARGS__)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized build/compatibility fixes with minimal behavior change; primary risk is unintended macro side effects from `#undef ERROR` in translation units that include `Log.hpp`.
> 
> **Overview**
> Fixes Windows build issues by adding an explicit `<cstdint>` include for `uint8_t` in `Infrastructure/Buffer.hpp` and guarding against the `ERROR` macro from `windows.h` by `#undef`ing it in `Infrastructure/Log.hpp`.
> 
> Also updates `Log.cpp` to reference the correct `infrastructure::logging::verbosity` enum when mapping to Loguru verbosity levels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c901f5a18bfd438c9310d34eebc4a6d8adf0319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->