### PR TITLE
cmake: refactor CMakeLists.txt to improve debug flag handling and compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,14 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-# Add debug definitions and flags
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions(-D_DEBUG)
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi /Od")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
-    endif()
+# Add debug definitions and flags. Use generator expressions so this works
+# correctly with multi-config generators (e.g. Visual Studio) where
+# CMAKE_BUILD_TYPE is empty at configure time.
+add_compile_definitions($<$<CONFIG:Debug>:_DEBUG>)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_options($<$<CONFIG:Debug>:/Zi> $<$<CONFIG:Debug>:/Od>)
+else()
+    add_compile_options($<$<CONFIG:Debug>:-g> $<$<CONFIG:Debug>:-O0>)
 endif()
 
 # Set cmake module directory
@@ -99,7 +99,9 @@ add_executable(AlphaEngine
     ${RENDERING_ENGINE_FILES})
 
 # Use C++ standard library
-target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)
+endif()
 
 # Find and link to external dependencies
 find_package(SDL2 REQUIRED)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-system-only changes that primarily affect how debug flags and compiler-specific options are applied; risk is limited to potential misconfiguration across different generators/compilers.
> 
> **Overview**
> Improves Debug build handling by switching to CMake generator expressions for `_DEBUG` and debug compile flags, so multi-config generators (e.g. Visual Studio) apply them per-configuration instead of relying on `CMAKE_BUILD_TYPE` at configure time.
> 
> Restricts the `-stdlib=libc++` option to Clang/AppleClang only, avoiding passing an unsupported flag to other compilers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92ab8156b71048b303cd0c84add23b9d4edf015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->