### PR TITLE
scripts: add build and setup scripts for windows environment

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Configures and builds AlphaEngine on Windows.
+
+.DESCRIPTION
+    Detects an installed toolchain and builds the project.
+    - If vcpkg is present at -VcpkgRoot, uses the Visual Studio 2022 generator
+      with the vcpkg toolchain file (the setup that scripts\setup-windows.ps1
+      produces).
+    - Otherwise, falls back to MSYS2 UCRT64 (Ninja + g++) if installed.
+
+    Can be run from any directory; resolves the repo root from the script path.
+
+.PARAMETER Toolchain
+    auto (default), msvc, or msys2.
+
+.PARAMETER Configuration
+    CMake build configuration. Debug, Release, RelWithDebInfo, MinSizeRel.
+    Defaults to Release.
+
+.PARAMETER Clean
+    Delete the build directory before configuring.
+
+.PARAMETER VcpkgRoot
+    vcpkg install location. Defaults to C:\vcpkg.
+
+.PARAMETER Msys2Root
+    MSYS2 install location. Defaults to C:\msys64.
+
+.PARAMETER BuildDir
+    Override the build directory (default: <repo>/build).
+
+.EXAMPLE
+    PS> .\scripts\build.ps1
+    PS> .\scripts\build.ps1 -Configuration Debug -Clean
+    PS> .\scripts\build.ps1 -Toolchain msys2
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('auto','msvc','msys2')]
+    [string]$Toolchain = 'auto',
+    [ValidateSet('Debug','Release','RelWithDebInfo','MinSizeRel')]
+    [string]$Configuration = 'Release',
+    [switch]$Clean,
+    [string]$VcpkgRoot = 'C:\vcpkg',
+    [string]$Msys2Root = 'C:\msys64',
+    [string]$BuildDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step { param([string]$m) Write-Host "==> $m" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$m) Write-Host "    $m" -ForegroundColor Green }
+function Fail       { param([string]$m) Write-Host "    $m" -ForegroundColor Red; throw $m }
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not (Test-Path (Join-Path $repoRoot 'CMakeLists.txt'))) {
+    Fail "CMakeLists.txt not found at $repoRoot. Is this script in the repo's scripts/ folder?"
+}
+if (-not $BuildDir) { $BuildDir = Join-Path $repoRoot 'build' }
+
+Write-Step "Repo root: $repoRoot"
+Write-Ok   "Build dir: $BuildDir"
+Write-Ok   "Configuration: $Configuration"
+
+# --- Toolchain detection ---
+$vcpkgExe = Join-Path $VcpkgRoot 'vcpkg.exe'
+$msys2Gpp = Join-Path $Msys2Root 'ucrt64\bin\g++.exe'
+
+if ($Toolchain -eq 'auto') {
+    if (Test-Path $vcpkgExe)      { $Toolchain = 'msvc' }
+    elseif (Test-Path $msys2Gpp)  { $Toolchain = 'msys2' }
+    else { Fail "No toolchain detected. Run .\scripts\setup-windows.ps1 first (or install MSYS2 at $Msys2Root)." }
+}
+Write-Step "Toolchain: $Toolchain"
+
+if ($Toolchain -eq 'msvc') {
+    if (-not (Test-Path $vcpkgExe)) { Fail "vcpkg not found at $vcpkgExe." }
+} else {
+    if (-not (Test-Path $msys2Gpp)) { Fail "MSYS2 g++ not found at $msys2Gpp." }
+}
+
+# --- Optional clean ---
+if ($Clean -and (Test-Path $BuildDir)) {
+    Write-Step "Cleaning $BuildDir"
+    Remove-Item -Recurse -Force -LiteralPath $BuildDir
+    Write-Ok "Removed"
+}
+
+# --- Find cmake ---
+$cmakeCmd = Get-Command cmake -ErrorAction SilentlyContinue
+$cmake = if ($cmakeCmd) { $cmakeCmd.Source } else { $null }
+if (-not $cmake) {
+    $fallback = if ($Toolchain -eq 'msys2') { Join-Path $Msys2Root 'ucrt64\bin\cmake.exe' } else { $null }
+    if ($fallback -and (Test-Path $fallback)) { $cmake = $fallback }
+    else { Fail "cmake not found on PATH. Install it (setup-windows.ps1 handles this) or point PATH at one." }
+}
+Write-Ok "CMake: $cmake"
+
+# --- Configure + build ---
+$configArgs = @('-S', $repoRoot, '-B', $BuildDir)
+$buildArgs  = @('--build', $BuildDir)
+
+if ($Toolchain -eq 'msvc') {
+    $vcpkgFwd = $VcpkgRoot -replace '\\','/'
+    $configArgs += @(
+        '-G', 'Visual Studio 17 2022',
+        '-A', 'x64',
+        "-DCMAKE_TOOLCHAIN_FILE=$vcpkgFwd/scripts/buildsystems/vcpkg.cmake",
+        "-DGLM_INCLUDE_DIR=$vcpkgFwd/installed/x64-windows/include/glm"
+    )
+    $buildArgs += @('--config', $Configuration)
+    $expectedExe = Join-Path $repoRoot "Binaries\$Configuration\AlphaEngine.exe"
+} else {
+    $gppFwd = ($msys2Gpp -replace '\\','/')
+    $glmFwd = (Join-Path $Msys2Root 'ucrt64\include\glm') -replace '\\','/'
+    $env:Path = (Join-Path $Msys2Root 'ucrt64\bin') + ';' + $env:Path
+    $configArgs += @(
+        '-G', 'Ninja',
+        "-DCMAKE_BUILD_TYPE=$Configuration",
+        "-DCMAKE_CXX_COMPILER=$gppFwd",
+        "-DGLM_INCLUDE_DIR=$glmFwd"
+    )
+    $expectedExe = Join-Path $repoRoot "Binaries\AlphaEngine.exe"
+}
+
+Write-Step "Configuring"
+& $cmake @configArgs
+if ($LASTEXITCODE -ne 0) { Fail "cmake configure failed (exit $LASTEXITCODE)." }
+Write-Ok "Configure succeeded"
+
+Write-Step "Building"
+& $cmake @buildArgs
+if ($LASTEXITCODE -ne 0) { Fail "cmake build failed (exit $LASTEXITCODE)." }
+Write-Ok "Build succeeded"
+
+# --- Verify output ---
+Write-Step "Verifying output"
+if (-not (Test-Path $expectedExe)) { Fail "Expected binary missing: $expectedExe" }
+$size = (Get-Item $expectedExe).Length
+Write-Ok ("Built: {0} ({1:N0} bytes)" -f $expectedExe, $size)
+
+Write-Host ""
+Write-Host "Build complete." -ForegroundColor Green

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+    Bootstraps a Windows 11 machine so AlphaEngine can be built and run with MSVC.
+
+.DESCRIPTION
+    Installs Visual Studio 2022 Build Tools (C++ workload) and vcpkg, then uses
+    vcpkg to install SDL2, GLEW, and GLM. Safe to re-run: every step skips work
+    that has already been done.
+
+    After completion, build from the repo root with:
+
+        cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+            -DGLM_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include
+        cmake --build build --config Release
+
+    The resulting binary is written to Binaries\Release\AlphaEngine.exe.
+
+.PARAMETER VcpkgRoot
+    Location where vcpkg is (or will be) installed. Defaults to C:\vcpkg.
+
+.EXAMPLE
+    PS> .\scripts\setup-windows.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$VcpkgRoot = 'C:\vcpkg'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step { param([string]$Message) Write-Host "==> $Message" -ForegroundColor Cyan }
+function Write-Ok   { param([string]$Message) Write-Host "    $Message" -ForegroundColor Green }
+
+if (-not [System.Environment]::OSVersion.Platform.ToString().StartsWith('Win')) {
+    throw "This script only runs on Windows."
+}
+
+Write-Step "Checking for winget"
+$winget = Get-Command winget -ErrorAction SilentlyContinue
+if (-not $winget) {
+    throw "winget is not available. Install 'App Installer' from the Microsoft Store, then re-run this script."
+}
+Write-Ok "winget found"
+
+Write-Step "Installing Git (if missing)"
+if (Get-Command git -ErrorAction SilentlyContinue) {
+    Write-Ok "Git already installed"
+} else {
+    winget install --id Git.Git --silent --accept-package-agreements --accept-source-agreements | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install Git (exit $LASTEXITCODE)." }
+    # Refresh PATH for this session so `git` is usable below.
+    $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')
+    Write-Ok "Git installed"
+}
+
+Write-Step "Installing Visual Studio 2022 Build Tools with C++ workload (if missing)"
+# vswhere.exe ships with any VS installation and is the canonical way to detect one.
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$hasVcTools = $false
+if (Test-Path $vswhere) {
+    $found = & $vswhere -products '*' -requires Microsoft.VisualStudio.Workload.VCTools -latest -property installationPath 2>$null
+    if ($LASTEXITCODE -eq 0 -and $found) { $hasVcTools = $true }
+}
+if ($hasVcTools) {
+    Write-Ok "Visual Studio Build Tools with C++ workload already installed"
+} else {
+    Write-Host "    Installing - this is a multi-GB download and may take a while..."
+    winget install --id Microsoft.VisualStudio.2022.BuildTools `
+        --silent --accept-package-agreements --accept-source-agreements `
+        --override "--wait --quiet --norestart --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install VS Build Tools (exit $LASTEXITCODE)." }
+    Write-Ok "Visual Studio Build Tools installed"
+}
+
+Write-Step "Installing CMake (if missing)"
+if (Get-Command cmake -ErrorAction SilentlyContinue) {
+    Write-Ok "CMake already on PATH"
+} else {
+    winget install --id Kitware.CMake --silent --accept-package-agreements --accept-source-agreements | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Failed to install CMake (exit $LASTEXITCODE)." }
+    $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')
+    Write-Ok "CMake installed"
+}
+
+Write-Step "Setting up vcpkg at $VcpkgRoot"
+if (-not (Test-Path $VcpkgRoot)) {
+    git clone --depth 1 https://github.com/microsoft/vcpkg.git $VcpkgRoot
+    if ($LASTEXITCODE -ne 0) { throw "git clone of vcpkg failed." }
+}
+$vcpkgExe = Join-Path $VcpkgRoot 'vcpkg.exe'
+if (-not (Test-Path $vcpkgExe)) {
+    & (Join-Path $VcpkgRoot 'bootstrap-vcpkg.bat') -disableMetrics
+    if ($LASTEXITCODE -ne 0) { throw "vcpkg bootstrap failed." }
+}
+Write-Ok "vcpkg ready at $VcpkgRoot"
+
+Write-Step "Installing SDL2, GLEW, GLM via vcpkg (x64-windows)"
+& $vcpkgExe install sdl2:x64-windows glew:x64-windows glm:x64-windows --recurse | Out-Host
+if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed." }
+Write-Ok "Libraries installed"
+
+$vcpkgFwd = $VcpkgRoot -replace '\\','/'
+$template = @'
+
+Environment is ready.
+
+To build AlphaEngine from the repository root, run:
+
+    cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_TOOLCHAIN_FILE={0}/scripts/buildsystems/vcpkg.cmake -DGLM_INCLUDE_DIR={0}/installed/x64-windows/include/glm
+    cmake --build build --config Release
+
+The binary will be produced at Binaries\Release\AlphaEngine.exe.
+'@
+Write-Host ($template -f $vcpkgFwd) -ForegroundColor Green


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds new developer tooling scripts without modifying runtime code; main risk is accidental environment changes on developer machines due to `winget` installs and file deletion when `-Clean` is used.
> 
> **Overview**
> Adds `scripts/setup-windows.ps1` to bootstrap a Windows machine for building AlphaEngine by installing Git, VS 2022 Build Tools (C++), and CMake via `winget`, cloning/bootstrapping `vcpkg`, and installing SDL2/GLEW/GLM.
> 
> Adds `scripts/build.ps1` to configure and build the project from any directory, auto-detecting `msvc` (vcpkg + VS 2022) vs `msys2` (Ninja + g++), optionally cleaning the build directory, and verifying the expected `AlphaEngine.exe` output path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13e80e5a929c60a25b817db558affca4e92c123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->