### PR TITLE
fix: register on_render_ui callback for render_ui event

### DIFF
--- a/external/api/game_module.cpp
+++ b/external/api/game_module.cpp
@@ -53,7 +53,7 @@ void register_game_module(struct game_module_info& info)
     if (info.on_render_ui)
     {
         event_engine::context::get_instance().register_listener(event_engine::event_type::render_ui,
-                                                                info.on_render_scene);
+                                                                info.on_render_ui);
     }
 
     if (info.on_mouse_key_down)


### PR DESCRIPTION
## Summary
- Fixes #13
- The `on_render_ui` handler in [external/api/game_module.cpp:56](external/api/game_module.cpp#L56) was registered with `info.on_render_scene` as the callback, so UI modules never fired on UI render events.

## Test plan
- [x] Build and verify UI module callbacks fire during UI rendering