### PR TITLE
refactor: replace raw pointers with RAII ownership semantics

### DIFF
--- a/external/api/camera.cpp
+++ b/external/api/camera.cpp
@@ -25,6 +25,7 @@
 #include <rendering_engine/rendering_engine.hpp>
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -32,24 +33,22 @@ struct camera_info
 {
     camera_id id;
     camera_type type;
-    rendering_engine::camera* handle;
+    std::unique_ptr<rendering_engine::camera> handle;
 };
 
-static std::vector<struct camera_info*> camera_infos;
+static std::vector<std::unique_ptr<camera_info>> camera_infos;
 
-static struct camera_info* get_camera_info(camera_id id)
+static camera_info* get_camera_info(camera_id id)
 {
-    struct camera_info* result{nullptr};
-
-    for (auto camera_info : camera_infos)
+    for (auto& info : camera_infos)
     {
-        if (camera_info->id == id)
+        if (info->id == id)
         {
-            result = camera_info;
+            return info.get();
         }
     }
 
-    return result;
+    return nullptr;
 }
 
 camera_id get_new_camera_id()
@@ -66,10 +65,10 @@ camera_id get_new_camera_id()
 
 camera_id create_camera(camera_type type)
 {
-    struct camera_info* camera_info{new struct camera_info};
+    auto info = std::make_unique<camera_info>();
 
-    camera_info->id = get_new_camera_id();
-    camera_info->type = type;
+    info->id = get_new_camera_id();
+    info->type = type;
 
     switch (type)
     {
@@ -77,25 +76,23 @@ camera_id create_camera(camera_type type)
     case camera_type::orthographic:
         // TODO: Implement Orthographic camera.
     case camera_type::perspective:
-        camera_info->handle = new rendering_engine::perspective_camera;
+        info->handle = std::make_unique<rendering_engine::perspective_camera>();
     }
 
-    camera_infos.push_back(camera_info);
-    return camera_info->id;
+    camera_id id = info->id;
+    camera_infos.push_back(std::move(info));
+    return id;
 }
 
 void destroy_camera(camera_id id)
 {
-    auto camera_info = get_camera_info(id);
+    auto it = std::find_if(begin(camera_infos), end(camera_infos),
+                           [id](const std::unique_ptr<camera_info>& info) { return info->id == id; });
 
-    if (camera_info == nullptr)
+    if (it == end(camera_infos))
         return;
 
-    auto it = std::find(begin(camera_infos), end(camera_infos), camera_info);
-
-    delete camera_info->handle;
-
-    camera_infos.erase(std::find(begin(camera_infos), end(camera_infos), camera_info));
+    camera_infos.erase(it);
 }
 
 camera_type get_camera_type(camera_id id)
@@ -160,11 +157,6 @@ void get_camera_rot(camera_id id, float* rx, float* ry, float* rz)
 
 void destroy_all_cameras()
 {
-    for (auto& camera_info : camera_infos)
-    {
-        delete camera_info->handle;
-    }
-
     camera_infos.clear();
 }
 
@@ -200,7 +192,7 @@ bool is_camera_attached(camera_id id)
     if (camera_info == nullptr)
         return false;
 
-    return (rendering_engine::camera::get_current_camera() == camera_info->handle);
+    return (rendering_engine::camera::get_current_camera() == camera_info->handle.get());
 }
 
 bool is_any_camera_attached()

--- a/external/cube_module.cpp
+++ b/external/cube_module.cpp
@@ -28,16 +28,22 @@
 
 #include <rendering_engine/opengl/opengl.hpp>
 
-static rendering_engine::cube* cube;
+#include <memory>
+
+static std::unique_ptr<rendering_engine::cube> cube;
 
 float rotation = 0.0f;
 float rotation_speed = 3.14f / 2;
 
 static void on_engine_start(const event_engine::event& event)
 {
-    cube = new rendering_engine::cube();
-
+    cube = std::make_unique<rendering_engine::cube>();
     cube->upload();
+}
+
+static void on_engine_stop(const event_engine::event& event)
+{
+    cube.reset();
 }
 
 static void on_frame(const event_engine::event& event)
@@ -55,6 +61,7 @@ GAME_MODULE()
 {
     struct game_module_info info;
     info.on_engine_start = on_engine_start;
+    info.on_engine_stop = on_engine_stop;
     info.on_render_scene = on_render_scene;
     info.on_frame = on_frame;
     register_game_module(info);

--- a/rendering_engine/camera/camera.hpp
+++ b/rendering_engine/camera/camera.hpp
@@ -35,6 +35,7 @@ namespace rendering_engine
         void attach();
         void detach();
 
+        // Non-owning: points to the currently attached camera, or nullptr.
         static camera* get_current_camera();
 
         rendering_engine::util::transform transform;
@@ -51,6 +52,7 @@ namespace rendering_engine
         mutable glm::mat4 m_projection;
         mutable bool m_is_projection_matrix_dirty;
 
+        // Non-owning observer: lifetime managed elsewhere (e.g. by the creator of the camera).
         static camera* m_current_camera;
     };
 } // namespace rendering_engine

--- a/rendering_engine/renderables/premade_2d/label.cpp
+++ b/rendering_engine/renderables/premade_2d/label.cpp
@@ -44,11 +44,11 @@ rendering_engine::label::label(rendering_engine::util::font* font, float size, c
         const rendering_engine::util::image* image = font->get_image(c, &x0, &y0, &x1, &y1);
         LOG_INF("%c - %i %i %i %i", c, x0, y0, x1, y1);
         const float width = ((float)image->get_width() / image->get_height()) * size;
-        rendering_engine::pane* pane = new rendering_engine::pane(glm::vec2{width, size});
+        auto pane = std::make_unique<rendering_engine::pane>(glm::vec2{width, size});
         pane->set_image(*image);
         pane->transform.set_position(glm::vec3{-0.3f + position, 0.95f, 0.0f});
         position += width + size * 0.1;
-        m_panes.push_back(pane);
+        m_panes.push_back(std::move(pane));
     }
 }
 

--- a/rendering_engine/renderables/premade_2d/label.hpp
+++ b/rendering_engine/renderables/premade_2d/label.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <rendering_engine/renderables/premade_2d/pane.hpp>
 #include <rendering_engine/renderables/renderable.hpp>
 
@@ -42,8 +44,9 @@ namespace rendering_engine
         void render() final;
 
     private:
+        // Non-owning: font lifetime is managed by the caller.
         rendering_engine::util::font* m_font;
         std::string m_text;
-        std::vector<rendering_engine::pane*> m_panes;
+        std::vector<std::unique_ptr<rendering_engine::pane>> m_panes;
     };
 } // namespace rendering_engine

--- a/rendering_engine/renderers/renderer.cpp
+++ b/rendering_engine/renderers/renderer.cpp
@@ -28,16 +28,34 @@
 
 rendering_engine::renderer* rendering_engine::renderer::m_current_renderer = nullptr;
 
+void rendering_engine::shader_deleter::operator()(opengl::shader* s) const noexcept
+{
+    if (s != nullptr)
+    {
+        opengl::context::get_instance().delete_shader(s);
+    }
+}
+
+void rendering_engine::program_deleter::operator()(opengl::program* p) const noexcept
+{
+    if (p != nullptr)
+    {
+        opengl::context::get_instance().delete_program(p);
+    }
+}
+
+rendering_engine::renderer::~renderer() = default;
+
 void rendering_engine::renderer::start_renderer()
 {
     m_current_renderer = this;
-    static_cast<opengl::program*>(m_program)->start();
+    m_program->start();
 }
 
 void rendering_engine::renderer::stop_renderer()
 {
     m_current_renderer = nullptr;
-    static_cast<opengl::program*>(m_program)->stop();
+    m_program->stop();
 }
 
 rendering_engine::renderer* rendering_engine::renderer::get_current_renderer()
@@ -87,105 +105,101 @@ void rendering_engine::renderer::setup_options(const render_options& options)
 
 void rendering_engine::renderer::upload_texture_reference(const std::string& texture_name, const int position)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(texture_name);
+    opengl::uniform uniform = m_program->get_uniform(texture_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", texture_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, position);
+    m_program->set_uniform(uniform, position);
 }
 
 void rendering_engine::renderer::upload_coefficient(const std::string& coefficient_name, const float coefficient)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(coefficient_name);
+    opengl::uniform uniform = m_program->get_uniform(coefficient_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", coefficient_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, coefficient);
+    m_program->set_uniform(uniform, coefficient);
 }
 
 void rendering_engine::renderer::upload_matrix3(const std::string& mat3_name, const glm::mat3& matrix)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(mat3_name);
+    opengl::uniform uniform = m_program->get_uniform(mat3_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", mat3_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, matrix);
+    m_program->set_uniform(uniform, matrix);
 }
 
 void rendering_engine::renderer::upload_matrix4(const std::string& mat4_name, const glm::mat4& matrix)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(mat4_name);
+    opengl::uniform uniform = m_program->get_uniform(mat4_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", mat4_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, matrix);
+    m_program->set_uniform(uniform, matrix);
 }
 
 void rendering_engine::renderer::upload_vector2(const std::string& vec2_name, const glm::vec2& vector)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(vec2_name);
+    opengl::uniform uniform = m_program->get_uniform(vec2_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", vec2_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, vector);
+    m_program->set_uniform(uniform, vector);
 }
 
 void rendering_engine::renderer::upload_vector3(const std::string& vec3_name, const glm::vec3& vector)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(vec3_name);
+    opengl::uniform uniform = m_program->get_uniform(vec3_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", vec3_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, vector);
+    m_program->set_uniform(uniform, vector);
 }
 
 void rendering_engine::renderer::upload_vector4(const std::string& vec4_name, const glm::vec4& vector)
 {
-    opengl::uniform uniform = static_cast<opengl::program*>(m_program)->get_uniform(vec4_name);
+    opengl::uniform uniform = m_program->get_uniform(vec4_name);
     if (uniform == -1)
     {
         LOG_WRN("Cannot find uniform: %s", vec4_name.c_str());
         return;
     }
-    static_cast<opengl::program*>(m_program)->set_uniform(uniform, vector);
+    m_program->set_uniform(uniform, vector);
 }
 
 void rendering_engine::renderer::construct_program(const std::string& vs_string, const std::string& fs_string)
 {
-    m_vertex_shader = opengl::context::get_instance().create_shader(opengl::shader_type::vertex);
-    m_fragment_shader = opengl::context::get_instance().create_shader(opengl::shader_type::fragment);
-    m_program = opengl::context::get_instance().create_program();
+    m_vertex_shader.reset(opengl::context::get_instance().create_shader(opengl::shader_type::vertex));
+    m_fragment_shader.reset(opengl::context::get_instance().create_shader(opengl::shader_type::fragment));
+    m_program.reset(opengl::context::get_instance().create_program());
 
-    auto vs = (opengl::shader*)m_vertex_shader;
-    auto fs = (opengl::shader*)m_fragment_shader;
-    auto prog = (opengl::program*)m_program;
+    m_vertex_shader->source(vs_string);
+    m_vertex_shader->compile();
 
-    vs->source(vs_string);
-    vs->compile();
+    m_fragment_shader->source(fs_string);
+    m_fragment_shader->compile();
 
-    fs->source(fs_string);
-    fs->compile();
-
-    prog->attach(*vs);
-    prog->attach(*fs);
-    prog->link();
+    m_program->attach(*m_vertex_shader);
+    m_program->attach(*m_fragment_shader);
+    m_program->link();
 }
 
 void rendering_engine::renderer::destruct_program()
 {
-    opengl::context::get_instance().delete_shader((opengl::shader*)m_vertex_shader);
-    opengl::context::get_instance().delete_shader((opengl::shader*)m_fragment_shader);
-    opengl::context::get_instance().delete_program((opengl::program*)m_program);
+    m_vertex_shader.reset();
+    m_fragment_shader.reset();
+    m_program.reset();
 }

--- a/rendering_engine/renderers/renderer.hpp
+++ b/rendering_engine/renderers/renderer.hpp
@@ -23,17 +23,35 @@
 #pragma once
 
 #include <glm.hpp>
+#include <memory>
 #include <string>
 
 #include <rendering_engine/renderers/render_options.hpp>
 
 namespace rendering_engine
 {
+    namespace opengl
+    {
+        class shader;
+        class program;
+    }
+
+    struct shader_deleter
+    {
+        void operator()(opengl::shader* s) const noexcept;
+    };
+
+    struct program_deleter
+    {
+        void operator()(opengl::program* p) const noexcept;
+    };
+
     struct renderer
     {
         void start_renderer();
         void stop_renderer();
 
+        // Non-owning: points to the currently attached renderer, or nullptr.
         static renderer* get_current_renderer();
 
         void setup_camera();
@@ -49,14 +67,16 @@ namespace rendering_engine
 
     protected:
         renderer() = default;
+        ~renderer();
 
         void construct_program(const std::string& vs_string, const std::string& fs_string);
         void destruct_program();
 
-        void* m_vertex_shader;
-        void* m_fragment_shader;
-        void* m_program;
+        std::unique_ptr<opengl::shader, shader_deleter> m_vertex_shader;
+        std::unique_ptr<opengl::shader, shader_deleter> m_fragment_shader;
+        std::unique_ptr<opengl::program, program_deleter> m_program;
 
+        // Non-owning: points to the currently active renderer, or nullptr.
         static renderer* m_current_renderer;
     };
 } // namespace rendering_engine

--- a/rendering_engine/util/font.cpp
+++ b/rendering_engine/util/font.cpp
@@ -47,7 +47,7 @@ rendering_engine::util::font::font(const std::string& filename, float font_size)
         int w, h;
         unsigned char* bitmap = stbtt_GetCodepointBitmap(&m_font, m_scale, m_scale, c, &w, &h, 0, 0);
 
-        auto img = new image(w, h, color{0, 0, 0, 0});
+        auto img = std::make_unique<image>(w, h, color{0, 0, 0, 0});
         for (int j = 0; j < h; ++j)
         {
             for (int i = 0; i < w; ++i)
@@ -56,7 +56,7 @@ rendering_engine::util::font::font(const std::string& filename, float font_size)
                 img->set_pixel(i, j, color{c_value, c_value, c_value, c_value});
             }
         }
-        m_images[c] = img;
+        m_images[c] = std::move(img);
     }
 
     LOG_INF("Loaded font \"%s\"", filename.c_str());
@@ -66,5 +66,5 @@ const rendering_engine::util::image*
 rendering_engine::util::font::get_image(char letter, int* x0, int* y0, int* x1, int* y1)
 {
     stbtt_GetCodepointBitmapBoxSubpixel(&m_font, letter, m_scale, m_scale, 0, 0, x0, y0, x1, y1);
-    return m_images[letter];
+    return m_images[letter].get();
 }

--- a/rendering_engine/util/font.hpp
+++ b/rendering_engine/util/font.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ namespace rendering_engine::util
         const rendering_engine::util::image* get_image(char letter, int* x0, int* y0, int* x1, int* y1);
 
     private:
-        std::map<char, rendering_engine::util::image*> m_images;
+        std::map<char, std::unique_ptr<rendering_engine::util::image>> m_images;
         std::vector<unsigned char> m_buffer;
         stbtt_fontinfo m_font;
         float m_scale;

--- a/rendering_engine/window.cpp
+++ b/rendering_engine/window.cpp
@@ -33,7 +33,23 @@
 
 namespace rendering_engine
 {
-    window::window() : m_window{nullptr}, m_gl_context{nullptr} {}
+    void sdl_window_deleter::operator()(SDL_Window* w) const noexcept
+    {
+        if (w != nullptr)
+        {
+            SDL_DestroyWindow(w);
+        }
+    }
+
+    void sdl_gl_context_deleter::operator()(void* ctx) const noexcept
+    {
+        if (ctx != nullptr)
+        {
+            SDL_GL_DeleteContext(ctx);
+        }
+    }
+
+    window::window() = default;
 
     void window::init()
     {
@@ -71,12 +87,12 @@ namespace rendering_engine
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, s.is_double_buffered());
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
-        m_window = SDL_CreateWindow(s.get_window_name(),
-                                    SDL_WINDOWPOS_CENTERED,
-                                    SDL_WINDOWPOS_CENTERED,
-                                    s.get_window_width(),
-                                    s.get_window_height(),
-                                    window_flags);
+        m_window.reset(SDL_CreateWindow(s.get_window_name(),
+                                        SDL_WINDOWPOS_CENTERED,
+                                        SDL_WINDOWPOS_CENTERED,
+                                        s.get_window_width(),
+                                        s.get_window_height(),
+                                        window_flags));
 
         if (m_window == nullptr)
         {
@@ -85,14 +101,14 @@ namespace rendering_engine
             throw std::runtime_error{SDL_GetError()};
         }
 
-        m_gl_context = SDL_GL_CreateContext(static_cast<SDL_Window*>(m_window));
+        m_gl_context.reset(SDL_GL_CreateContext(m_window.get()));
         SDL_GL_SetSwapInterval(0);
     }
 
     void window::quit()
     {
-        SDL_GL_DeleteContext(m_gl_context);
-        SDL_DestroyWindow(static_cast<SDL_Window*>(m_window));
+        m_gl_context.reset();
+        m_window.reset();
 
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
@@ -108,13 +124,13 @@ namespace rendering_engine
 
     void window::swap_buffers()
     {
-        SDL_GL_SwapWindow(static_cast<SDL_Window*>(m_window));
+        SDL_GL_SwapWindow(m_window.get());
     }
 
     void window::show_message(const std::string& title, const std::string& message)
     {
         SDL_ShowSimpleMessageBox(
-            SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), static_cast<SDL_Window*>(m_window));
+            SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), m_window.get());
     }
 
     void window::show_cursor()

--- a/rendering_engine/window.hpp
+++ b/rendering_engine/window.hpp
@@ -22,12 +22,28 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include <infrastructure/singleton.hpp>
 
+struct SDL_Window;
+
 namespace rendering_engine
 {
+    struct sdl_window_deleter
+    {
+        void operator()(SDL_Window* w) const noexcept;
+    };
+
+    struct sdl_gl_context_deleter
+    {
+        void operator()(void* ctx) const noexcept;
+    };
+
+    using sdl_window_handle = std::unique_ptr<SDL_Window, sdl_window_deleter>;
+    using sdl_gl_context_handle = std::unique_ptr<void, sdl_gl_context_deleter>;
+
     struct window : public singleton<window>
     {
         window();
@@ -45,7 +61,7 @@ namespace rendering_engine
         void hide_cursor();
 
     private:
-        void* m_window;
-        void* m_gl_context;
+        sdl_window_handle m_window;
+        sdl_gl_context_handle m_gl_context;
     };
 } // namespace rendering_engine


### PR DESCRIPTION
## Summary
- Wrap SDL_Window and SDL_GLContext handles in typed `std::unique_ptr` with custom deleters; remove all `void*` casts in `rendering_engine/window`
- Replace `void*` shader/program handles in `rendering_engine::renderer` with typed `std::unique_ptr` and dedicated deleter functors
- Convert owning raw pointers to `std::unique_ptr` in the cube game module, `external/api/camera.cpp`, `label`, and `font`
- Document the active camera and renderer globals as non-owning observers

Closes #14

## Test plan
- [x] Project builds cleanly on Windows (MSVC Debug via `scripts/build.ps1`)
- [x] Run the engine and verify window, cube module, and camera lifecycle behave unchanged