### PR TITLE
fix: forward va_list through vstrprintf in log wrapper

### DIFF
--- a/infrastructure/log.cpp
+++ b/infrastructure/log.cpp
@@ -58,11 +58,11 @@ void infrastructure::logging::init(int argc, char* argv[])
     LOG_INF("AlphaEngine v%s starting ...", infrastructure::version::get_version().c_str());
 }
 
-void infrastructure::logging::message(enum verbosity verbosity, const char* format, ...)
+void infrastructure::logging::message(enum verbosity verbosity, const char* file, unsigned line, const char* format, ...)
 {
     va_list args;
     va_start(args, format);
     auto formatted = loguru::vstrprintf(format, args);
     va_end(args);
-    VLOG_F(verbosity_to_loguru(verbosity), "%s", formatted.c_str());
+    loguru::log(verbosity_to_loguru(verbosity), file, line, "%s", formatted.c_str());
 }

--- a/infrastructure/log.cpp
+++ b/infrastructure/log.cpp
@@ -62,6 +62,7 @@ void infrastructure::logging::message(enum verbosity verbosity, const char* form
 {
     va_list args;
     va_start(args, format);
-    VLOG_F(verbosity_to_loguru(verbosity), format, args);
+    auto formatted = loguru::vstrprintf(format, args);
     va_end(args);
+    VLOG_F(verbosity_to_loguru(verbosity), "%s", formatted.c_str());
 }

--- a/infrastructure/log.hpp
+++ b/infrastructure/log.hpp
@@ -24,10 +24,10 @@
 
 #define LOG_INIT(argc, argv) infrastructure::logging::init(argc, argv)
 
-#define LOG_INF(...) infrastructure::logging::message(infrastructure::logging::verbosity::info, __VA_ARGS__)
-#define LOG_WRN(...) infrastructure::logging::message(infrastructure::logging::verbosity::warn, __VA_ARGS__)
-#define LOG_ERR(...) infrastructure::logging::message(infrastructure::logging::verbosity::error, __VA_ARGS__)
-#define LOG_FTL(...) infrastructure::logging::message(infrastructure::logging::verbosity::fatal, __VA_ARGS__)
+#define LOG_INF(...) infrastructure::logging::message(infrastructure::logging::verbosity::info,  __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_WRN(...) infrastructure::logging::message(infrastructure::logging::verbosity::warn,  __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_ERR(...) infrastructure::logging::message(infrastructure::logging::verbosity::error, __FILE__, __LINE__, __VA_ARGS__)
+#define LOG_FTL(...) infrastructure::logging::message(infrastructure::logging::verbosity::fatal, __FILE__, __LINE__, __VA_ARGS__)
 
 namespace infrastructure
 {
@@ -54,9 +54,11 @@ namespace infrastructure
         /**
          * @brief Logs a message
          * @param verbosity The verbosity of the message (INFO, WARN, ERROR, FATAL)
+         * @param file The source file the call originated from
+         * @param line The source line the call originated from
          * @param format The format of the message
          * @param ... The arguments
          */
-        void message(enum verbosity verbosity, const char* format, ...);
+        void message(enum verbosity verbosity, const char* file, unsigned line, const char* format, ...);
     }; // namespace logging
 } // namespace infrastructure


### PR DESCRIPTION
## Summary
- `infrastructure::logging::message` was passing a `va_list` object as a single positional argument to `VLOG_F`, so `%s`/`%d` placeholders dereferenced the `va_list` address and printed garbage (e.g. `AlphaEngine v╪°osj starting ...`).
- Resolve the format through `loguru::vstrprintf` first, then forward the already-formatted message to `VLOG_F` as `"%s"`, keeping loguru hidden behind the wrapper.

## Test plan
- [x] Build the engine and confirm startup log reads `AlphaEngine v0.0.1 starting ...`.
- [x] Exercise a `LOG_INF`/`LOG_WRN`/`LOG_ERR` call site with mixed `%s`/`%d` args and verify output is correct.

Closes #30