### PR TITLE
docs: add Doxygen comments to public headers

### DIFF
--- a/event_engine/event.hpp
+++ b/event_engine/event.hpp
@@ -20,10 +20,19 @@
  * SOFTWARE.
  */
 
+/**
+ * @file event.hpp
+ * @brief Event value types broadcast through the event engine.
+ */
+
 #pragma once
 
 namespace event_engine
 {
+    /**
+     * @brief Discriminator used by @ref event to identify its dynamic type
+     *        and by listeners to subscribe to a specific event category.
+     */
     enum class event_type
     {
         engine_start,
@@ -39,6 +48,10 @@ namespace event_engine
         mouse_move
     };
 
+    /**
+     * @brief Keyboard key identifiers. Values mirror SDL keysym codes so
+     *        the window layer can cast directly into this enum.
+     */
     enum class key_code
     {
         w = 119,
@@ -52,6 +65,7 @@ namespace event_engine
         escape = 27,
     };
 
+    /** @brief Mouse button identifiers. */
     enum class mouse_key_code
     {
         left = 141881,
@@ -59,6 +73,15 @@ namespace event_engine
         middle = 141883,
     };
 
+    /**
+     * @brief Polymorphic base for every event passed through the bus.
+     *
+     * Listeners receive a @c const reference and may @c static_cast /
+     * @c dynamic_cast to the concrete subtype after inspecting @ref m_type.
+     * Events are passed by reference only and are not retained by the
+     * dispatcher — derived objects are typically stack-allocated at the
+     * broadcast site.
+     */
     struct event
     {
         event(event_type type) : m_type{type} {}
@@ -67,38 +90,51 @@ namespace event_engine
         event_type m_type;
     };
 
+    /** @brief Broadcast once after all subsystems have been initialized. */
     struct engine_start : public event
     {
         engine_start() : event(event_type::engine_start) {}
     };
 
+    /** @brief Broadcast once as the main loop is tearing down. */
     struct engine_stop : public event
     {
         engine_stop() : event(event_type::engine_stop) {}
     };
 
+    /** @brief Signals the user requested application termination. */
     struct quit_requested : public event
     {
         quit_requested() : event(event_type::quit_requested) {}
     };
 
+    /**
+     * @brief Per-frame tick event.
+     *
+     * Broadcast once per iteration of the main loop and carries the
+     * time elapsed since the previous frame.
+     */
     struct frame : public event
     {
         frame() : event(event_type::frame) {}
 
+        /** @brief Time since the previous frame, in milliseconds. */
         float m_delta_time;
     };
 
+    /** @brief Broadcast while the 3D scene pass is active; renderables should submit draw calls. */
     struct render_scene : public event
     {
         render_scene() : event(event_type::render_scene) {}
     };
 
+    /** @brief Broadcast while the 2D overlay/UI pass is active. */
     struct render_ui : public event
     {
         render_ui() : event(event_type::render_ui) {}
     };
 
+    /** @brief Key release. @ref m_key_code is the released key. */
     struct key_up : public event
     {
         key_up() : event(event_type::key_up) {}
@@ -106,6 +142,7 @@ namespace event_engine
         key_code m_key_code;
     };
 
+    /** @brief Key press. @ref m_key_code is the pressed key. */
     struct key_down : public event
     {
         key_down() : event(event_type::key_down) {}
@@ -113,6 +150,7 @@ namespace event_engine
         key_code m_key_code;
     };
 
+    /** @brief Mouse button release. @ref m_key_code is the released button. */
     struct mouse_key_up : public event
     {
         mouse_key_up() : event(event_type::mouse_key_up) {}
@@ -120,6 +158,7 @@ namespace event_engine
         mouse_key_code m_key_code;
     };
 
+    /** @brief Mouse button press. @ref m_key_code is the pressed button. */
     struct mouse_key_down : public event
     {
         mouse_key_down() : event(event_type::mouse_key_down) {}
@@ -127,11 +166,17 @@ namespace event_engine
         mouse_key_code m_key_code;
     };
 
+    /**
+     * @brief Mouse motion event.
+     *
+     * @ref m_x and @ref m_y carry the relative motion since the previous
+     * report (not absolute cursor coordinates).
+     */
     struct mouse_move : public event
     {
         mouse_move() : event(event_type::mouse_move) {}
 
-        int m_x;
-        int m_y;
+        int m_x; /**< Horizontal delta in pixels. */
+        int m_y; /**< Vertical delta in pixels. */
     };
 } // namespace event_engine

--- a/event_engine/event_engine.hpp
+++ b/event_engine/event_engine.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file event_engine.hpp
+ * @brief Event dispatch subsystem: publish/subscribe hub for engine events.
+ */
+
 #pragma once
 
 #include <functional>
@@ -31,14 +36,42 @@
 
 namespace event_engine
 {
+    /**
+     * @brief Central event bus used by all subsystems.
+     *
+     * Listeners register callbacks keyed on an @ref event_type and are
+     * invoked synchronously whenever an event of that type is broadcast.
+     * The context is a process-wide singleton; listener storage and
+     * dispatch are not thread-safe — register listeners during init and
+     * broadcast from the main loop thread only.
+     */
     struct context : public singleton<context>
     {
         context() = default;
 
+        /** @brief Initializes the event engine. Must be called once at startup. */
         void init();
+
+        /** @brief Shuts down the event engine. Called once at teardown. */
         void quit();
 
+        /**
+         * @brief Dispatches @p event synchronously to every listener
+         *        registered for its type.
+         * @param event Event to broadcast. The reference must stay valid
+         *              for the duration of the call; listeners receive a
+         *              const reference and must not retain it.
+         */
         void broadcast(const event& event);
+
+        /**
+         * @brief Registers a callback for events of a given type.
+         * @param type     The event type to subscribe to.
+         * @param listener Callable invoked on every matching broadcast.
+         *                 Stored by value in the engine; any captured
+         *                 state must outlive the engine or be owned by
+         *                 the callable itself.
+         */
         void register_listener(const event_type type, const std::function<void(const event&)>& listener);
 
     private:

--- a/infrastructure/buffer.hpp
+++ b/infrastructure/buffer.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file buffer.hpp
+ * @brief In-memory byte buffer loaded from a file.
+ */
+
 #pragma once
 
 #include <cstdint>
@@ -28,13 +33,30 @@
 
 namespace infrastructure
 {
+    /**
+     * @brief Owns the raw bytes of a file read from disk.
+     *
+     * The contents are read in full during construction and owned by
+     * the @c std::vector member — the pointer returned by @ref get_data
+     * is valid for the lifetime of the @ref buffer instance.
+     */
     struct buffer
     {
+        /**
+         * @brief Reads @p filename in binary mode into memory.
+         *        On failure the buffer is left empty and an error is logged
+         *        (the constructor does not throw).
+         * @param filename Path to the file to load.
+         */
         buffer(const std::string& filename);
 
+        /**
+         * @brief Pointer to the loaded bytes, or to empty storage if the
+         *        load failed. Valid until the @ref buffer is destroyed.
+         */
         const uint8_t* get_data() const;
 
     private:
         std::vector<uint8_t> m_data;
     };
-} // namespace Infrastructure
+} // namespace infrastructure

--- a/infrastructure/log.hpp
+++ b/infrastructure/log.hpp
@@ -20,13 +20,27 @@
  * SOFTWARE.
  */
 
+/**
+ * @file log.hpp
+ * @brief Printf-style logging facade backed by Loguru.
+ *
+ * Prefer the @c LOG_INF / @c LOG_WRN / @c LOG_ERR / @c LOG_FTL macros
+ * over calling @ref infrastructure::logging::message directly — they
+ * capture the originating @c __FILE__ and @c __LINE__ automatically.
+ */
+
 #pragma once
 
+/** @brief Initializes the logging system. Wraps @ref infrastructure::logging::init. */
 #define LOG_INIT(argc, argv) infrastructure::logging::init(argc, argv)
 
+/** @brief Logs an informational message (printf-style). */
 #define LOG_INF(...) infrastructure::logging::message(infrastructure::logging::verbosity::info,  __FILE__, __LINE__, __VA_ARGS__)
+/** @brief Logs a warning message (printf-style). */
 #define LOG_WRN(...) infrastructure::logging::message(infrastructure::logging::verbosity::warn,  __FILE__, __LINE__, __VA_ARGS__)
+/** @brief Logs an error message (printf-style). */
 #define LOG_ERR(...) infrastructure::logging::message(infrastructure::logging::verbosity::error, __FILE__, __LINE__, __VA_ARGS__)
+/** @brief Logs a fatal message (printf-style); Loguru will abort the process. */
 #define LOG_FTL(...) infrastructure::logging::message(infrastructure::logging::verbosity::fatal, __FILE__, __LINE__, __VA_ARGS__)
 
 namespace infrastructure
@@ -36,6 +50,7 @@ namespace infrastructure
      */
     namespace logging
     {
+        /** @brief Severity levels accepted by @ref message. */
         enum class verbosity
         {
             info,

--- a/infrastructure/settings.hpp
+++ b/infrastructure/settings.hpp
@@ -20,19 +20,33 @@
  * SOFTWARE.
  */
 
+/**
+ * @file settings.hpp
+ * @brief Global read-only application settings (window, camera, input).
+ */
+
 #pragma once
 
 #include <string>
 
 #include <infrastructure/singleton.hpp>
 
+/** @brief Presentation mode for the application window. */
 enum class win_type
 {
-    win_type_windowed,
-    win_type_borderless,
-    win_type_fullscreen
+    win_type_windowed,   /**< Standard decorated window. */
+    win_type_borderless, /**< Borderless window. */
+    win_type_fullscreen  /**< Exclusive fullscreen. */
 };
 
+/**
+ * @brief Process-wide configuration singleton.
+ *
+ * Values are populated in the constructor — debug builds default to an
+ * 800x600 windowed layout, release builds match the current display
+ * mode and go fullscreen. All accessors are @c const and @c noexcept;
+ * the struct is intended as read-only engine-wide configuration.
+ */
 struct settings : public singleton<settings>
 {
     settings();
@@ -44,7 +58,10 @@ struct settings : public singleton<settings>
     const bool is_double_buffered() const noexcept;
     const float get_field_of_view() const noexcept;
     const float get_mouse_sensitivity() const noexcept;
+
+    /** @brief Returns @c width / @c height of the window. */
     const float get_aspect_ratio() const noexcept;
+
     const bool is_mouse_reversed() const noexcept;
 
 private:

--- a/infrastructure/singleton.hpp
+++ b/infrastructure/singleton.hpp
@@ -20,19 +20,30 @@
  * SOFTWARE.
  */
 
+/**
+ * @file singleton.hpp
+ * @brief CRTP helper for process-wide singletons.
+ */
+
 #pragma once
 
 /**
- * @brief A generic singleton class
- * @tparam T The class that will be a singleton
+ * @brief Meyers-style singleton base, used via CRTP (e.g. @c struct foo : singleton<foo>).
+ *
+ * The instance is a function-local @c static, so construction is thread-safe
+ * under C++11 rules but other member access is not — subclasses must document
+ * their own thread-safety. Copy and assignment are deleted to prevent
+ * accidental duplication of the singleton state.
+ *
+ * @tparam T The derived class being made into a singleton.
  */
 template<typename T>
 class singleton
 {
 public:
     /**
-     * @brief Returns the instance of the singleton
-     * @return The instance of the singleton
+     * @brief Returns the singleton instance, constructing it on first call.
+     * @return Reference to the single instance of @p T.
      */
     static T& get_instance()
     {

--- a/infrastructure/time.hpp
+++ b/infrastructure/time.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file time.hpp
+ * @brief Frame timing utilities (delta time, frame count, FPS).
+ */
+
 #pragma once
 
 #include <cstdint>
@@ -28,20 +33,41 @@
 
 namespace infrastructure
 {
+    /**
+     * @brief Process-wide frame clock.
+     *
+     * Backed by SDL's high-resolution performance counter. Call
+     * @ref perform_tick once per frame to advance the clock; the other
+     * accessors report values from the most recent tick. Not thread-safe.
+     */
     struct time : public singleton<time>
     {
         time();
 
+        /**
+         * @brief Advances the clock by one frame, updating the delta
+         *        time and incrementing the frame counter. Call exactly
+         *        once per main-loop iteration.
+         */
         void perform_tick();
 
+        /** @brief Time between the last two ticks, in milliseconds. */
         const double delta_time() const;
+
+        /** @brief Milliseconds since SDL was initialized. */
         const float total_time() const;
 
+        /** @brief Number of ticks (frames) since startup. */
         const uint32_t frame_count() const;
+
+        /**
+         * @brief Instantaneous FPS derived from the most recent delta.
+         * @return Frames per second, or 0 when the delta is below 1us.
+         */
         const float current_fps() const;
 
     private:
         uint32_t m_frame_count;
         double m_delta_time;
     };
-} // namespace Infrastructure
+} // namespace infrastructure

--- a/infrastructure/version.hpp
+++ b/infrastructure/version.hpp
@@ -20,15 +20,30 @@
  * SOFTWARE.
  */
 
+/**
+ * @file version.hpp
+ * @brief Compile-time version information for the engine.
+ */
+
 #pragma once
 
 #include <string>
 
 namespace infrastructure
 {
+    /**
+     * @brief Static accessors for build-time version metadata.
+     *
+     * The version triplet is baked in from the @c VERSION_MAJOR /
+     * @c VERSION_MINOR / @c VERSION_PATCH preprocessor macros (set by
+     * CMake), and the build date is captured from @c __DATE__.
+     */
     struct version
     {
+        /** @brief Returns the version string in @c "MAJOR.MINOR.PATCH" form. */
         static const std::string get_version();
+
+        /** @brief Returns the build date captured at compile time. */
         static const std::string get_build_date();
     };
-} // namespace Infrastructure
+} // namespace infrastructure

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file rendering_engine.hpp
+ * @brief Top-level entry point for the rendering subsystem.
+ */
+
 #pragma once
 
 #include <vector>
@@ -28,11 +33,34 @@
 
 namespace rendering_engine
 {
+    /**
+     * @brief Orchestrates the rendering subsystem (window, GL context, renderers).
+     *
+     * Process-wide singleton. @ref init brings up the window and OpenGL
+     * context and constructs the built-in renderers; @ref quit tears the
+     * GL context and window down in reverse order. All methods must be
+     * called from the main thread that owns the GL context.
+     */
     struct context : public singleton<context>
     {
+        /**
+         * @brief Initializes the window, GL context and built-in renderers.
+         *        Must be called once before @ref render.
+         */
         void init();
+
+        /** @brief Tears the renderers, GL context and window down. */
         void quit();
 
+        /**
+         * @brief Renders one frame.
+         *
+         * Runs the scene pass (broadcasting @ref event_engine::render_scene
+         * if a camera is active) followed by the UI overlay pass
+         * (broadcasting @ref event_engine::render_ui). Depth testing is
+         * disabled for the overlay and restored afterwards. Does not
+         * swap buffers — callers are responsible for presenting.
+         */
         void render();
     };
 } // namespace rendering_engine

--- a/rendering_engine/window.hpp
+++ b/rendering_engine/window.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file window.hpp
+ * @brief SDL-backed OS window and GL context owner; source of input events.
+ */
+
 #pragma once
 
 #include <memory>
@@ -31,33 +36,74 @@ struct SDL_Window;
 
 namespace rendering_engine
 {
+    /** @brief Custom deleter that destroys an @c SDL_Window via @c SDL_DestroyWindow. */
     struct sdl_window_deleter
     {
         void operator()(SDL_Window* w) const noexcept;
     };
 
+    /** @brief Custom deleter that destroys an SDL GL context via @c SDL_GL_DeleteContext. */
     struct sdl_gl_context_deleter
     {
         void operator()(void* ctx) const noexcept;
     };
 
+    /** @brief RAII-owning handle to an @c SDL_Window. */
     using sdl_window_handle = std::unique_ptr<SDL_Window, sdl_window_deleter>;
+
+    /** @brief RAII-owning handle to an SDL OpenGL context. */
     using sdl_gl_context_handle = std::unique_ptr<void, sdl_gl_context_deleter>;
 
+    /**
+     * @brief Owns the application window, its GL context, and pumps OS input.
+     *
+     * Process-wide singleton. The window and GL context are held as
+     * @c std::unique_ptr with SDL-specific deleters, so their lifetime
+     * is strictly tied to this instance — @ref init creates them and
+     * @ref quit (or destruction) releases them. All methods must be
+     * invoked from the main thread.
+     */
     struct window : public singleton<window>
     {
         window();
 
+        /**
+         * @brief Initializes SDL video, creates the window and the GL
+         *        context using the dimensions and flags read from the
+         *        global @c settings singleton.
+         * @throws std::runtime_error if SDL video init or window creation fails.
+         */
         void init();
+
+        /** @brief Destroys the GL context and window and shuts down SDL video. */
         void quit();
 
+        /**
+         * @brief Pumps the SDL event queue and translates OS input into
+         *        engine events broadcast through @ref event_engine::context.
+         *
+         * Also broadcasts a @ref event_engine::frame event carrying the
+         * current delta time. Call once per main-loop iteration.
+         */
         void tick();
 
+        /** @brief Clears the color and depth buffers to opaque black. */
         void clear();
+
+        /** @brief Presents the back buffer to the screen. */
         void swap_buffers();
+
+        /**
+         * @brief Displays a modal error message box parented to the window.
+         * @param title   Title of the message box.
+         * @param message Body text of the message box.
+         */
         void show_message(const std::string& title, const std::string& message);
 
+        /** @brief Shows the OS cursor and disables relative mouse mode. */
         void show_cursor();
+
+        /** @brief Hides the OS cursor and enables relative mouse mode. */
         void hide_cursor();
 
     private:

--- a/scene_graph/scene_graph.hpp
+++ b/scene_graph/scene_graph.hpp
@@ -20,6 +20,11 @@
  * SOFTWARE.
  */
 
+/**
+ * @file scene_graph.hpp
+ * @brief Scene graph subsystem entry point.
+ */
+
 #pragma once
 
 #include <string>
@@ -28,9 +33,19 @@
 
 namespace scene_graph
 {
+    /**
+     * @brief Lifetime owner of the scene graph subsystem.
+     *
+     * Process-wide singleton. Currently a lifecycle stub that matches
+     * the shape of the other engine subsystems — @ref init is called
+     * at startup and @ref quit at shutdown.
+     */
     struct context : public singleton<context>
     {
+        /** @brief Initializes the scene graph subsystem. */
         void init();
+
+        /** @brief Shuts down the scene graph subsystem. */
         void quit();
     };
-} // namespace SceneGraph
+} // namespace scene_graph


### PR DESCRIPTION
## Summary

Adds Doxygen comments to the public subsystem entry-point headers so that
class purpose, method contracts, ownership/lifetime and thread-safety are
discoverable without reading the corresponding .cpp files. Trivial
getters/setters are left alone as requested by the issue. Comment-only
change — no behavior, signatures or names were modified.

## Files touched

- event_engine/event_engine.hpp
- event_engine/event.hpp
- rendering_engine/rendering_engine.hpp
- rendering_engine/window.hpp
- scene_graph/scene_graph.hpp
- infrastructure/log.hpp
- infrastructure/settings.hpp
- infrastructure/time.hpp
- infrastructure/buffer.hpp
- infrastructure/singleton.hpp
- infrastructure/version.hpp

Built locally with \`scripts/build.ps1\` (MSVC + vcpkg); build succeeded.

Closes #25