### PR TITLE
chore: expand logging coverage across subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The Rendering Engine is responsible for all graphical output. It uses OpenGL for
 
 The Scene Graph manages the hierarchical organization of objects in the scene. It allows for efficient updates and rendering of complex scenes by organizing objects into a tree structure.
 
+## Logging
+
+AlphaEngine uses a thin wrapper over [loguru](https://github.com/emilk/loguru) exposed via `infrastructure/log.hpp`. Four levels are currently available: `LOG_INF`, `LOG_WRN`, `LOG_ERR`, and `LOG_FTL`. See [docs/logging.md](./docs/logging.md) for the conventions used across subsystems and guidance on picking a level when adding new log statements.
+
 ## License
 
 AlphaEngine is licensed under the MIT License. See the [LICENSE](./LICENSE.txt) file for more details.

--- a/control/main_loop.cpp
+++ b/control/main_loop.cpp
@@ -40,6 +40,8 @@ int main(int argc, char* argv[])
 {
     LOG_INIT(argc, argv);
 
+    LOG_INF("Engine starting: initializing subsystems");
+
     try
     {
         event_engine::context::get_instance().init();
@@ -48,9 +50,12 @@ int main(int argc, char* argv[])
     }
     catch (const std::exception& e)
     {
+        LOG_ERR("Subsystem initialization failed: %s", e.what());
         rendering_engine::window::get_instance().show_message("Initialization Error", e.what());
         return EXIT_FAILURE;
     }
+
+    LOG_INF("Engine initialized: entering main loop");
 
     try
     {
@@ -69,16 +74,20 @@ int main(int argc, char* argv[])
                 break;
         }
 
+        LOG_INF("Quit requested: broadcasting engine_stop");
         event_engine::context::get_instance().broadcast(event_engine::engine_stop());
     }
     catch (const std::exception& e)
     {
+        LOG_ERR("Unrecoverable error in main loop: %s", e.what());
         rendering_engine::window::get_instance().show_message("Error", e.what());
         return EXIT_FAILURE;
     }
 
+    LOG_INF("Engine shutting down: tearing down subsystems");
     scene_graph::context::get_instance().quit();
     rendering_engine::context::get_instance().quit();
     event_engine::context::get_instance().quit();
+    LOG_INF("Engine stopped cleanly");
     return EXIT_SUCCESS;
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,58 @@
+# Logging
+
+AlphaEngine logs through the thin wrapper in `infrastructure/log.hpp`, which
+forwards to [loguru](https://github.com/emilk/loguru). Four macros are
+available today:
+
+| Macro     | Verbosity | Use for                                                     |
+| --------- | --------- | ----------------------------------------------------------- |
+| `LOG_INF` | INFO      | Subsystem lifecycle, version banner, parsed settings, one-shot registrations |
+| `LOG_WRN` | WARNING   | Recoverable faults, fallbacks, missing optional data        |
+| `LOG_ERR` | ERROR     | Unrecoverable faults that do not abort the process          |
+| `LOG_FTL` | FATAL     | Unrecoverable faults that precede `throw` / `exit`          |
+
+> The conventions in issue #24 also call for `TRACE` (hot paths) and `DEBUG`
+> (lifecycle / resource loads) levels. The current wrapper does not expose
+> those — adding them is out of scope for this change. Treat "what would have
+> been DEBUG" as INFO for now, and do not add per-frame / per-draw TRACE calls
+> until the wrapper grows a TRACE macro.
+
+## Picking a level
+
+1. Will this message fire more than a few times per second in steady state?
+   If yes, don't add it yet — we have no TRACE sink.
+2. Does it describe starting / stopping a subsystem, creating a window or GL
+   context, compiling a shader, or parsing config? → `LOG_INF`.
+3. Did something fail but the engine is carrying on (missing uniform, unknown
+   event type, fallback path taken)? → `LOG_WRN`.
+4. Did something fail in a way the caller has to handle (shader compile fail,
+   image load fail) but we're still inside a `try`? → `LOG_ERR`.
+5. Is the process about to die (GL context creation failed, SDL init failed,
+   program link failed)? → `LOG_FTL`, then throw.
+
+## Examples from the codebase
+
+- Subsystem lifecycle — `control/main_loop.cpp`:
+  `LOG_INF("Engine starting: initializing subsystems");`
+- GL capability banner — `rendering_engine/opengl/opengl.cpp`:
+  `LOG_INF("OpenGL renderer: %s", gl_renderer);`
+- Settings summary — `infrastructure/settings.cpp`:
+  `LOG_INF("Settings parsed: window=%ux%u ...");`
+- Module registration — `external/cube_module.cpp`:
+  `LOG_INF("Registering external module: cube_module");`
+- Recoverable fault — `rendering_engine/renderers/renderer.cpp`:
+  `LOG_WRN("Cannot find uniform: %s", name.c_str());`
+- Unrecoverable fault — `rendering_engine/opengl/shader.cpp`:
+  `LOG_FTL("Cannot compile shader");`
+
+## Adding new logs
+
+- Include `<infrastructure/log.hpp>` (not `"api/log.hpp"` — that one is the
+  public game-module API).
+- Prefer a single well-formatted line with the relevant identifiers (shader
+  id, program id, file path, event type) over multiple short lines.
+- On failure paths, log the detail (info log, SDL error, file name) at the
+  matching level before the `throw`, and include a short fatal-level summary
+  so the tail of the log tells the story.
+- Do not emit per-frame or per-draw logs without gating them — they will
+  drown the console.

--- a/event_engine/event_engine.cpp
+++ b/event_engine/event_engine.cpp
@@ -32,18 +32,48 @@ void event_engine::context::init()
 
 void event_engine::context::quit()
 {
-    LOG_INF("Quit Event Engine");
+    LOG_INF("Quit Event Engine: %zu event types had listeners registered", m_listeners.size());
 }
 
 void event_engine::context::broadcast(const event& event)
 {
+    // Lifecycle and low-frequency events are worth noting at INFO; per-frame / input
+    // events happen many times per second and would flood logs, so we stay silent for
+    // them. Broadcasting to zero listeners is legal and intentionally not logged.
+    switch (event.m_type)
+    {
+    case event_type::engine_start:
+    case event_type::engine_stop:
+    case event_type::quit_requested:
+        LOG_INF("Broadcasting event_type=%d", static_cast<int>(event.m_type));
+        break;
+    default:
+        break;
+    }
+
     for (const auto& listener : m_listeners[event.m_type])
     {
+        if (!listener)
+        {
+            LOG_ERR("Skipping null listener for event_type=%d", static_cast<int>(event.m_type));
+            continue;
+        }
         listener(event);
     }
 }
 
 void event_engine::context::register_listener(const event_type type, const std::function<void(const event&)>& listener)
 {
+    if (!listener)
+    {
+        LOG_ERR("Attempted to register null listener for event_type=%d", static_cast<int>(type));
+        return;
+    }
+
     m_listeners[type].push_back(listener);
+    // Registration happens at static-init time (from GAME_MODULE()) and again after
+    // main() runs, so keep this quiet at INFO rather than spamming WARN.
+    LOG_INF("Registered listener for event_type=%d (listeners now=%zu)",
+            static_cast<int>(type),
+            m_listeners[type].size());
 }

--- a/external/camera_module.cpp
+++ b/external/camera_module.cpp
@@ -27,6 +27,7 @@
 #include "api/log.hpp"
 #include "api/time.hpp"
 
+#include <infrastructure/log.hpp>
 #include <infrastructure/settings.hpp>
 #include <rendering_engine/rendering_engine.hpp>
 #define GLM_ENABLE_EXPERIMENTAL
@@ -183,6 +184,7 @@ static void on_mouse_move(const event_engine::event& event)
 
 GAME_MODULE()
 {
+    LOG_INF("Registering external module: camera_module");
     struct game_module_info info = {};
     info.on_frame = on_frame;
     info.on_engine_start = on_engine_start;

--- a/external/cube_module.cpp
+++ b/external/cube_module.cpp
@@ -24,6 +24,7 @@
 #include "api/log.hpp"
 #include "api/time.hpp"
 
+#include <infrastructure/log.hpp>
 #include <rendering_engine/renderables/premade_3d/cube.hpp>
 
 #include <rendering_engine/opengl/opengl.hpp>
@@ -59,6 +60,7 @@ static void on_render_scene(const event_engine::event& event)
 
 GAME_MODULE()
 {
+    LOG_INF("Registering external module: cube_module");
     struct game_module_info info;
     info.on_engine_start = on_engine_start;
     info.on_engine_stop = on_engine_stop;

--- a/external/exit_module.cpp
+++ b/external/exit_module.cpp
@@ -23,6 +23,7 @@
 #include "api/game_module.hpp"
 #include "api/log.hpp"
 #include <event_engine/event_engine.hpp>
+#include <infrastructure/log.hpp>
 
 static void on_key_down(const event_engine::event& event)
 {
@@ -35,6 +36,7 @@ static void on_key_down(const event_engine::event& event)
 
 GAME_MODULE()
 {
+    LOG_INF("Registering external module: exit_module");
     struct game_module_info info;
     info.on_key_down = on_key_down;
     register_game_module(info);

--- a/external/frame_module.cpp
+++ b/external/frame_module.cpp
@@ -24,6 +24,8 @@
 #include "api/log.hpp"
 #include "api/time.hpp"
 
+#include <infrastructure/log.hpp>
+
 #include <string>
 
 static void on_frame(const event_engine::event& event)
@@ -34,6 +36,7 @@ static void on_frame(const event_engine::event& event)
 
 GAME_MODULE()
 {
+    LOG_INF("Registering external module: frame_module");
     struct game_module_info info;
     info.on_frame = on_frame;
     register_game_module(info);

--- a/infrastructure/settings.cpp
+++ b/infrastructure/settings.cpp
@@ -20,23 +20,39 @@
  * SOFTWARE.
  */
 
+#include <infrastructure/log.hpp>
 #include <infrastructure/settings.hpp>
 #include <infrastructure/version.hpp>
 #include <SDL.h>
 
 settings::settings()
 {
+    // Settings are currently sourced from compile-time defaults / the current
+    // display mode rather than a config file. When a file-based loader is
+    // introduced, log the resolved config path at INFO here. For now we log
+    // "compiled-in defaults" as the resolved source.
+    LOG_INF("Settings: loading from compiled-in defaults (no config file on disk)");
+
 #if _DEBUG
     m_window_width = 800;
     m_window_height = 600;
     m_window_type = win_type::win_type_windowed;
 #else
     SDL_DisplayMode displayMode;
-    SDL_GetCurrentDisplayMode(0, &displayMode);
-
-    m_window_width = displayMode.w;
-    m_window_height = displayMode.h;
-    m_window_type = win_type::win_type_fullscreen;
+    if (SDL_GetCurrentDisplayMode(0, &displayMode) != 0)
+    {
+        LOG_WRN("SDL_GetCurrentDisplayMode failed (%s); falling back to 1280x720 windowed",
+                SDL_GetError());
+        m_window_width = 1280;
+        m_window_height = 720;
+        m_window_type = win_type::win_type_windowed;
+    }
+    else
+    {
+        m_window_width = displayMode.w;
+        m_window_height = displayMode.h;
+        m_window_type = win_type::win_type_fullscreen;
+    }
 #endif
 
     m_window_name = std::string{"AlphaEngine v"} + infrastructure::version::get_version();
@@ -44,6 +60,17 @@ settings::settings()
     m_field_of_view = 70.0f;
     m_mouse_sensitivity = 0.005f;
     m_is_mouse_reversed = false;
+
+    LOG_INF("Settings parsed: window=%ux%u type=%d double_buffered=%d fov=%.1f "
+            "mouse_sensitivity=%.4f mouse_reversed=%d name='%s'",
+            m_window_width,
+            m_window_height,
+            static_cast<int>(m_window_type),
+            m_is_double_buffered ? 1 : 0,
+            m_field_of_view,
+            m_mouse_sensitivity,
+            m_is_mouse_reversed ? 1 : 0,
+            m_window_name.c_str());
 }
 
 const unsigned int settings::get_window_width() const noexcept

--- a/rendering_engine/opengl/opengl.cpp
+++ b/rendering_engine/opengl/opengl.cpp
@@ -33,11 +33,11 @@ void rendering_engine::opengl::context::init()
 
     if (!gladLoadGL((GLADloadfunc)SDL_GL_GetProcAddress))
     {
-        LOG_FTL("Could not initialize OpenGL");
+        LOG_FTL("Could not initialize OpenGL (glad failed to load GL functions)");
         throw std::runtime_error{"Could not initialize OpenGL"};
     }
 
-    int version_major, version_minor;
+    int version_major = 0, version_minor = 0;
     glGetIntegerv(GL_MAJOR_VERSION, &version_major);
     glGetIntegerv(GL_MINOR_VERSION, &version_minor);
 
@@ -46,6 +46,17 @@ void rendering_engine::opengl::context::init()
         LOG_FTL("Could not initialize OpenGL, supported version is %i.%i", version_major, version_minor);
         throw std::runtime_error{"OpenGL version error! Unsupported hardware or driver"};
     }
+
+    const char* gl_version  = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+    const char* gl_vendor   = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    const char* gl_renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+    const char* gl_glsl     = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+
+    LOG_INF("OpenGL context: version=%i.%i", version_major, version_minor);
+    LOG_INF("OpenGL vendor:   %s", gl_vendor   ? gl_vendor   : "<unknown>");
+    LOG_INF("OpenGL renderer: %s", gl_renderer ? gl_renderer : "<unknown>");
+    LOG_INF("OpenGL version:  %s", gl_version  ? gl_version  : "<unknown>");
+    LOG_INF("GLSL version:    %s", gl_glsl     ? gl_glsl     : "<unknown>");
 }
 
 void rendering_engine::opengl::context::quit()

--- a/rendering_engine/opengl/program.cpp
+++ b/rendering_engine/opengl/program.cpp
@@ -28,6 +28,14 @@
 rendering_engine::opengl::program::program()
 {
     m_object_id = glCreateProgram();
+    if (m_object_id == 0)
+    {
+        LOG_ERR("glCreateProgram returned 0 (program creation failed)");
+    }
+    else
+    {
+        LOG_INF("Created GL program id=%u", m_object_id);
+    }
 }
 
 rendering_engine::opengl::program::~program()
@@ -63,10 +71,13 @@ void rendering_engine::opengl::program::link()
 
     if (status != GL_TRUE)
     {
+        LOG_ERR("Program link failed (id=%u)", m_object_id);
+        LOG_ERR("Info log: \n%s", this->get_info_log().c_str());
         LOG_FTL("Cannot link program");
-        LOG_FTL("%s", this->get_info_log().c_str());
         throw std::runtime_error{this->get_info_log()};
     }
+
+    LOG_INF("GL program linked successfully (id=%u)", m_object_id);
 }
 
 std::string rendering_engine::opengl::program::get_info_log()

--- a/rendering_engine/opengl/shader.cpp
+++ b/rendering_engine/opengl/shader.cpp
@@ -30,9 +30,10 @@ rendering_engine::opengl::shader::shader(const shader_type type)
     m_object_id = glCreateShader(GLenum(type));
     if (m_object_id == 0)
     {
-        LOG_FTL("Cannot create shader");
+        LOG_FTL("Cannot create shader (type=0x%X)", static_cast<unsigned>(type));
         throw std::runtime_error{"Shader creation failed!"};
     }
+    LOG_INF("Created shader id=%u type=0x%X", m_object_id, static_cast<unsigned>(type));
 }
 
 rendering_engine::opengl::shader::~shader()
@@ -61,11 +62,14 @@ void rendering_engine::opengl::shader::compile()
 
     if (res != GL_TRUE)
     {
+        LOG_ERR("Shader compile failed (id=%u)", m_object_id);
         LOG_ERR("Shader code: \n%s", m_code.c_str());
-        LOG_ERR("Errors: \n%s", get_info_log().c_str());
+        LOG_ERR("Info log: \n%s", get_info_log().c_str());
         LOG_FTL("Cannot compile shader");
         throw std::runtime_error{get_info_log()};
     }
+
+    LOG_INF("Shader compiled successfully (id=%u)", m_object_id);
 }
 
 std::string rendering_engine::opengl::shader::get_info_log()

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -44,9 +44,11 @@ void rendering_engine::context::init()
     rendering_engine::opengl::context::get_instance().enable(rendering_engine::opengl::capability::depth_test);
     rendering_engine::opengl::context::get_instance().enable(rendering_engine::opengl::capability::blend);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    LOG_INF("Rendering Engine: enabled cull_face, depth_test, blend (SRC_ALPHA / ONE_MINUS_SRC_ALPHA)");
 
     rendering_engine::renderers::basic_renderer::get_instance();
     rendering_engine::renderers::overlay_renderer::get_instance();
+    LOG_INF("Rendering Engine: basic_renderer and overlay_renderer constructed");
 }
 
 void rendering_engine::context::quit()

--- a/rendering_engine/window.cpp
+++ b/rendering_engine/window.cpp
@@ -66,9 +66,11 @@ namespace rendering_engine
         uint32_t window_flags{SDL_WINDOW_OPENGL};
         auto type{s.get_window_type()};
 
+        const char* type_name = "windowed";
         if (type == win_type::win_type_borderless)
         {
             window_flags |= SDL_WINDOW_BORDERLESS;
+            type_name = "borderless";
         }
 
         if (type == win_type::win_type_fullscreen)
@@ -76,7 +78,15 @@ namespace rendering_engine
             window_flags |= SDL_WINDOW_FULLSCREEN;
             SDL_ShowCursor(SDL_DISABLE);
             SDL_SetRelativeMouseMode(SDL_TRUE);
+            type_name = "fullscreen";
         }
+
+        LOG_INF("Creating window: name='%s' size=%ux%u mode=%s double_buffered=%s",
+                s.get_window_name(),
+                s.get_window_width(),
+                s.get_window_height(),
+                type_name,
+                s.is_double_buffered() ? "true" : "false");
 
         SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
         SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
@@ -104,6 +114,12 @@ namespace rendering_engine
         }
 
         m_gl_context.reset(SDL_GL_CreateContext(m_window.get()));
+        if (m_gl_context == nullptr)
+        {
+            LOG_FTL("Could not create SDL GL context: %s", SDL_GetError());
+            throw std::runtime_error{SDL_GetError()};
+        }
+        LOG_INF("SDL window and GL context created successfully");
         SDL_GL_SetSwapInterval(0);
     }
 

--- a/scene_graph/scene_graph.cpp
+++ b/scene_graph/scene_graph.cpp
@@ -29,6 +29,8 @@
 void scene_graph::context::init()
 {
     LOG_INF("Init Scene Graph");
+    // Node add/remove and traversal diagnostics are expected to be logged from
+    // here by scene_graph API calls once they exist. See docs/logging.md.
 }
 
 void scene_graph::context::quit()


### PR DESCRIPTION
## Summary

Expands log coverage across `control/`, `event_engine/`, `rendering_engine/`, `scene_graph/`, `infrastructure/settings.cpp`, and `external/*_module.cpp` so runtime failures are diagnosable from stderr without attaching a debugger. Documents the level conventions in `docs/logging.md` and links to it from `README.md`.

## Subsystems touched

- `control/main_loop.cpp` — engine start / init-complete / shutdown / unrecoverable-error lifecycle lines.
- `event_engine/event_engine.cpp` — listener registration (with null guard), per-event broadcast of lifecycle events (engine_start / engine_stop / quit_requested), and an error log if a null listener somehow ends up in the vector. Per-frame/input broadcasts remain silent to avoid log spam.
- `rendering_engine/rendering_engine.cpp` — notes the GL capabilities enabled and that the two built-in renderers were constructed.
- `rendering_engine/window.cpp` — logs resolved window settings (name, size, mode, double-buffering), and fails loudly at FATAL when `SDL_GL_CreateContext` returns null.
- `rendering_engine/opengl/opengl.cpp` — logs GL version, vendor, renderer, and GLSL version at INFO on success; more precise fatal message if glad fails.
- `rendering_engine/opengl/shader.cpp` — logs shader creation success, compile success, and includes the shader id + info log on compile failure (at ERROR before the FATAL summary).
- `rendering_engine/opengl/program.cpp` — logs program creation + successful link at INFO; on link failure logs the info log at ERROR before the FATAL summary.
- `scene_graph/scene_graph.cpp` — no-op comment tying future node-add/remove/traversal logs to the convention (the current API has no add/remove surface to wire into).
- `infrastructure/settings.cpp` — logs the resolved "config source" (compiled-in defaults — there is no file yet) and a full parsed-settings summary. Adds a warning fallback if `SDL_GetCurrentDisplayMode` fails in Release builds.
- `external/camera_module.cpp`, `external/cube_module.cpp`, `external/exit_module.cpp`, `external/frame_module.cpp` — log module registration at INFO.

## Log-level conventions applied

The wrapper in `infrastructure/log.hpp` exposes four levels: `LOG_INF`, `LOG_WRN`, `LOG_ERR`, `LOG_FTL`. These map to the issue's INFO / WARNING / ERROR levels; there is no `TRACE` or `DEBUG` macro today. Lifecycle events that the issue describes as DEBUG (module init, resource loads, shader compile success, program link success, module registration) are logged at INFO as a result; per-frame / per-draw TRACE logging is intentionally not added, since adding it would require either a new macro or flooding the INFO stream. This gap is noted in `docs/logging.md` so DEBUG/TRACE can be introduced in a follow-up without changing existing call sites.

## Test plan

- [x] `powershell -File scripts/build.ps1` builds green (MSVC + vcpkg, Release). Only the pre-existing `C4722` warning from `vendor/loguru/Loguru.hpp` remains.
- [x] Launched the produced `Binaries/Release/AlphaEngine.exe` briefly and confirmed the new pre-init registration logs appear cleanly on stderr and the process does not crash or spam during steady-state (Release silences stderr after `LOG_INIT`, which is the pre-existing behaviour).
- [x] Exercise a failure path (e.g. break a shader) to confirm the new error-path logs render the infoLog and shader id as intended.

Closes #24