### PR TITLE
chore: upgrade SDL2 to SDL3 and link statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,23 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "App
     target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)
 endif()
 
-# Find and link to external dependencies
-find_package(SDL2 REQUIRED)
-target_link_libraries(AlphaEngine SDL2::SDL2)
-target_include_directories(AlphaEngine PRIVATE ${SDL2_INCLUDE_DIRS})
+# SDL3 — fetched and built statically from source
+include(FetchContent)
+set(SDL_STATIC ON CACHE BOOL "" FORCE)
+set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+set(SDL_TEST_LIBRARY OFF CACHE BOOL "" FORCE)
+set(SDL_TESTS OFF CACHE BOOL "" FORCE)
+set(SDL_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(SDL_INSTALL OFF CACHE BOOL "" FORCE)
+set(SDL_DISABLE_INSTALL ON CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    SDL3
+    GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+    GIT_TAG release-3.2.0
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(SDL3)
+target_link_libraries(AlphaEngine SDL3::SDL3-static)
 
 find_package(GLM REQUIRED)
 target_include_directories(AlphaEngine PRIVATE ${GLM_INCLUDE_DIR})
@@ -126,9 +139,3 @@ target_link_libraries(AlphaEngine ${OPENGL_LIBRARIES})
 if(APPLE)
     target_link_libraries(AlphaEngine "-framework CoreFoundation -framework IOKit -framework CoreVideo")
 endif(APPLE)
-
-#if(APPLE)
-#    add_custom_command(TARGET AlphaEngine POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E copy ${SDL2_LIBRARIES} ${LIBRARY_OUTPUT_PATH}
-#        COMMAND ${CMAKE_COMMAND} -E copy ${OPENGL_LIBRARIES} ${LIBRARY_OUTPUT_PATH})
-#endif(APPLE)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ AlphaEngine is a simulation engine written in C++ that uses OpenGL for rendering
 
 - CMake 3.16 or higher
 - A C++20 compatible compiler
-- SDL2
 - OpenGL 3.3 (Core profile)
+
+SDL3 is fetched and built statically by CMake via `FetchContent`, so no system SDL package is required.
 
 ## Building the Project
 

--- a/infrastructure/settings.cpp
+++ b/infrastructure/settings.cpp
@@ -23,7 +23,7 @@
 #include <infrastructure/log.hpp>
 #include <infrastructure/settings.hpp>
 #include <infrastructure/version.hpp>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 settings::settings()
 {
@@ -38,19 +38,18 @@ settings::settings()
     m_window_height = 600;
     m_window_type = win_type::win_type_windowed;
 #else
-    SDL_DisplayMode displayMode;
-    if (SDL_GetCurrentDisplayMode(0, &displayMode) != 0)
+    const SDL_DisplayMode* displayMode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
+    if (displayMode == nullptr)
     {
-        LOG_WRN("SDL_GetCurrentDisplayMode failed (%s); falling back to 1280x720 windowed",
-                SDL_GetError());
+        LOG_WRN("SDL_GetCurrentDisplayMode failed (%s); falling back to 1280x720 windowed", SDL_GetError());
         m_window_width = 1280;
         m_window_height = 720;
         m_window_type = win_type::win_type_windowed;
     }
     else
     {
-        m_window_width = displayMode.w;
-        m_window_height = displayMode.h;
+        m_window_width = displayMode->w;
+        m_window_height = displayMode->h;
         m_window_type = win_type::win_type_fullscreen;
     }
 #endif

--- a/infrastructure/time.cpp
+++ b/infrastructure/time.cpp
@@ -21,7 +21,7 @@
  */
 
 #include <infrastructure/time.hpp>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 infrastructure::time::time() : m_frame_count{0}, m_delta_time{0} {}
 

--- a/rendering_engine/opengl/opengl.cpp
+++ b/rendering_engine/opengl/opengl.cpp
@@ -22,7 +22,7 @@
 
 #include <stdexcept>
 
-#include <SDL2/SDL_video.h>
+#include <SDL3/SDL_video.h>
 
 #include <infrastructure/log.hpp>
 #include <rendering_engine/opengl/opengl.hpp>
@@ -47,16 +47,16 @@ void rendering_engine::opengl::context::init()
         throw std::runtime_error{"OpenGL version error! Unsupported hardware or driver"};
     }
 
-    const char* gl_version  = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-    const char* gl_vendor   = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    const char* gl_version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+    const char* gl_vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
     const char* gl_renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
-    const char* gl_glsl     = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+    const char* gl_glsl = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
 
     LOG_INF("OpenGL context: version=%i.%i", version_major, version_minor);
-    LOG_INF("OpenGL vendor:   %s", gl_vendor   ? gl_vendor   : "<unknown>");
+    LOG_INF("OpenGL vendor:   %s", gl_vendor ? gl_vendor : "<unknown>");
     LOG_INF("OpenGL renderer: %s", gl_renderer ? gl_renderer : "<unknown>");
-    LOG_INF("OpenGL version:  %s", gl_version  ? gl_version  : "<unknown>");
-    LOG_INF("GLSL version:    %s", gl_glsl     ? gl_glsl     : "<unknown>");
+    LOG_INF("OpenGL version:  %s", gl_version ? gl_version : "<unknown>");
+    LOG_INF("GLSL version:    %s", gl_glsl ? gl_glsl : "<unknown>");
 }
 
 void rendering_engine::opengl::context::quit()
@@ -151,7 +151,7 @@ void rendering_engine::opengl::context::depth_mask(const bool write_enabled)
 }
 
 void rendering_engine::opengl::context::bind_texture(const rendering_engine::opengl::texture& texture,
-                                                   const unsigned char unit)
+                                                     const unsigned char unit)
 {
     glActiveTexture(GL_TEXTURE0 + unit);
     glBindTexture(GL_TEXTURE_2D, texture.handle());
@@ -189,9 +189,9 @@ void rendering_engine::opengl::context::bind_framebuffer()
 }
 
 void rendering_engine::opengl::context::draw_arrays(const rendering_engine::opengl::vertex_array& vao,
-                                                  const rendering_engine::opengl::primitive mode,
-                                                  const unsigned int offset,
-                                                  const size_t vertices)
+                                                    const rendering_engine::opengl::primitive mode,
+                                                    const unsigned int offset,
+                                                    const size_t vertices)
 {
     glBindVertexArray(vao.handle());
     glDrawArrays((GLenum)mode, offset, (GLsizei)vertices);
@@ -199,10 +199,10 @@ void rendering_engine::opengl::context::draw_arrays(const rendering_engine::open
 }
 
 void rendering_engine::opengl::context::draw_elements(const rendering_engine::opengl::vertex_array& vao,
-                                                    const rendering_engine::opengl::primitive mode,
-                                                    const intptr_t offset,
-                                                    const unsigned int count,
-                                                    const rendering_engine::opengl::type type)
+                                                      const rendering_engine::opengl::primitive mode,
+                                                      const intptr_t offset,
+                                                      const unsigned int count,
+                                                      const rendering_engine::opengl::type type)
 {
     glBindVertexArray(vao.handle());
     glDrawElements((GLenum)mode, count, (GLenum)type, (const GLvoid*)offset);

--- a/rendering_engine/window.cpp
+++ b/rendering_engine/window.cpp
@@ -29,7 +29,7 @@
 #include <rendering_engine/opengl/opengl.hpp>
 #include <rendering_engine/util/color.hpp>
 #include <rendering_engine/window.hpp>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 
 namespace rendering_engine
 {
@@ -45,7 +45,7 @@ namespace rendering_engine
     {
         if (ctx != nullptr)
         {
-            SDL_GL_DeleteContext(ctx);
+            SDL_GL_DestroyContext(static_cast<SDL_GLContext>(ctx));
         }
     }
 
@@ -55,7 +55,7 @@ namespace rendering_engine
     {
         LOG_INF("Init rendering_engine::window");
 
-        if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0)
+        if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
         {
             LOG_FTL("Could not initialize video system");
             LOG_FTL("SDL_Error: %s", SDL_GetError());
@@ -63,10 +63,11 @@ namespace rendering_engine
         }
 
         ::settings& s{::settings::get_instance()};
-        uint32_t window_flags{SDL_WINDOW_OPENGL};
+        SDL_WindowFlags window_flags{SDL_WINDOW_OPENGL};
         auto type{s.get_window_type()};
 
         const char* type_name = "windowed";
+        bool fullscreen = false;
         if (type == win_type::win_type_borderless)
         {
             window_flags |= SDL_WINDOW_BORDERLESS;
@@ -76,9 +77,8 @@ namespace rendering_engine
         if (type == win_type::win_type_fullscreen)
         {
             window_flags |= SDL_WINDOW_FULLSCREEN;
-            SDL_ShowCursor(SDL_DISABLE);
-            SDL_SetRelativeMouseMode(SDL_TRUE);
             type_name = "fullscreen";
+            fullscreen = true;
         }
 
         LOG_INF("Creating window: name='%s' size=%ux%u mode=%s double_buffered=%s",
@@ -99,18 +99,20 @@ namespace rendering_engine
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
 
-        m_window.reset(SDL_CreateWindow(s.get_window_name(),
-                                        SDL_WINDOWPOS_CENTERED,
-                                        SDL_WINDOWPOS_CENTERED,
-                                        s.get_window_width(),
-                                        s.get_window_height(),
-                                        window_flags));
+        m_window.reset(
+            SDL_CreateWindow(s.get_window_name(), s.get_window_width(), s.get_window_height(), window_flags));
 
         if (m_window == nullptr)
         {
             LOG_FTL("Cannot create window");
             LOG_FTL("SDL Error: %s", SDL_GetError());
             throw std::runtime_error{SDL_GetError()};
+        }
+
+        if (fullscreen)
+        {
+            SDL_HideCursor();
+            SDL_SetWindowRelativeMouseMode(m_window.get(), true);
         }
 
         m_gl_context.reset(SDL_GL_CreateContext(m_window.get()));
@@ -147,20 +149,19 @@ namespace rendering_engine
 
     void window::show_message(const std::string& title, const std::string& message)
     {
-        SDL_ShowSimpleMessageBox(
-            SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), m_window.get());
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title.c_str(), message.c_str(), m_window.get());
     }
 
     void window::show_cursor()
     {
-        SDL_ShowCursor(SDL_ENABLE);
-        SDL_SetRelativeMouseMode(SDL_FALSE);
+        SDL_ShowCursor();
+        SDL_SetWindowRelativeMouseMode(m_window.get(), false);
     }
 
     void window::hide_cursor()
     {
-        SDL_ShowCursor(SDL_DISABLE);
-        SDL_SetRelativeMouseMode(SDL_TRUE);
+        SDL_HideCursor();
+        SDL_SetWindowRelativeMouseMode(m_window.get(), true);
     }
 
     void window::tick()
@@ -176,23 +177,23 @@ namespace rendering_engine
         {
             switch (events.type)
             {
-            case SDL_KEYDOWN:
+            case SDL_EVENT_KEY_DOWN:
             {
                 event_engine::key_down key_down;
-                key_down.m_key_code = (event_engine::key_code)events.key.keysym.sym;
+                key_down.m_key_code = (event_engine::key_code)events.key.key;
                 event_engine::context::get_instance().broadcast(key_down);
                 break;
             }
 
-            case SDL_KEYUP:
+            case SDL_EVENT_KEY_UP:
             {
                 event_engine::key_up key_up;
-                key_up.m_key_code = (event_engine::key_code)events.key.keysym.sym;
+                key_up.m_key_code = (event_engine::key_code)events.key.key;
                 event_engine::context::get_instance().broadcast(key_up);
                 break;
             }
 
-            case SDL_MOUSEBUTTONDOWN:
+            case SDL_EVENT_MOUSE_BUTTON_DOWN:
             {
                 event_engine::mouse_key_down mouse_key_down;
                 switch (events.button.button)
@@ -216,7 +217,7 @@ namespace rendering_engine
                 break;
             }
 
-            case SDL_MOUSEBUTTONUP:
+            case SDL_EVENT_MOUSE_BUTTON_UP:
             {
                 event_engine::mouse_key_up mouse_key_up;
                 mouse_key_up.m_key_code = event_engine::mouse_key_code::left;
@@ -241,16 +242,16 @@ namespace rendering_engine
                 break;
             }
 
-            case SDL_MOUSEMOTION:
+            case SDL_EVENT_MOUSE_MOTION:
             {
                 event_engine::mouse_move mouse_move;
-                mouse_move.m_x = events.motion.xrel;
-                mouse_move.m_y = events.motion.yrel;
+                mouse_move.m_x = static_cast<int>(events.motion.xrel);
+                mouse_move.m_y = static_cast<int>(events.motion.yrel);
                 event_engine::context::get_instance().broadcast(mouse_move);
                 break;
             }
 
-            case SDL_QUIT:
+            case SDL_EVENT_QUIT:
                 event_engine::context::get_instance().broadcast(event_engine::quit_requested());
                 break;
 

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -4,8 +4,9 @@
 
 .DESCRIPTION
     Installs Visual Studio 2022 Build Tools (C++ workload) and vcpkg, then uses
-    vcpkg to install SDL2 and GLM. Safe to re-run: every step skips work
-    that has already been done.
+    vcpkg to install GLM. SDL3 is built from source by the project's CMake via
+    FetchContent, so no vcpkg SDL package is required. Safe to re-run: every
+    step skips work that has already been done.
 
     After completion, build from the repo root with:
 
@@ -95,8 +96,8 @@ if (-not (Test-Path $vcpkgExe)) {
 }
 Write-Ok "vcpkg ready at $VcpkgRoot"
 
-Write-Step "Installing SDL2, GLM via vcpkg (x64-windows)"
-& $vcpkgExe install sdl2:x64-windows glm:x64-windows --recurse | Out-Host
+Write-Step "Installing GLM via vcpkg (x64-windows)"
+& $vcpkgExe install glm:x64-windows --recurse | Out-Host
 if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed." }
 Write-Ok "Libraries installed"
 


### PR DESCRIPTION
Resolves #27.

## Summary
- Replace the vcpkg/system SDL2 dependency with SDL3 pulled in via `FetchContent` and built as a static library (`SDL_STATIC=ON`, `SDL_SHARED=OFF`). No SDL runtime DLL is shipped alongside the executable anymore.
- Migrate every SDL call site to the SDL3 API: bool-returning init, `SDL_EVENT_*` enum names, `SDL_Keycode key` field, `SDL_CreateWindow` without x/y, `SDL_GL_DestroyContext`, per-window relative mouse mode, `SDL_HideCursor`/`SDL_ShowCursor`, and the new `SDL_GetCurrentDisplayMode` / `SDL_GetPrimaryDisplay` pair.
- Drop the SDL2 vcpkg install step from `scripts/setup-windows.ps1` and refresh the README requirements list.

## Test plan
- [x] `cmake -S . -B build -G "Visual Studio 17 2022" -A x64` configures and pulls SDL3 `release-3.2.0` via FetchContent.
- [x] `cmake --build build --config Release` produces `Binaries/Release/AlphaEngine.exe` with no accompanying SDL DLL.
- [x] Smoke-test the binary on a clean Windows machine to confirm the window, GL context, input, and cursor modes all behave as before.