### PR TITLE
feat: implement SceneManager with scene stack

### DIFF
--- a/scene_graph/scene.hpp
+++ b/scene_graph/scene.hpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file scene.hpp
+ * @brief Base class for scenes managed by the @ref scene_manager stack.
+ */
+
+#pragma once
+
+#include <scene_graph/world.hpp>
+
+namespace scene_graph
+{
+    /**
+     * @brief Polymorphic base for a single gameplay scene.
+     *
+     * Scenes are owned by the @ref scene_manager through
+     * @c std::unique_ptr and invoked through the three lifecycle hooks
+     * below. Every scene carries its own @ref world — the ECS world is
+     * currently a placeholder (see @c world.hpp) and will be replaced
+     * once issue #16 lands.
+     *
+     * Subclasses override the hooks they care about; default
+     * implementations are no-ops so trivial scenes can opt in
+     * selectively. Lifecycle ordering:
+     *   - @ref on_load is called when the scene is pushed onto the
+     *     stack (via @ref scene_manager::push or @ref scene_manager::replace).
+     *   - @ref on_update is driven from the main loop for the active
+     *     (top-of-stack) scene only.
+     *   - @ref on_unload is called when the scene is popped or replaced.
+     */
+    class scene
+    {
+    public:
+        virtual ~scene() = default;
+
+        /** @brief Called once immediately after the scene is pushed onto the stack. */
+        virtual void on_load() {}
+
+        /** @brief Called once immediately before the scene is removed from the stack. */
+        virtual void on_unload() {}
+
+        /**
+         * @brief Called once per frame for the active scene.
+         * @param dt Time elapsed since the previous frame, in seconds.
+         */
+        virtual void on_update(float dt)
+        {
+            (void)dt;
+        }
+
+        /**
+         * @brief Per-scene ECS world.
+         *
+         * Placeholder until issue #16 (ECS world) is merged — see
+         * @c world.hpp for the rationale.
+         */
+        world game_world;
+    };
+} // namespace scene_graph

--- a/scene_graph/scene_graph.cpp
+++ b/scene_graph/scene_graph.cpp
@@ -22,6 +22,8 @@
 
 #include <scene_graph/scene_graph.hpp>
 
+#include <event_engine/event.hpp>
+#include <event_engine/event_engine.hpp>
 #include <infrastructure/log.hpp>
 
 #include <string>
@@ -29,11 +31,32 @@
 void scene_graph::context::init()
 {
     LOG_INF("Init Scene Graph");
-    // Node add/remove and traversal diagnostics are expected to be logged from
-    // here by scene_graph API calls once they exist. See docs/logging.md.
+
+    // Drive the active scene's on_update from the per-frame event. The active
+    // scene is looked up at dispatch time so push/pop/replace take effect
+    // immediately on the following frame.
+    event_engine::context::get_instance().register_listener(
+        event_engine::event_type::frame,
+        [this](const event_engine::event& event)
+        {
+            auto& frame_event = static_cast<const event_engine::frame&>(event);
+            if (m_scene_manager.has_active())
+            {
+                m_scene_manager.active().on_update(frame_event.m_delta_time);
+            }
+        });
 }
 
 void scene_graph::context::quit()
 {
-    LOG_INF("Quit Scene Graph");
+    LOG_INF("Quit Scene Graph: unloading %zu scene(s) left on the stack", m_scene_manager.size());
+    while (m_scene_manager.has_active())
+    {
+        m_scene_manager.pop();
+    }
+}
+
+scene_graph::scene_manager& scene_graph::context::get_scene_manager()
+{
+    return m_scene_manager;
 }

--- a/scene_graph/scene_manager.cpp
+++ b/scene_graph/scene_manager.cpp
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <scene_graph/scene_manager.hpp>
+
+#include <infrastructure/log.hpp>
+
+#include <stdexcept>
+#include <utility>
+
+void scene_graph::scene_manager::push(std::unique_ptr<scene> next)
+{
+    if (!next)
+    {
+        LOG_ERR("scene_manager::push called with null scene; ignoring");
+        return;
+    }
+
+    m_stack.push_back(std::move(next));
+    LOG_INF("scene_manager: pushed scene (depth now=%zu)", m_stack.size());
+    m_stack.back()->on_load();
+}
+
+void scene_graph::scene_manager::replace(std::unique_ptr<scene> next)
+{
+    if (!next)
+    {
+        LOG_ERR("scene_manager::replace called with null scene; ignoring");
+        return;
+    }
+
+    if (!m_stack.empty())
+    {
+        m_stack.back()->on_unload();
+        m_stack.pop_back();
+        LOG_INF("scene_manager: replace unloaded previous top (depth now=%zu)", m_stack.size());
+    }
+
+    m_stack.push_back(std::move(next));
+    LOG_INF("scene_manager: replace pushed new top (depth now=%zu)", m_stack.size());
+    m_stack.back()->on_load();
+}
+
+void scene_graph::scene_manager::pop()
+{
+    if (m_stack.empty())
+    {
+        LOG_WRN("scene_manager::pop on empty stack; ignoring");
+        return;
+    }
+
+    m_stack.back()->on_unload();
+    m_stack.pop_back();
+    LOG_INF("scene_manager: popped scene (depth now=%zu)", m_stack.size());
+}
+
+scene_graph::scene& scene_graph::scene_manager::active()
+{
+    if (m_stack.empty())
+    {
+        throw std::runtime_error{"scene_manager::active called on empty stack"};
+    }
+    return *m_stack.back();
+}
+
+bool scene_graph::scene_manager::has_active() const
+{
+    return !m_stack.empty();
+}
+
+std::size_t scene_graph::scene_manager::size() const
+{
+    return m_stack.size();
+}

--- a/scene_graph/scene_manager.hpp
+++ b/scene_graph/scene_manager.hpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file scene_manager.hpp
+ * @brief Stack-based owner of @ref scene instances.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <scene_graph/scene.hpp>
+
+namespace scene_graph
+{
+    /**
+     * @brief Owning stack of scenes with push / pop / replace semantics.
+     *
+     * The top of the stack is the @ref active scene — the one that
+     * receives @ref scene::on_update from the main loop. Lower scenes
+     * remain loaded but frozen, which makes it cheap to overlay e.g. a
+     * pause menu over a running gameplay scene and pop back to it.
+     *
+     * Ownership is transferred to the manager via @c std::unique_ptr:
+     * callers construct a concrete @ref scene subclass and hand the
+     * owned pointer to @ref push or @ref replace. Not thread-safe —
+     * call only from the main loop thread.
+     */
+    class scene_manager
+    {
+    public:
+        /**
+         * @brief Pushes @p next onto the stack and calls @c on_load on it.
+         *
+         * The previously active scene remains on the stack but stops
+         * receiving @c on_update. Typical use: overlay a pause menu
+         * while the gameplay scene stays loaded underneath.
+         *
+         * @param next The scene to push. Must not be null.
+         */
+        void push(std::unique_ptr<scene> next);
+
+        /**
+         * @brief Replaces the top of the stack with @p next.
+         *
+         * If a scene is already active, its @c on_unload is called and
+         * it is destroyed before @p next is pushed and loaded. Typical
+         * use: transition between gameplay scenes (e.g. level change).
+         *
+         * @param next The scene to make active. Must not be null.
+         */
+        void replace(std::unique_ptr<scene> next);
+
+        /**
+         * @brief Pops the top of the stack.
+         *
+         * Calls @c on_unload on the popped scene and destroys it. The
+         * scene below (if any) becomes active again. No-op when the
+         * stack is empty.
+         */
+        void pop();
+
+        /**
+         * @brief Returns the active (top-of-stack) scene.
+         *
+         * Throws @c std::runtime_error if the stack is empty — callers
+         * should check @ref has_active first when the stack may be empty.
+         */
+        scene& active();
+
+        /** @brief Returns @c true when at least one scene is on the stack. */
+        bool has_active() const;
+
+        /** @brief Number of scenes currently on the stack. */
+        std::size_t size() const;
+
+    private:
+        std::vector<std::unique_ptr<scene>> m_stack;
+    };
+} // namespace scene_graph

--- a/scene_graph/world.hpp
+++ b/scene_graph/world.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2019 Tomislav Radanovic
+ * Copyright (c) 2015-2025 Tomislav Radanovic
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,39 +21,28 @@
  */
 
 /**
- * @file scene_graph.hpp
- * @brief Scene graph subsystem entry point.
+ * @file world.hpp
+ * @brief Placeholder ECS world type embedded in every @ref scene_graph::scene.
+ *
+ * The real ECS @c world is being implemented in parallel on the
+ * @c feat/ecs-world branch (issue #16). Until that lands this empty
+ * struct keeps the @ref scene_graph::scene API stable; once the ECS
+ * world is merged, this header will be superseded and the @c game_world
+ * member of @ref scene_graph::scene will become the real type.
  */
 
 #pragma once
 
-#include <string>
-
-#include <infrastructure/singleton.hpp>
-#include <scene_graph/scene_manager.hpp>
-
 namespace scene_graph
 {
     /**
-     * @brief Lifetime owner of the scene graph subsystem.
+     * @brief Placeholder ECS world used by @ref scene until issue #16 lands.
      *
-     * Process-wide singleton. Owns the @ref scene_manager and drives
-     * the active scene's @c on_update hook from the event engine's
-     * per-frame @c frame event. The @ref init / @ref quit pair matches
-     * the shape of the other engine subsystems.
+     * Intentionally empty — existence of the type is enough to pin the
+     * @ref scene ABI while the ECS implementation is in flight on a
+     * separate branch.
      */
-    struct context : public singleton<context>
+    struct world
     {
-        /** @brief Initializes the scene graph subsystem. */
-        void init();
-
-        /** @brief Shuts down the scene graph subsystem. */
-        void quit();
-
-        /** @brief Returns the owned @ref scene_manager. */
-        scene_manager& get_scene_manager();
-
-    private:
-        scene_manager m_scene_manager;
     };
 } // namespace scene_graph


### PR DESCRIPTION
## Summary

- Introduces `scene_graph::scene` — a polymorphic base with `on_load` / `on_update(dt)` / `on_unload` hooks and a per-scene `world` member.
- Introduces `scene_graph::scene_manager` — an owning `std::unique_ptr<scene>` stack with `push` (overlay), `replace` (transition), `pop`, and `active()`.
- Wires the manager into `scene_graph::context`: it owns the manager and registers a per-frame listener that drives `on_update` on the active scene. Any scenes left on the stack are unloaded in `quit()`.
- New files `scene_graph/scene.hpp`, `scene_graph/scene_manager.{hpp,cpp}`, `scene_graph/world.hpp` are picked up by the existing top-level `file(GLOB ...)` for `scene_graph/` — no CMake changes required.

Closes #20.

## Note on dependency

The issue specifies an ECS `World` member on each scene. Issue #16 (ECS world) is being implemented on a separate parallel PR; to keep this PR unblocked, `scene_graph::world` is currently an empty placeholder struct in `scene_graph/world.hpp`. Once #16 lands, that header is superseded and `scene::game_world` becomes the real ECS world type.

## Test plan

- [x] `./scripts/check-style.ps1` passes (clang-format, LLVM 18).
- [x] `./scripts/check-naming.ps1` reports no new violations for the `scene_graph/` files (pre-existing violations in `external/fps_overlay_module.cpp` are unrelated and live on master).
- [x] `./scripts/build.ps1` configure + Release build succeed (MSVC); the engine links with `scene_manager.cpp` included.
- [ ] Once a concrete `scene` subclass exists (typically a gameplay module under `external/`), verify `push` / `replace` / `pop` drive `on_load` / `on_unload` / `on_update` in the expected order via the event-engine `frame` broadcast.