### PR TITLE
feat: implement asset manager with handle-based caching

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,7 @@ WarningsAsErrors: ''
 # Only lint first-party subsystem headers. Vendored code (glad, stb)
 # and system/toolchain headers use their own naming conventions and would
 # otherwise flood diagnostics.
-HeaderFilterRegex: '[\\/](control|event_engine|rendering_engine|scene_graph|infrastructure|external)[\\/]'
+HeaderFilterRegex: '[\\/](control|event_engine|rendering_engine|scene_graph|infrastructure|external|asset_manager)[\\/]'
 
 CheckOptions:
   # Types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SOURCE_DIRS: "control event_engine rendering_engine scene_graph infrastructure external"
+  SOURCE_DIRS: "control event_engine rendering_engine scene_graph infrastructure external asset_manager"
   CLANG_VERSION: "18"
 
 jobs:
@@ -102,7 +102,7 @@ jobs:
       - name: Run run-clang-tidy on subsystem sources
         run: |
           set -euo pipefail
-          pattern="/(control|event_engine|rendering_engine|scene_graph|infrastructure|external)/"
+          pattern="/(control|event_engine|rendering_engine|scene_graph|infrastructure|external|asset_manager)/"
           run-clang-tidy -p build -quiet "${pattern}"
 
   # ---------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_custom_target(build-time-make-directory ALL
 include_directories(${CMAKE_SOURCE_DIR})
 
 # Main executable
+file(GLOB ASSET_MANAGER_FILES "asset_manager/*.hpp" "asset_manager/*.cpp")
 file(GLOB EVENT_ENGINE_FILES "event_engine/*.hpp" "event_engine/*.cpp")
 file(GLOB INFRASTRUCTURE_FILES "infrastructure/*.hpp" "infrastructure/*.cpp")
 file(GLOB SCENE_GRAPH_FILES "scene_graph/*.hpp" "scene_graph/*.cpp")
@@ -92,6 +93,7 @@ file(GLOB EXTERNAL_FILES
         "external/api/*.hpp" "external/api/*.cpp")
 add_executable(AlphaEngine
     control/main_loop.cpp
+    ${ASSET_MANAGER_FILES}
     ${EXTERNAL_FILES}
     ${EVENT_ENGINE_FILES}
     ${INFRASTRUCTURE_FILES}

--- a/asset_manager/asset_manager.cpp
+++ b/asset_manager/asset_manager.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <asset_manager/asset_manager.hpp>
+#include <infrastructure/log.hpp>
+
+void asset_manager::context::init()
+{
+    LOG_INF("Init Asset Manager");
+}
+
+void asset_manager::context::quit()
+{
+    // Count live vs. expired handles for a final diagnostic. The cache itself
+    // is cleared either way — remaining shared_ptrs keep the assets alive
+    // until their last holder drops them.
+    std::size_t live = 0;
+    std::size_t expired = 0;
+    for (const auto& [type, bucket] : m_caches)
+    {
+        for (const auto& [path, weak] : bucket)
+        {
+            if (weak.expired())
+            {
+                ++expired;
+            }
+            else
+            {
+                ++live;
+            }
+        }
+    }
+    LOG_INF("Quit Asset Manager: %zu live handle(s), %zu expired entry(ies) tracked", live, expired);
+    m_caches.clear();
+}
+
+std::size_t asset_manager::context::collect_unused()
+{
+    std::size_t pruned = 0;
+    for (auto& [type, bucket] : m_caches)
+    {
+        for (auto it = bucket.begin(); it != bucket.end();)
+        {
+            if (it->second.expired())
+            {
+                it = bucket.erase(it);
+                ++pruned;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+    if (pruned > 0)
+    {
+        LOG_INF("Asset Manager collected %zu unused entry(ies)", pruned);
+    }
+    return pruned;
+}

--- a/asset_manager/asset_manager.hpp
+++ b/asset_manager/asset_manager.hpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file asset_manager.hpp
+ * @brief Handle-based asset cache keyed by filesystem path.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+#include <utility>
+
+#include <infrastructure/log.hpp>
+#include <infrastructure/singleton.hpp>
+
+namespace asset_manager
+{
+    /**
+     * @brief Process-wide asset cache that deduplicates assets by path.
+     *
+     * Assets are returned as @c std::shared_ptr<T> so their lifetime is tied
+     * to their usage. Internally the cache stores @c std::weak_ptr entries,
+     * so once every handle to a given asset is dropped the underlying object
+     * is destroyed immediately; @ref collect_unused simply prunes the
+     * expired bookkeeping entries from the lookup tables.
+     *
+     * The manager is keyed by @c (type, path) — the same path loaded as two
+     * different asset types is tracked as two independent entries. The path
+     * is stored using @c std::filesystem::path::generic_string() so that
+     * `a/b.png` and `a\b.png` hit the same cache slot on Windows.
+     *
+     * Listener storage and access are not thread-safe — register and load
+     * from the main loop thread only.
+     */
+    struct context : public singleton<context>
+    {
+        context() = default;
+
+        /** @brief Initializes the asset manager. Must be called once at startup. */
+        void init();
+
+        /** @brief Shuts down the asset manager and clears all cache entries. */
+        void quit();
+
+        /**
+         * @brief Returns a cached asset, loading it if not already present.
+         *
+         * If an entry for @p path (under type @c T) is already cached and
+         * still has live handles, the existing @c shared_ptr is returned
+         * and @p args are ignored. Otherwise a new @c T is constructed via
+         * @c std::make_shared<T>(path_as_string, args...) and inserted
+         * into the cache.
+         *
+         * @tparam T    Asset type. Must be constructible from
+         *              @c (const std::string&, Args&&...).
+         * @tparam Args Forwarded constructor arguments used on cache miss.
+         * @param path  Filesystem path used as the cache key and passed to
+         *              the @p T constructor.
+         * @param args  Additional constructor arguments (e.g. font size).
+         * @return Shared handle to the cached asset.
+         */
+        template<typename T, typename... Args>
+        std::shared_ptr<T> load(const std::filesystem::path& path, Args&&... args)
+        {
+            const std::string key = path.generic_string();
+            auto& bucket = m_caches[std::type_index(typeid(T))];
+
+            auto it = bucket.find(key);
+            if (it != bucket.end())
+            {
+                if (auto existing = std::static_pointer_cast<T>(it->second.lock()))
+                {
+                    return existing;
+                }
+                // Cached entry expired between frames — fall through and reload.
+                bucket.erase(it);
+            }
+
+            auto asset = std::make_shared<T>(key, std::forward<Args>(args)...);
+            bucket.emplace(key, std::weak_ptr<void>(asset));
+            LOG_INF("Asset loaded (type=%s, path=\"%s\")", typeid(T).name(), key.c_str());
+            return asset;
+        }
+
+        /**
+         * @brief Inserts an already-constructed asset into the cache.
+         *
+         * Useful for asset types that do not have a path-based constructor
+         * (for example, meshes that are built programmatically or loaded
+         * by a caller-supplied parser). If an entry for @p path already
+         * exists and is still live, the existing handle is returned and
+         * @p asset is discarded.
+         *
+         * @tparam T    Asset type.
+         * @param path  Filesystem path used as the cache key.
+         * @param asset Handle to take ownership of.
+         * @return The cached handle (either @p asset or the pre-existing one).
+         */
+        template<typename T>
+        std::shared_ptr<T> insert(const std::filesystem::path& path, std::shared_ptr<T> asset)
+        {
+            const std::string key = path.generic_string();
+            auto& bucket = m_caches[std::type_index(typeid(T))];
+
+            auto it = bucket.find(key);
+            if (it != bucket.end())
+            {
+                if (auto existing = std::static_pointer_cast<T>(it->second.lock()))
+                {
+                    return existing;
+                }
+                bucket.erase(it);
+            }
+
+            bucket.emplace(key, std::weak_ptr<void>(asset));
+            LOG_INF("Asset inserted (type=%s, path=\"%s\")", typeid(T).name(), key.c_str());
+            return asset;
+        }
+
+        /**
+         * @brief Returns the cached handle for @p path, or @c nullptr if absent.
+         *
+         * Does not load on miss. Stale entries (weak_ptr expired) are treated
+         * as absent and pruned.
+         *
+         * @tparam T    Asset type.
+         * @param path  Filesystem path used as the cache key.
+         */
+        template<typename T>
+        std::shared_ptr<T> get(const std::filesystem::path& path)
+        {
+            const std::string key = path.generic_string();
+            auto type_it = m_caches.find(std::type_index(typeid(T)));
+            if (type_it == m_caches.end())
+            {
+                return nullptr;
+            }
+
+            auto& bucket = type_it->second;
+            auto it = bucket.find(key);
+            if (it == bucket.end())
+            {
+                return nullptr;
+            }
+
+            auto existing = std::static_pointer_cast<T>(it->second.lock());
+            if (!existing)
+            {
+                bucket.erase(it);
+            }
+            return existing;
+        }
+
+        /**
+         * @brief Drops bookkeeping entries for assets with no live handles.
+         *
+         * Walks every cache bucket and removes any @c weak_ptr whose
+         * referent has already been destroyed. The underlying asset is
+         * destroyed as soon as the last handle drops — this call only
+         * reclaims the map entries themselves.
+         *
+         * @return Number of entries pruned.
+         */
+        std::size_t collect_unused();
+
+    private:
+        std::unordered_map<std::type_index, std::unordered_map<std::string, std::weak_ptr<void>>> m_caches;
+    };
+} // namespace asset_manager

--- a/control/main_loop.cpp
+++ b/control/main_loop.cpp
@@ -22,6 +22,7 @@
 
 #include <stdexcept>
 
+#include <asset_manager/asset_manager.hpp>
 #include <event_engine/event_engine.hpp>
 #include <infrastructure/log.hpp>
 #include <infrastructure/time.hpp>
@@ -45,6 +46,7 @@ int main(int argc, char* argv[])
     try
     {
         event_engine::event_bus::get_instance().init();
+        asset_manager::context::get_instance().init();
         rendering_engine::context::get_instance().init();
         scene_graph::context::get_instance().init();
     }
@@ -86,6 +88,7 @@ int main(int argc, char* argv[])
     LOG_INF("Engine shutting down: tearing down subsystems");
     scene_graph::context::get_instance().quit();
     rendering_engine::context::get_instance().quit();
+    asset_manager::context::get_instance().quit();
     event_engine::event_bus::get_instance().quit();
     LOG_INF("Engine stopped cleanly");
     return EXIT_SUCCESS;

--- a/scripts/check-naming.ps1
+++ b/scripts/check-naming.ps1
@@ -87,7 +87,7 @@ if (-not (Test-Path $compileDb)) { throw "compile_commands.json was not generate
 Write-Ok "compile_commands.json: $compileDb"
 
 # --- Enumerate project source files ---
-$sourceDirs = @('control', 'event_engine', 'infrastructure', 'scene_graph', 'rendering_engine', 'external')
+$sourceDirs = @('control', 'event_engine', 'infrastructure', 'scene_graph', 'rendering_engine', 'external', 'asset_manager')
 $files = foreach ($d in $sourceDirs) {
     $path = Join-Path $repoRoot $d
     if (Test-Path $path) {

--- a/scripts/check-style.ps1
+++ b/scripts/check-style.ps1
@@ -55,7 +55,7 @@ if (-not $ClangFormat) {
 Write-Step "Using $ClangFormat"
 
 # --- Enumerate source files ---
-$sourceDirs = @('control', 'event_engine', 'infrastructure', 'scene_graph', 'rendering_engine', 'external')
+$sourceDirs = @('control', 'event_engine', 'infrastructure', 'scene_graph', 'rendering_engine', 'external', 'asset_manager')
 $files = foreach ($d in $sourceDirs) {
     $path = Join-Path $repoRoot $d
     if (Test-Path $path) {


### PR DESCRIPTION
## Summary

- Adds a new `asset_manager` subsystem (`asset_manager::context`) wired into `main_loop.cpp` alongside the existing `event_engine`, `rendering_engine`, and `scene_graph` contexts. Follows the same `singleton<T>` + `init()`/`quit()` shape.
- Deduplicates assets by `std::filesystem::path` (normalized via `generic_string()` so Windows back/forward-slash variants collide) using `std::unordered_map`.
- Returns `std::shared_ptr<T>` handles; internal storage is `std::weak_ptr<void>` keyed by `(std::type_index, path)`, so asset lifetime is tied to usage.
- `load<T>(path, args...)` forwards to `std::make_shared<T>(path, args...)` on miss — works out of the box for `rendering_engine::util::image` (texture) and `rendering_engine::util::font`.
- `insert<T>(path, shared_ptr<T>)` lets callers register already-built assets such as `rendering_engine::mesh`, which has no path-based constructor today.
- `collect_unused()` walks every bucket and drops expired `weak_ptr` entries; returns the number pruned.
- Stdlib only — no new dependencies. Updates `CMakeLists.txt`, `.clang-tidy` header filter, `.github/workflows/ci.yml`, and both PowerShell check scripts to cover the new directory.

Closes #15

## Test plan

- [x] `./scripts/check-style.ps1` — passes (no style issues).
- [x] `./scripts/build.ps1` — MSVC Release build succeeds, produces `Binaries/Release/AlphaEngine.exe`.
- [x] CI (clang-format, clang-tidy, Windows MSVC Debug + Release) green on the PR.
- [ ] Manual smoke: launch the engine and verify `Init Asset Manager` / `Quit Asset Manager` lifecycle log lines appear.