### PR TITLE
feat: implement ECS world to replace empty scene_graph

### DIFF
--- a/scene_graph/entity.hpp
+++ b/scene_graph/entity.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file entity.hpp
+ * @brief Opaque identifier type used by the scene_graph ECS world.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace scene_graph
+{
+    /**
+     * @brief Opaque handle identifying an entity in the ECS @ref world.
+     *
+     * Identifiers are dense 32-bit unsigned integers allocated monotonically
+     * by @ref world::create_entity. They are stable for the lifetime of the
+     * entity but may be reused after destruction, so prefer not to retain
+     * them across @ref world::destroy_entity calls without external
+     * bookkeeping.
+     */
+    using entity_id = std::uint32_t;
+
+    /**
+     * @brief Sentinel @ref entity_id value reserved to mean "no entity".
+     *
+     * Never returned by @ref world::create_entity. Useful as a default
+     * for uninitialized handles or to signal lookup failure.
+     */
+    inline constexpr entity_id invalid_entity = 0;
+} // namespace scene_graph

--- a/scene_graph/scene_graph.cpp
+++ b/scene_graph/scene_graph.cpp
@@ -22,6 +22,8 @@
 
 #include <scene_graph/scene_graph.hpp>
 
+#include <event_engine/event.hpp>
+#include <event_engine/event_engine.hpp>
 #include <infrastructure/log.hpp>
 
 #include <string>
@@ -29,11 +31,28 @@
 void scene_graph::context::init()
 {
     LOG_INF("Init Scene Graph");
-    // Node add/remove and traversal diagnostics are expected to be logged from
-    // here by scene_graph API calls once they exist. See docs/logging.md.
+
+    // Dispatch render_scene events through the ECS world so that entities
+    // carrying a renderable_component can draw without each game module
+    // having to subscribe to render_scene directly. See docs/logging.md.
+    event_engine::context::get_instance().register_listener(event_engine::event_type::render_scene,
+                                                            [](const event_engine::event&)
+                                                            {
+                                                                auto& world = context::get_instance().get_world();
+                                                                for (auto id : world.view<renderable_component>())
+                                                                {
+                                                                    auto* renderable =
+                                                                        world.get<renderable_component>(id);
+                                                                    if (renderable != nullptr && renderable->draw)
+                                                                    {
+                                                                        renderable->draw();
+                                                                    }
+                                                                }
+                                                            });
 }
 
 void scene_graph::context::quit()
 {
-    LOG_INF("Quit Scene Graph");
+    LOG_INF("Quit Scene Graph: %zu entities still alive", m_world.entity_count());
+    m_world.clear();
 }

--- a/scene_graph/scene_graph.hpp
+++ b/scene_graph/scene_graph.hpp
@@ -30,22 +30,44 @@
 #include <string>
 
 #include <infrastructure/singleton.hpp>
+#include <scene_graph/world.hpp>
 
 namespace scene_graph
 {
     /**
      * @brief Lifetime owner of the scene graph subsystem.
      *
-     * Process-wide singleton. Currently a lifecycle stub that matches
-     * the shape of the other engine subsystems — @ref init is called
-     * at startup and @ref quit at shutdown.
+     * Process-wide singleton that owns the ECS @ref world. @ref init is
+     * called at startup and @ref quit at shutdown. Between those two calls,
+     * the context subscribes to @c render_scene on the event bus and
+     * iterates every entity with a @ref renderable_component, invoking its
+     * @c draw callback. This replaces the older pattern of every game
+     * module subscribing to @c render_scene independently.
      */
     struct context : public singleton<context>
     {
-        /** @brief Initializes the scene graph subsystem. */
+        /** @brief Initializes the scene graph subsystem and registers event listeners. */
         void init();
 
-        /** @brief Shuts down the scene graph subsystem. */
+        /** @brief Shuts down the scene graph subsystem and clears the world. */
         void quit();
+
+        /**
+         * @brief Accessor for the ECS world owned by this subsystem.
+         * @return Mutable reference to the process-wide @ref world.
+         */
+        world& get_world()
+        {
+            return m_world;
+        }
+
+        /** @brief Const overload of @ref get_world. */
+        [[nodiscard]] const world& get_world() const
+        {
+            return m_world;
+        }
+
+    private:
+        world m_world;
     };
 } // namespace scene_graph

--- a/scene_graph/world.cpp
+++ b/scene_graph/world.cpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <scene_graph/world.hpp>
+
+#include <infrastructure/log.hpp>
+
+namespace scene_graph
+{
+    entity_id world::create_entity()
+    {
+        // Skip over invalid_entity (0) on the extremely unlikely wrap-around.
+        // With 32 bits of id space this is defensive rather than realistic.
+        if (m_next_id == invalid_entity)
+        {
+            ++m_next_id;
+        }
+        const entity_id id = m_next_id++;
+        m_alive.insert(id);
+        return id;
+    }
+
+    void world::destroy_entity(entity_id entity)
+    {
+        if (entity == invalid_entity)
+        {
+            return;
+        }
+        if (m_alive.erase(entity) == 0)
+        {
+            // Destroying an already-dead entity is benign but almost always a bug
+            // in the caller; surface it at WARN so the pattern shows up in logs.
+            LOG_WRN("destroy_entity called on unknown id=%u", entity);
+            return;
+        }
+        for (auto& [key, storage] : m_components)
+        {
+            storage->erase(entity);
+        }
+    }
+
+    bool world::is_alive(entity_id entity) const
+    {
+        if (entity == invalid_entity)
+        {
+            return false;
+        }
+        return m_alive.find(entity) != m_alive.end();
+    }
+
+    void world::clear()
+    {
+        m_alive.clear();
+        m_components.clear();
+        m_next_id = 1;
+    }
+} // namespace scene_graph

--- a/scene_graph/world.hpp
+++ b/scene_graph/world.hpp
@@ -1,0 +1,369 @@
+/**
+ * Copyright (c) 2015-2025 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file world.hpp
+ * @brief Minimal stdlib-only Entity-Component-System container.
+ *
+ * The @ref scene_graph::world owns a set of @ref entity_id handles and
+ * arbitrary user-defined component types associated with them. Component
+ * storage is type-erased by @c std::type_index and implemented on top of
+ * @c std::unordered_map, so any default-constructible, movable struct can
+ * be used as a component with no registration step.
+ *
+ * The world is not thread-safe - mutate it only from the main-loop thread.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <typeindex>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <scene_graph/entity.hpp>
+
+namespace scene_graph
+{
+    /**
+     * @brief Entity-Component-System container.
+     *
+     * Entities are opaque ids (see @ref entity_id). Components are stored in
+     * type-erased per-type maps keyed by entity. Lookup and mutation cost
+     * one or two @c unordered_map operations - this is intentionally a
+     * simple, correct implementation rather than a cache-optimal one.
+     *
+     * Typical usage:
+     * @code
+     * scene_graph::world w;
+     * auto e = w.create_entity();
+     * w.add<transform>(e, transform{});
+     * for (auto id : w.view<transform, mesh>())
+     * {
+     *     auto& t = *w.get<transform>(id);
+     *     // ...
+     * }
+     * @endcode
+     */
+    class world
+    {
+    public:
+        world() = default;
+        ~world() = default;
+
+        world(const world&) = delete;
+        world& operator=(const world&) = delete;
+        world(world&&) = delete;
+        world& operator=(world&&) = delete;
+
+        /**
+         * @brief Allocates a fresh entity id.
+         *
+         * The returned id is never @ref invalid_entity and is unique among
+         * currently-live entities in this world. Ids of destroyed entities
+         * may eventually be reused; callers that retain ids across
+         * @ref destroy_entity calls must guard against that themselves.
+         *
+         * @return A new live @ref entity_id.
+         */
+        entity_id create_entity();
+
+        /**
+         * @brief Destroys @p entity and erases every component attached to it.
+         *
+         * No-op if @p entity is @ref invalid_entity or already destroyed.
+         *
+         * @param entity Entity handle to destroy.
+         */
+        void destroy_entity(entity_id entity);
+
+        /**
+         * @brief Reports whether @p entity currently exists in this world.
+         * @param entity Entity handle to query.
+         * @return @c true if live, @c false if destroyed or invalid.
+         */
+        [[nodiscard]] bool is_alive(entity_id entity) const;
+
+        /**
+         * @brief Attaches (or overwrites) a component of type @p T on @p entity.
+         *
+         * The component is stored by move. If @p entity already has a
+         * component of type @p T, it is replaced.
+         *
+         * @tparam T         Component type. Must be move-constructible.
+         * @param  entity    Live entity to attach the component to.
+         * @param  component Component value, taken by value and moved in.
+         * @return Reference to the stored component, valid until the next
+         *         mutation of the same component storage.
+         */
+        template<typename T>
+        T& add(entity_id entity, T component);
+
+        /**
+         * @brief Looks up the component of type @p T on @p entity.
+         *
+         * @tparam T      Component type.
+         * @param  entity Entity handle.
+         * @return Pointer to the stored component, or @c nullptr if
+         *         @p entity has no component of type @p T.
+         */
+        template<typename T>
+        [[nodiscard]] T* get(entity_id entity);
+
+        /** @brief Const overload of @ref get. */
+        template<typename T>
+        [[nodiscard]] const T* get(entity_id entity) const;
+
+        /**
+         * @brief Reports whether @p entity has a component of type @p T.
+         * @tparam T      Component type.
+         * @param  entity Entity handle.
+         * @return @c true if the component is present.
+         */
+        template<typename T>
+        [[nodiscard]] bool has(entity_id entity) const;
+
+        /**
+         * @brief Removes the component of type @p T from @p entity, if any.
+         *
+         * @tparam T      Component type.
+         * @param  entity Entity handle.
+         * @return @c true if a component was removed, @c false if none was
+         *         present.
+         */
+        template<typename T>
+        bool remove(entity_id entity);
+
+        /**
+         * @brief Returns the ids of all entities that have every component
+         *        in @p Ts.
+         *
+         * The returned vector is a snapshot - mutating the world after the
+         * call does not invalidate it, but the set of matching entities may
+         * drift from what the snapshot contains. Prefer to consume the
+         * result inside a single frame.
+         *
+         * @tparam Ts Component type pack. With no parameters, returns every
+         *            live entity.
+         * @return A newly-allocated vector of matching ids.
+         */
+        template<typename... Ts>
+        [[nodiscard]] std::vector<entity_id> view() const;
+
+        /** @brief Number of currently live entities. */
+        [[nodiscard]] std::size_t entity_count() const
+        {
+            return m_alive.size();
+        }
+
+        /**
+         * @brief Drops every entity and component.
+         *
+         * After @ref clear, @ref entity_count is 0 and future ids start
+         * from 1 again.
+         */
+        void clear();
+
+    private:
+        /**
+         * @brief Type-erased interface used to drop a single entity's
+         *        component from any per-type storage without knowing @p T.
+         *
+         * Needed so @ref destroy_entity can uniformly sweep across all
+         * registered component types.
+         */
+        struct component_storage_base
+        {
+            virtual ~component_storage_base() = default;
+            virtual void erase(entity_id entity) = 0;
+        };
+
+        /**
+         * @brief Concrete per-component-type storage: a map from entity to
+         *        component value.
+         *
+         * Instantiated lazily the first time @ref add is called with a
+         * given @p T.
+         */
+        template<typename T>
+        struct component_storage : component_storage_base
+        {
+            std::unordered_map<entity_id, T> data;
+
+            void erase(entity_id entity) override
+            {
+                data.erase(entity);
+            }
+        };
+
+        template<typename T>
+        component_storage<T>* get_storage();
+
+        template<typename T>
+        const component_storage<T>* get_storage() const;
+
+        entity_id m_next_id{1};
+        std::unordered_set<entity_id> m_alive;
+        std::unordered_map<std::type_index, std::unique_ptr<component_storage_base>> m_components;
+    };
+
+    // ---- template implementations ----
+
+    template<typename T>
+    T& world::add(entity_id entity, T component)
+    {
+        auto* storage = get_storage<T>();
+        auto [it, inserted] = storage->data.insert_or_assign(entity, std::move(component));
+        return it->second;
+    }
+
+    template<typename T>
+    T* world::get(entity_id entity)
+    {
+        auto* storage = get_storage<T>();
+        auto it = storage->data.find(entity);
+        if (it == storage->data.end())
+        {
+            return nullptr;
+        }
+        return &it->second;
+    }
+
+    template<typename T>
+    const T* world::get(entity_id entity) const
+    {
+        const auto* storage = get_storage<T>();
+        if (storage == nullptr)
+        {
+            return nullptr;
+        }
+        auto it = storage->data.find(entity);
+        if (it == storage->data.end())
+        {
+            return nullptr;
+        }
+        return &it->second;
+    }
+
+    template<typename T>
+    bool world::has(entity_id entity) const
+    {
+        const auto* storage = get_storage<T>();
+        if (storage == nullptr)
+        {
+            return false;
+        }
+        return storage->data.find(entity) != storage->data.end();
+    }
+
+    template<typename T>
+    bool world::remove(entity_id entity)
+    {
+        auto it = m_components.find(std::type_index(typeid(T)));
+        if (it == m_components.end())
+        {
+            return false;
+        }
+        auto* storage = static_cast<component_storage<T>*>(it->second.get());
+        return storage->data.erase(entity) > 0;
+    }
+
+    template<typename... Ts>
+    std::vector<entity_id> world::view() const
+    {
+        std::vector<entity_id> result;
+        if constexpr (sizeof...(Ts) == 0)
+        {
+            result.reserve(m_alive.size());
+            for (auto id : m_alive)
+            {
+                result.push_back(id);
+            }
+            return result;
+        }
+        else
+        {
+            // If any required component type has never been stored, the view
+            // is empty by definition - short-circuit instead of paying for
+            // an iteration.
+            const bool any_missing = (... || (get_storage<Ts>() == nullptr));
+            if (any_missing)
+            {
+                return result;
+            }
+
+            for (auto id : m_alive)
+            {
+                if ((... && has<Ts>(id)))
+                {
+                    result.push_back(id);
+                }
+            }
+            return result;
+        }
+    }
+
+    template<typename T>
+    world::component_storage<T>* world::get_storage()
+    {
+        const auto key = std::type_index(typeid(T));
+        auto it = m_components.find(key);
+        if (it == m_components.end())
+        {
+            auto owned = std::make_unique<component_storage<T>>();
+            auto* raw = owned.get();
+            m_components.emplace(key, std::move(owned));
+            return raw;
+        }
+        return static_cast<component_storage<T>*>(it->second.get());
+    }
+
+    template<typename T>
+    const world::component_storage<T>* world::get_storage() const
+    {
+        const auto key = std::type_index(typeid(T));
+        auto it = m_components.find(key);
+        if (it == m_components.end())
+        {
+            return nullptr;
+        }
+        return static_cast<const component_storage<T>*>(it->second.get());
+    }
+
+    /**
+     * @brief Built-in component that hooks an entity into the scene render pass.
+     *
+     * When the @ref context is active, every entity that carries a
+     * @ref renderable_component has its @ref draw callback invoked during
+     * the @c render_scene event broadcast. This demonstrates how gameplay
+     * code can register visuals through the ECS instead of subscribing to
+     * @c render_scene directly from a game module.
+     */
+    struct renderable_component
+    {
+        /** @brief Called once per scene render. Must not be empty at dispatch time. */
+        std::function<void()> draw;
+    };
+} // namespace scene_graph


### PR DESCRIPTION
## Summary

- Adds a minimal stdlib-only ECS world (`scene_graph::world`) using `std::unordered_map` + `std::type_index` for type-erased component storage. No external ECS dependency.
- Exposes `create_entity` / `destroy_entity`, `add<T>` / `get<T>` / `has<T>` / `remove<T>` per entity, and a variadic `view<Ts...>` that returns every entity carrying the requested component set.
- `entity_id` is an opaque `uint32_t`; `invalid_entity = 0` is the sentinel.
- `scene_graph::context` now owns a `world` instance and registers a single `render_scene` listener that iterates `view<renderable_component>` and invokes each entity's `draw` callback, replacing the per-module broadcast pattern for rendering.

Closes #16

## Test plan

- [x] `./scripts/check-style.ps1` reports no style issues
- [x] `./scripts/check-naming.ps1` reports no naming violations
- [x] `./scripts/build.ps1` configures and builds (`Binaries/Release/AlphaEngine.exe` produced)
- [x] Smoke test on a follow-up: spawn a cube via the ECS with a `renderable_component` and verify it renders without subscribing to `render_scene` from a game module