### PR TITLE
refactor: replace hardcoded event enum with a generic typed event bus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Entry point is `control/main_loop.cpp`. It initializes three subsystems, runs th
 
 The subsystems:
 
-- **`event_engine`** — process-wide synchronous publish/subscribe hub (`event_engine::context`). Listeners register against `event_type` keys and receive `const event&` callbacks. Not thread-safe; register during init, broadcast from the main loop. Engine-wide events include `engine_start`, `engine_stop`, `render_scene`, `render_ui`, input events, and `quit_requested`.
+- **`event_engine`** — process-wide synchronous publish/subscribe hub (`event_engine::event_bus`). Listeners subscribe by event struct type (`std::type_index`-keyed) and receive a typed `const E&` callback; the bus exposes `subscribe<E>(listener)`, immediate `emit<E>(args...)`, buffered `enqueue<E>(args...)`, and `flush()`. Not thread-safe; register during init, dispatch from the main loop. Built-in events include `engine_start`, `engine_stop`, `render_scene`, `render_ui`, input events, and `quit_requested`; game modules may define their own event structs without touching core headers.
 - **`rendering_engine`** — owns the window, SDL/GL context, and built-in renderers (`basic_renderer`, `overlay_renderer`). `render()` broadcasts `render_scene` (if a camera is active) then `render_ui` with depth test disabled. It does **not** swap buffers — the main loop calls `window::swap_buffers()` explicitly. Subfolders: `camera/`, `mesh/`, `opengl/` (GL wrapper types: program, shader, buffer, texture, framebuffer, vertex_array), `renderables/` (+ `premade_2d/`, `premade_3d/`), `renderers/`, `util/` (color, font, image, transform).
 - **`scene_graph`** — currently a lifecycle stub with the same init/quit shape as the others.
 

--- a/control/main_loop.cpp
+++ b/control/main_loop.cpp
@@ -31,7 +31,7 @@
 
 bool is_quit_requested = false;
 
-void quit_request_listener(const event_engine::event& event)
+void quit_request_listener(const event_engine::quit_requested& event)
 {
     is_quit_requested = true;
 }
@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        event_engine::context::get_instance().init();
+        event_engine::event_bus::get_instance().init();
         rendering_engine::context::get_instance().init();
         scene_graph::context::get_instance().init();
     }
@@ -59,9 +59,8 @@ int main(int argc, char* argv[])
 
     try
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::quit_requested,
-                                                                quit_request_listener);
-        event_engine::context::get_instance().broadcast(event_engine::engine_start());
+        event_engine::event_bus::get_instance().subscribe<event_engine::quit_requested>(quit_request_listener);
+        event_engine::event_bus::get_instance().emit<event_engine::engine_start>();
 
         for (;;)
         {
@@ -75,7 +74,7 @@ int main(int argc, char* argv[])
         }
 
         LOG_INF("Quit requested: broadcasting engine_stop");
-        event_engine::context::get_instance().broadcast(event_engine::engine_stop());
+        event_engine::event_bus::get_instance().emit<event_engine::engine_stop>();
     }
     catch (const std::exception& e)
     {
@@ -87,7 +86,7 @@ int main(int argc, char* argv[])
     LOG_INF("Engine shutting down: tearing down subsystems");
     scene_graph::context::get_instance().quit();
     rendering_engine::context::get_instance().quit();
-    event_engine::context::get_instance().quit();
+    event_engine::event_bus::get_instance().quit();
     LOG_INF("Engine stopped cleanly");
     return EXIT_SUCCESS;
 }

--- a/event_engine/event.hpp
+++ b/event_engine/event.hpp
@@ -22,32 +22,18 @@
 
 /**
  * @file event.hpp
- * @brief Event value types broadcast through the event engine.
+ * @brief Built-in event value types broadcast through the event bus.
+ *
+ * Every event is an ordinary value type — there is no shared base class.
+ * The @ref event_engine::event_bus is keyed on @c std::type_index, so game
+ * modules can define their own event structs and dispatch them through
+ * the same bus without modifying this header.
  */
 
 #pragma once
 
 namespace event_engine
 {
-    /**
-     * @brief Discriminator used by @ref event to identify its dynamic type
-     *        and by listeners to subscribe to a specific event category.
-     */
-    enum class event_type
-    {
-        engine_start,
-        engine_stop,
-        quit_requested,
-        frame,
-        render_scene,
-        render_ui,
-        mouse_key_up,
-        mouse_key_down,
-        key_up,
-        key_down,
-        mouse_move
-    };
-
     /**
      * @brief Keyboard key identifiers. Values mirror SDL keysym codes so
      *        the window layer can cast directly into this enum.
@@ -73,39 +59,19 @@ namespace event_engine
         middle = 141883,
     };
 
-    /**
-     * @brief Polymorphic base for every event passed through the bus.
-     *
-     * Listeners receive a @c const reference and may @c static_cast /
-     * @c dynamic_cast to the concrete subtype after inspecting @ref m_type.
-     * Events are passed by reference only and are not retained by the
-     * dispatcher — derived objects are typically stack-allocated at the
-     * broadcast site.
-     */
-    struct event
-    {
-        event(event_type type) : m_type{type} {}
-        virtual ~event() = default;
-
-        event_type m_type;
-    };
-
     /** @brief Broadcast once after all subsystems have been initialized. */
-    struct engine_start : public event
+    struct engine_start
     {
-        engine_start() : event(event_type::engine_start) {}
     };
 
     /** @brief Broadcast once as the main loop is tearing down. */
-    struct engine_stop : public event
+    struct engine_stop
     {
-        engine_stop() : event(event_type::engine_stop) {}
     };
 
     /** @brief Signals the user requested application termination. */
-    struct quit_requested : public event
+    struct quit_requested
     {
-        quit_requested() : event(event_type::quit_requested) {}
     };
 
     /**
@@ -114,55 +80,43 @@ namespace event_engine
      * Broadcast once per iteration of the main loop and carries the
      * time elapsed since the previous frame.
      */
-    struct frame : public event
+    struct frame
     {
-        frame() : event(event_type::frame) {}
-
         /** @brief Time since the previous frame, in milliseconds. */
         float m_delta_time;
     };
 
     /** @brief Broadcast while the 3D scene pass is active; renderables should submit draw calls. */
-    struct render_scene : public event
+    struct render_scene
     {
-        render_scene() : event(event_type::render_scene) {}
     };
 
     /** @brief Broadcast while the 2D overlay/UI pass is active. */
-    struct render_ui : public event
+    struct render_ui
     {
-        render_ui() : event(event_type::render_ui) {}
     };
 
     /** @brief Key release. @ref m_key_code is the released key. */
-    struct key_up : public event
+    struct key_up
     {
-        key_up() : event(event_type::key_up) {}
-
         key_code m_key_code;
     };
 
     /** @brief Key press. @ref m_key_code is the pressed key. */
-    struct key_down : public event
+    struct key_down
     {
-        key_down() : event(event_type::key_down) {}
-
         key_code m_key_code;
     };
 
     /** @brief Mouse button release. @ref m_key_code is the released button. */
-    struct mouse_key_up : public event
+    struct mouse_key_up
     {
-        mouse_key_up() : event(event_type::mouse_key_up) {}
-
         mouse_key_code m_key_code;
     };
 
     /** @brief Mouse button press. @ref m_key_code is the pressed button. */
-    struct mouse_key_down : public event
+    struct mouse_key_down
     {
-        mouse_key_down() : event(event_type::mouse_key_down) {}
-
         mouse_key_code m_key_code;
     };
 
@@ -172,10 +126,8 @@ namespace event_engine
      * @ref m_x and @ref m_y carry the relative motion since the previous
      * report (not absolute cursor coordinates).
      */
-    struct mouse_move : public event
+    struct mouse_move
     {
-        mouse_move() : event(event_type::mouse_move) {}
-
         int m_x; /**< Horizontal delta in pixels. */
         int m_y; /**< Vertical delta in pixels. */
     };

--- a/event_engine/event_engine.cpp
+++ b/event_engine/event_engine.cpp
@@ -20,59 +20,52 @@
  * SOFTWARE.
  */
 
-#include <stdexcept>
+#include <utility>
 
 #include <event_engine/event_engine.hpp>
 #include <infrastructure/log.hpp>
 
-void event_engine::context::init()
+void event_engine::event_bus::init()
 {
     LOG_INF("Init Event Engine");
 }
 
-void event_engine::context::quit()
+void event_engine::event_bus::quit()
 {
     LOG_INF("Quit Event Engine: %zu event types had listeners registered", m_listeners.size());
+    m_listeners.clear();
+    m_pending.clear();
 }
 
-void event_engine::context::broadcast(const event& event)
+void event_engine::event_bus::dispatch(std::type_index type, const std::any& payload)
 {
-    // Lifecycle and low-frequency events are worth noting at INFO; per-frame / input
-    // events happen many times per second and would flood logs, so we stay silent for
-    // them. Broadcasting to zero listeners is legal and intentionally not logged.
-    switch (event.m_type)
+    auto it = m_listeners.find(type);
+    if (it == m_listeners.end())
     {
-    case event_type::engine_start:
-    case event_type::engine_stop:
-    case event_type::quit_requested:
-        LOG_INF("Broadcasting event_type=%d", static_cast<int>(event.m_type));
-        break;
-    default:
-        break;
-    }
-
-    for (const auto& listener : m_listeners[event.m_type])
-    {
-        if (!listener)
-        {
-            LOG_ERR("Skipping null listener for event_type=%d", static_cast<int>(event.m_type));
-            continue;
-        }
-        listener(event);
-    }
-}
-
-void event_engine::context::register_listener(const event_type type, const std::function<void(const event&)>& listener)
-{
-    if (!listener)
-    {
-        LOG_ERR("Attempted to register null listener for event_type=%d", static_cast<int>(type));
         return;
     }
 
-    m_listeners[type].push_back(listener);
-    // Registration happens at static-init time (from GAME_MODULE()) and again after
-    // main() runs, so keep this quiet at INFO rather than spamming WARN.
-    LOG_INF(
-        "Registered listener for event_type=%d (listeners now=%zu)", static_cast<int>(type), m_listeners[type].size());
+    for (const auto& listener : it->second)
+    {
+        if (!listener)
+        {
+            LOG_ERR("Skipping null listener for event type '%s'", type.name());
+            continue;
+        }
+        listener(payload);
+    }
+}
+
+void event_engine::event_bus::flush()
+{
+    // Swap the pending queue into a local so that listeners re-entering via
+    // enqueue() during this flush have their events deferred to the next
+    // flush, matching the buffered-dispatch contract.
+    std::vector<queued_entry> draining;
+    draining.swap(m_pending);
+
+    for (const auto& entry : draining)
+    {
+        dispatch(entry.first, entry.second);
+    }
 }

--- a/event_engine/event_engine.hpp
+++ b/event_engine/event_engine.hpp
@@ -22,13 +22,16 @@
 
 /**
  * @file event_engine.hpp
- * @brief Event dispatch subsystem: publish/subscribe hub for engine events.
+ * @brief Generic typed event bus: publish/subscribe hub for engine events.
  */
 
 #pragma once
 
+#include <any>
 #include <functional>
+#include <typeindex>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <event_engine/event.hpp>
@@ -37,44 +40,103 @@
 namespace event_engine
 {
     /**
-     * @brief Central event bus used by all subsystems.
+     * @brief Central typed event bus used by all subsystems.
      *
-     * Listeners register callbacks keyed on an @ref event_type and are
-     * invoked synchronously whenever an event of that type is broadcast.
-     * The context is a process-wide singleton; listener storage and
-     * dispatch are not thread-safe — register listeners during init and
-     * broadcast from the main loop thread only.
+     * Listeners are registered per event type @c E via @ref subscribe and
+     * invoked synchronously whenever an event of that type is dispatched
+     * through @ref emit. @ref enqueue buffers events for later delivery
+     * through @ref flush, which drains the queue once in FIFO order.
+     *
+     * The bus is a process-wide singleton. Listener storage, dispatch, and
+     * the pending queue are not thread-safe — register listeners during
+     * init and emit/enqueue from the main-loop thread only.
+     *
+     * Events are arbitrary value types. No base class is required: the
+     * bus keys listeners on @c std::type_index and stores enqueued events
+     * in @c std::any. Game modules can introduce their own event structs
+     * without touching engine headers.
      */
-    struct context : public singleton<context>
+    struct event_bus : public singleton<event_bus>
     {
-        context() = default;
+        event_bus() = default;
 
-        /** @brief Initializes the event engine. Must be called once at startup. */
+        /** @brief Initializes the event bus. Must be called once at startup. */
         void init();
 
-        /** @brief Shuts down the event engine. Called once at teardown. */
+        /** @brief Shuts down the event bus. Called once at teardown. */
         void quit();
 
         /**
-         * @brief Dispatches @p event synchronously to every listener
-         *        registered for its type.
-         * @param event Event to broadcast. The reference must stay valid
-         *              for the duration of the call; listeners receive a
-         *              const reference and must not retain it.
+         * @brief Registers a callback for events of type @c E.
+         * @tparam E        The event struct type to subscribe to.
+         * @param listener  Callable invoked on every matching dispatch.
+         *                  Stored by value in the bus; any captured state
+         *                  must outlive the bus or be owned by the callable.
          */
-        void broadcast(const event& event);
+        template<typename E>
+        void subscribe(std::function<void(const E&)> listener);
 
         /**
-         * @brief Registers a callback for events of a given type.
-         * @param type     The event type to subscribe to.
-         * @param listener Callable invoked on every matching broadcast.
-         *                 Stored by value in the engine; any captured
-         *                 state must outlive the engine or be owned by
-         *                 the callable itself.
+         * @brief Constructs an event of type @c E in place and dispatches
+         *        it synchronously to every subscribed listener.
+         * @tparam E       The event struct type to emit.
+         * @tparam Args    Argument types forwarded to @c E's constructor.
+         * @param args     Arguments forwarded to @c E's constructor.
          */
-        void register_listener(const event_type type, const std::function<void(const event&)>& listener);
+        template<typename E, typename... Args>
+        void emit(Args&&... args);
+
+        /**
+         * @brief Constructs an event of type @c E in place and buffers it
+         *        on the pending queue for later delivery via @ref flush.
+         * @tparam E       The event struct type to enqueue.
+         * @tparam Args    Argument types forwarded to @c E's constructor.
+         * @param args     Arguments forwarded to @c E's constructor.
+         */
+        template<typename E, typename... Args>
+        void enqueue(Args&&... args);
+
+        /**
+         * @brief Drains the pending queue in FIFO order, dispatching each
+         *        buffered event through its registered listeners. Events
+         *        enqueued while flushing are deferred until the next
+         *        @ref flush call.
+         */
+        void flush();
 
     private:
-        std::unordered_map<event_type, std::vector<std::function<void(const event&)>>> m_listeners;
+        using listener_entry = std::function<void(const std::any&)>;
+        using queued_entry = std::pair<std::type_index, std::any>;
+
+        std::unordered_map<std::type_index, std::vector<listener_entry>> m_listeners;
+        std::vector<queued_entry> m_pending;
+
+        void dispatch(std::type_index type, const std::any& payload);
     };
+
+    template<typename E>
+    void event_bus::subscribe(std::function<void(const E&)> listener)
+    {
+        if (!listener)
+        {
+            return;
+        }
+
+        auto wrapper = [listener = std::move(listener)](const std::any& payload)
+        { listener(*std::any_cast<E>(&payload)); };
+        m_listeners[std::type_index(typeid(E))].push_back(std::move(wrapper));
+    }
+
+    template<typename E, typename... Args>
+    void event_bus::emit(Args&&... args)
+    {
+        std::any payload = E{std::forward<Args>(args)...};
+        dispatch(std::type_index(typeid(E)), payload);
+    }
+
+    template<typename E, typename... Args>
+    void event_bus::enqueue(Args&&... args)
+    {
+        m_pending.emplace_back(std::type_index(typeid(E)), std::any{E{std::forward<Args>(args)...}});
+    }
 } // namespace event_engine

--- a/external/api/game_module.cpp
+++ b/external/api/game_module.cpp
@@ -23,63 +23,60 @@
 #define INTERNAL_GAMEMODULE_IMPLEMENTATION
 #include "game_module.hpp"
 #undef INTERNAL_GAMEMODULE_IMPLEMENTATION
+
 #include <event_engine/event_engine.hpp>
 
 void register_game_module(struct game_module_info& info)
 {
+    auto& bus = event_engine::event_bus::get_instance();
+
     if (info.on_engine_start)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::engine_start,
-                                                                info.on_engine_start);
+        bus.subscribe<event_engine::engine_start>(info.on_engine_start);
     }
 
     if (info.on_engine_stop)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::engine_stop,
-                                                                info.on_engine_stop);
+        bus.subscribe<event_engine::engine_stop>(info.on_engine_stop);
     }
 
     if (info.on_frame)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::frame, info.on_frame);
+        bus.subscribe<event_engine::frame>(info.on_frame);
     }
 
     if (info.on_render_scene)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::render_scene,
-                                                                info.on_render_scene);
+        bus.subscribe<event_engine::render_scene>(info.on_render_scene);
     }
 
     if (info.on_render_ui)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::render_ui, info.on_render_ui);
+        bus.subscribe<event_engine::render_ui>(info.on_render_ui);
     }
 
     if (info.on_mouse_key_down)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::mouse_key_down,
-                                                                info.on_mouse_key_down);
+        bus.subscribe<event_engine::mouse_key_down>(info.on_mouse_key_down);
     }
 
     if (info.on_mouse_key_up)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::mouse_key_up,
-                                                                info.on_mouse_key_up);
+        bus.subscribe<event_engine::mouse_key_up>(info.on_mouse_key_up);
     }
 
     if (info.on_key_down)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::key_down, info.on_key_down);
+        bus.subscribe<event_engine::key_down>(info.on_key_down);
     }
 
     if (info.on_key_up)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::key_up, info.on_key_up);
+        bus.subscribe<event_engine::key_up>(info.on_key_up);
     }
 
     if (info.on_mouse_move)
     {
-        event_engine::context::get_instance().register_listener(event_engine::event_type::mouse_move,
-                                                                info.on_mouse_move);
+        bus.subscribe<event_engine::mouse_move>(info.on_mouse_move);
     }
 }

--- a/external/api/game_module.hpp
+++ b/external/api/game_module.hpp
@@ -22,21 +22,22 @@
 
 #pragma once
 
+#include <functional>
+
 #include <event_engine/event_engine.hpp>
-#include <string>
 
 struct game_module_info
 {
-    std::function<void(const event_engine::event&)> on_engine_start;
-    std::function<void(const event_engine::event&)> on_engine_stop;
-    std::function<void(const event_engine::event&)> on_frame;
-    std::function<void(const event_engine::event&)> on_render_scene;
-    std::function<void(const event_engine::event&)> on_render_ui;
-    std::function<void(const event_engine::event&)> on_key_down;
-    std::function<void(const event_engine::event&)> on_key_up;
-    std::function<void(const event_engine::event&)> on_mouse_key_down;
-    std::function<void(const event_engine::event&)> on_mouse_key_up;
-    std::function<void(const event_engine::event&)> on_mouse_move;
+    std::function<void(const event_engine::engine_start&)> on_engine_start;
+    std::function<void(const event_engine::engine_stop&)> on_engine_stop;
+    std::function<void(const event_engine::frame&)> on_frame;
+    std::function<void(const event_engine::render_scene&)> on_render_scene;
+    std::function<void(const event_engine::render_ui&)> on_render_ui;
+    std::function<void(const event_engine::key_down&)> on_key_down;
+    std::function<void(const event_engine::key_up&)> on_key_up;
+    std::function<void(const event_engine::mouse_key_down&)> on_mouse_key_down;
+    std::function<void(const event_engine::mouse_key_up&)> on_mouse_key_up;
+    std::function<void(const event_engine::mouse_move&)> on_mouse_move;
 
     game_module_info()
         : on_engine_start{nullptr}, on_engine_stop{nullptr}, on_frame{nullptr}, on_render_scene{nullptr},

--- a/external/camera_module.cpp
+++ b/external/camera_module.cpp
@@ -37,7 +37,7 @@ camera_id g_camera_id = 0;
 std::map<event_engine::key_code, bool> keys;
 std::map<event_engine::mouse_key_code, bool> mouse_keys;
 
-static void on_engine_start(const event_engine::event& event)
+static void on_engine_start(const event_engine::engine_start& event)
 {
     g_camera_id = create_camera(camera_type::perspective);
     attach_camera(g_camera_id);
@@ -45,36 +45,32 @@ static void on_engine_start(const event_engine::event& event)
     set_camera_pos(g_camera_id, -5.0, 0.0, 0.0);
 }
 
-static void on_engine_stop(const event_engine::event& event)
+static void on_engine_stop(const event_engine::engine_stop& event)
 {
     destroy_camera(g_camera_id);
 }
 
-static void on_key_down(const event_engine::event& event)
+static void on_key_down(const event_engine::key_down& event)
 {
-    auto key_event = dynamic_cast<const event_engine::key_down*>(&event);
-    keys[key_event->m_key_code] = true;
+    keys[event.m_key_code] = true;
 }
 
-static void on_key_up(const event_engine::event& event)
+static void on_key_up(const event_engine::key_up& event)
 {
-    auto key_event = dynamic_cast<const event_engine::key_up*>(&event);
-    keys[key_event->m_key_code] = false;
+    keys[event.m_key_code] = false;
 }
 
-static void on_mouse_key_down(const event_engine::event& event)
+static void on_mouse_key_down(const event_engine::mouse_key_down& event)
 {
-    auto mouse_event = dynamic_cast<const event_engine::mouse_key_down*>(&event);
-    mouse_keys[mouse_event->m_key_code] = true;
+    mouse_keys[event.m_key_code] = true;
 }
 
-static void on_mouse_key_up(const event_engine::event& event)
+static void on_mouse_key_up(const event_engine::mouse_key_up& event)
 {
-    auto mouse_event = dynamic_cast<const event_engine::mouse_key_up*>(&event);
-    mouse_keys[mouse_event->m_key_code] = false;
+    mouse_keys[event.m_key_code] = false;
 }
 
-static void on_frame(const event_engine::event& event)
+static void on_frame(const event_engine::frame& event)
 {
     if (g_camera_id == 0)
     {
@@ -130,11 +126,10 @@ static void on_frame(const event_engine::event& event)
     set_camera_pos(g_camera_id, new_position.x, new_position.y, new_position.z);
 }
 
-static void on_mouse_move(const event_engine::event& event)
+static void on_mouse_move(const event_engine::mouse_move& event)
 {
-    auto move_event = dynamic_cast<const event_engine::mouse_move*>(&event);
-    int32_t delta_x = move_event->m_x;
-    int32_t delta_y = move_event->m_y;
+    int32_t delta_x = event.m_x;
+    int32_t delta_y = event.m_y;
 
 #if _DEBUG
     if (!mouse_keys[event_engine::mouse_key_code::left])

--- a/external/cube_module.cpp
+++ b/external/cube_module.cpp
@@ -36,24 +36,24 @@ static std::unique_ptr<rendering_engine::cube> cube;
 float rotation = 0.0f;
 float rotation_speed = 3.14f / 2;
 
-static void on_engine_start(const event_engine::event& event)
+static void on_engine_start(const event_engine::engine_start& event)
 {
     cube = std::make_unique<rendering_engine::cube>();
     cube->upload();
 }
 
-static void on_engine_stop(const event_engine::event& event)
+static void on_engine_stop(const event_engine::engine_stop& event)
 {
     cube.reset();
 }
 
-static void on_frame(const event_engine::event& event)
+static void on_frame(const event_engine::frame& event)
 {
     rotation += rotation_speed * (static_cast<float>(get_delta_time()) / 1000);
     cube->transform.set_rotation(glm::vec3{0.f, 0.f, rotation});
 }
 
-static void on_render_scene(const event_engine::event& event)
+static void on_render_scene(const event_engine::render_scene& event)
 {
     cube->render();
 }

--- a/external/exit_module.cpp
+++ b/external/exit_module.cpp
@@ -25,13 +25,11 @@
 #include <event_engine/event_engine.hpp>
 #include <infrastructure/log.hpp>
 
-static void on_key_down(const event_engine::event& event)
+static void on_key_down(const event_engine::key_down& event)
 {
-    auto key_down_event = dynamic_cast<const event_engine::key_down*>(&event);
-    auto key_code = key_down_event->m_key_code;
-    if (key_code != event_engine::key_code::escape)
+    if (event.m_key_code != event_engine::key_code::escape)
         return;
-    event_engine::context::get_instance().broadcast(event_engine::quit_requested());
+    event_engine::event_bus::get_instance().emit<event_engine::quit_requested>();
 }
 
 GAME_MODULE()

--- a/external/fps_overlay_module.cpp
+++ b/external/fps_overlay_module.cpp
@@ -32,11 +32,11 @@
 #include <memory>
 #include <string>
 
-static constexpr const char* FONT_PATH = "C:/Windows/Fonts/consola.ttf";
-static constexpr float FONT_SIZE = 0.08f;
-static constexpr float TOP_Y = 0.92f;
-static constexpr float RIGHT_MARGIN = 0.02f;
-static constexpr double UPDATE_INTERVAL_MS = 250.0;
+static constexpr const char* font_path = "C:/Windows/Fonts/consola.ttf";
+static constexpr float font_size = 0.08f;
+static constexpr float top_y = 0.92f;
+static constexpr float right_margin = 0.02f;
+static constexpr double update_interval_ms = 250.0;
 
 static std::unique_ptr<rendering_engine::util::font> font;
 static std::unique_ptr<rendering_engine::label> fps_label;
@@ -44,16 +44,16 @@ static double time_since_update_ms = 0.0;
 
 static void reposition_top_right()
 {
-    const float x = 1.0f - fps_label->get_width() - RIGHT_MARGIN;
-    fps_label->set_position(glm::vec3{x, TOP_Y, 0.0f});
+    const float x = 1.0f - fps_label->get_width() - right_margin;
+    fps_label->set_position(glm::vec3{x, top_y, 0.0f});
 }
 
-static void on_engine_start(const event_engine::event& event)
+static void on_engine_start(const event_engine::engine_start& event)
 {
     try
     {
-        font = std::make_unique<rendering_engine::util::font>(FONT_PATH, 64.0f);
-        fps_label = std::make_unique<rendering_engine::label>(font.get(), FONT_SIZE, "FPS: ---");
+        font = std::make_unique<rendering_engine::util::font>(font_path, 64.0f);
+        fps_label = std::make_unique<rendering_engine::label>(font.get(), font_size, "FPS: ---");
         fps_label->upload();
         reposition_top_right();
     }
@@ -65,13 +65,13 @@ static void on_engine_start(const event_engine::event& event)
     }
 }
 
-static void on_engine_stop(const event_engine::event& event)
+static void on_engine_stop(const event_engine::engine_stop& event)
 {
     fps_label.reset();
     font.reset();
 }
 
-static void on_frame(const event_engine::event& event)
+static void on_frame(const event_engine::frame& event)
 {
     if (!fps_label)
     {
@@ -79,7 +79,7 @@ static void on_frame(const event_engine::event& event)
     }
 
     time_since_update_ms += get_delta_time();
-    if (time_since_update_ms < UPDATE_INTERVAL_MS)
+    if (time_since_update_ms < update_interval_ms)
     {
         return;
     }
@@ -90,7 +90,7 @@ static void on_frame(const event_engine::event& event)
     reposition_top_right();
 }
 
-static void on_render_ui(const event_engine::event& event)
+static void on_render_ui(const event_engine::render_ui& event)
 {
     if (!fps_label)
     {

--- a/external/frame_module.cpp
+++ b/external/frame_module.cpp
@@ -28,7 +28,7 @@
 
 #include <string>
 
-static void on_frame(const event_engine::event& event)
+static void on_frame(const event_engine::frame& event)
 {
     // PrintInfo(std::string{"Delta time: "} + std::to_string(GetDeltaTime()) + " ms");
     // PrintInfo(std::string{"FPS: "} + std::to_string(GetCurrentFPS()));

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -67,13 +67,13 @@ void rendering_engine::context::render()
     {
         rendering_engine::renderers::basic_renderer::get_instance().start_renderer();
         rendering_engine::renderers::basic_renderer::get_instance().setup_camera();
-        event_engine::context::get_instance().broadcast(event_engine::render_scene());
+        event_engine::event_bus::get_instance().emit<event_engine::render_scene>();
         rendering_engine::renderers::basic_renderer::get_instance().stop_renderer();
     }
 
     rendering_engine::opengl::context::get_instance().disable(rendering_engine::opengl::capability::depth_test);
     rendering_engine::renderers::overlay_renderer::get_instance().start_renderer();
-    event_engine::context::get_instance().broadcast(event_engine::render_ui());
+    event_engine::event_bus::get_instance().emit<event_engine::render_ui>();
     rendering_engine::renderers::overlay_renderer::get_instance().stop_renderer();
     rendering_engine::opengl::context::get_instance().enable(rendering_engine::opengl::capability::depth_test);
 }

--- a/rendering_engine/window.cpp
+++ b/rendering_engine/window.cpp
@@ -171,9 +171,11 @@ namespace rendering_engine
     {
         SDL_Event events = {0};
 
+        auto& bus = event_engine::event_bus::get_instance();
+
         event_engine::frame frame;
         frame.m_delta_time = static_cast<float>(infrastructure::time::get_instance().delta_time());
-        event_engine::context::get_instance().broadcast(frame);
+        bus.emit<event_engine::frame>(frame);
 
         SDL_PumpEvents();
         while (SDL_PollEvent(&events))
@@ -184,7 +186,7 @@ namespace rendering_engine
             {
                 event_engine::key_down key_down;
                 key_down.m_key_code = (event_engine::key_code)events.key.key;
-                event_engine::context::get_instance().broadcast(key_down);
+                bus.emit<event_engine::key_down>(key_down);
                 break;
             }
 
@@ -192,7 +194,7 @@ namespace rendering_engine
             {
                 event_engine::key_up key_up;
                 key_up.m_key_code = (event_engine::key_code)events.key.key;
-                event_engine::context::get_instance().broadcast(key_up);
+                bus.emit<event_engine::key_up>(key_up);
                 break;
             }
 
@@ -216,7 +218,7 @@ namespace rendering_engine
                 default:
                     break;
                 }
-                event_engine::context::get_instance().broadcast(mouse_key_down);
+                bus.emit<event_engine::mouse_key_down>(mouse_key_down);
                 break;
             }
 
@@ -241,7 +243,7 @@ namespace rendering_engine
                 default:
                     break;
                 }
-                event_engine::context::get_instance().broadcast(mouse_key_up);
+                bus.emit<event_engine::mouse_key_up>(mouse_key_up);
                 break;
             }
 
@@ -250,12 +252,12 @@ namespace rendering_engine
                 event_engine::mouse_move mouse_move;
                 mouse_move.m_x = static_cast<int>(events.motion.xrel);
                 mouse_move.m_y = static_cast<int>(events.motion.yrel);
-                event_engine::context::get_instance().broadcast(mouse_move);
+                bus.emit<event_engine::mouse_move>(mouse_move);
                 break;
             }
 
             case SDL_EVENT_QUIT:
-                event_engine::context::get_instance().broadcast(event_engine::quit_requested());
+                bus.emit<event_engine::quit_requested>();
                 break;
 
             default:

--- a/rendering_engine/window.hpp
+++ b/rendering_engine/window.hpp
@@ -80,7 +80,7 @@ namespace rendering_engine
 
         /**
          * @brief Pumps the SDL event queue and translates OS input into
-         *        engine events broadcast through @ref event_engine::context.
+         *        engine events broadcast through @ref event_engine::event_bus.
          *
          * Also broadcasts a @ref event_engine::frame event carrying the
          * current delta time. Call once per main-loop iteration.


### PR DESCRIPTION
## Summary

Replaces the 11-value `event_engine::event_type` enum and the polymorphic `event` base class with a type-erased event bus keyed on `std::type_index`. Event types are now plain value structs and game modules can define their own event types without touching any core engine header.

The bus exposes a minimal template API:

```cpp
template <typename E> void subscribe(std::function<void(const E&)>);
template <typename E, typename... Args> void emit(Args&&...);     // immediate
template <typename E, typename... Args> void enqueue(Args&&...);  // buffered
void flush();                                                     // drains queue
```

Implemented with stdlib only — `std::type_index`, `std::any`, and `std::function`. No new external dependencies.

### Changes

- `event_engine/event.hpp` — dropped `event_type` enum and `event` base; the eleven built-in events (`engine_start`, `engine_stop`, `quit_requested`, `frame`, `render_scene`, `render_ui`, `key_up`, `key_down`, `mouse_key_up`, `mouse_key_down`, `mouse_move`) are now plain value structs.
- `event_engine/event_engine.{hpp,cpp}` — renamed `event_engine::context` to `event_engine::event_bus`; replaced `register_listener` / `broadcast` with the new `subscribe` / `emit` / `enqueue` / `flush` template API. Listeners receive typed `const E&` callbacks.
- `external/api/game_module.{hpp,cpp}` — `game_module_info` callbacks are now typed per event struct (`std::function<void(const event_engine::frame&)>` etc.); the registrar wires them up via `subscribe<E>`.
- Migrated every call site: `control/main_loop.cpp`, `rendering_engine/rendering_engine.cpp` (keeps the `render_scene` / `render_ui` broadcasts via `emit<>`), `rendering_engine/window.cpp` (per-frame and input events), and the `cube`, `camera`, `frame`, `fps_overlay`, and `exit` game modules (no more `dynamic_cast`).
- `CLAUDE.md` updated to describe the new bus shape.

Closes #19.

## Test plan

- [x] `scripts/check-style.ps1` — no style issues
- [x] `scripts/check-naming.ps1` — no naming violations
- [x] `scripts/build.ps1` — MSVC Release build succeeds
- [x] Smoke run locally: cube + camera + FPS overlay + Escape-to-quit still work