### PR TITLE
refactor: introduce internal math types wrapping GLM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ Game modules must include the **public API headers** under `external/api/` — `
 
 Use the wrapper in `infrastructure/log.hpp`: `LOG_INF`, `LOG_WRN`, `LOG_ERR`, `LOG_FTL`. There is **no TRACE or DEBUG sink yet** — do not add per-frame or per-draw logs. Level-selection guidance and examples are in `docs/logging.md`.
 
+## Math
+
+Use the engine-owned math types in `infrastructure/math/math.hpp`: `infrastructure::math::vec2`, `vec3`, `vec4`, `mat3`, `mat4`, `quat`, and the snake_case free functions `dot`, `cross`, `normalize`, `length`, `distance`, `lerp`, `look_at`, `perspective`, `ortho`, `translate`, `rotate`, `scale`, `inverse`, `transpose`. These are thin wrappers over GLM with identical memory layout, so GLSL uniform uploads use `value.data()` (matrices) or the existing pointer form for arrays. **Do not reference `glm::` anywhere outside `infrastructure/math/`** — that directory is the only place that may include or name GLM directly.
+
 ## Working conventions
 
 Before finishing any task:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,9 @@ include_directories(${CMAKE_SOURCE_DIR})
 
 # Main executable
 file(GLOB EVENT_ENGINE_FILES "event_engine/*.hpp" "event_engine/*.cpp")
-file(GLOB INFRASTRUCTURE_FILES "infrastructure/*.hpp" "infrastructure/*.cpp")
+file(GLOB INFRASTRUCTURE_FILES
+        "infrastructure/*.hpp" "infrastructure/*.cpp"
+        "infrastructure/math/*.hpp" "infrastructure/math/*.cpp")
 file(GLOB SCENE_GRAPH_FILES "scene_graph/*.hpp" "scene_graph/*.cpp")
 file(GLOB RENDERING_ENGINE_FILES
         "rendering_engine/*.hpp" "rendering_engine/*.cpp"

--- a/external/api/camera.cpp
+++ b/external/api/camera.cpp
@@ -124,7 +124,7 @@ void get_camera_pos(camera_id id, float* px, float* py, float* pz)
     if (camera_info == nullptr)
         return;
 
-    glm::vec3 pos{camera_info->handle->transform.get_position()};
+    infrastructure::math::vec3 pos{camera_info->handle->transform.get_position()};
 
     *px = pos.x;
     *py = pos.y;
@@ -149,7 +149,7 @@ void get_camera_rot(camera_id id, float* rx, float* ry, float* rz)
     if (camera_info == nullptr)
         return;
 
-    glm::vec3 rot{camera_info->handle->transform.get_rotation()};
+    infrastructure::math::vec3 rot{camera_info->handle->transform.get_rotation()};
 
     *rx = rot.x;
     *ry = rot.y;

--- a/external/camera_module.cpp
+++ b/external/camera_module.cpp
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+#include <cmath>
 #include <map>
 
 #include "api/camera.hpp"
@@ -28,10 +29,9 @@
 #include "api/time.hpp"
 
 #include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
 #include <infrastructure/settings.hpp>
 #include <rendering_engine/rendering_engine.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/vector_angle.hpp>
 
 camera_id g_camera_id = 0;
 std::map<event_engine::key_code, bool> keys;
@@ -77,10 +77,10 @@ static void on_frame(const event_engine::frame& event)
         return;
     }
 
-    glm::vec3 position;
+    infrastructure::math::vec3 position;
     get_camera_pos(g_camera_id, &position.x, &position.y, &position.z);
 
-    glm::vec3 rotation;
+    infrastructure::math::vec3 rotation;
     get_camera_rot(g_camera_id, &rotation.x, &rotation.y, &rotation.z);
 
     float speed = 3.0f;
@@ -90,8 +90,8 @@ static void on_frame(const event_engine::frame& event)
     }
 
     float distance = speed * ((float)get_delta_time() / 1000);
-    glm::vec3 up_vector{0.0f, 0.0f, 1.0f};
-    glm::vec3 new_position = position;
+    infrastructure::math::vec3 up_vector{0.0f, 0.0f, 1.0f};
+    infrastructure::math::vec3 new_position = position;
 
     if (keys[event_engine::key_code::w])
     {
@@ -100,7 +100,7 @@ static void on_frame(const event_engine::frame& event)
 
     if (keys[event_engine::key_code::a])
     {
-        new_position -= glm::cross(rotation, up_vector) * distance;
+        new_position -= infrastructure::math::cross(rotation, up_vector) * distance;
     }
 
     if (keys[event_engine::key_code::s])
@@ -110,7 +110,7 @@ static void on_frame(const event_engine::frame& event)
 
     if (keys[event_engine::key_code::d])
     {
-        new_position += glm::cross(rotation, up_vector) * distance;
+        new_position += infrastructure::math::cross(rotation, up_vector) * distance;
     }
 
     if (keys[event_engine::key_code::space])
@@ -143,15 +143,15 @@ static void on_mouse_move(const event_engine::mouse_move& event)
         return;
     }
 
-    glm::vec3 rotation;
+    infrastructure::math::vec3 rotation;
     get_camera_rot(g_camera_id, &rotation.x, &rotation.y, &rotation.z);
-    glm::vec3 up_vector{0.0f, 0.0f, 1.0f};
+    infrastructure::math::vec3 up_vector{0.0f, 0.0f, 1.0f};
 
     // Normalize the rotation vector to get the forward direction
-    glm::vec3 forward = glm::normalize(rotation);
+    infrastructure::math::vec3 forward = infrastructure::math::normalize(rotation);
 
     // Calculate the right vector (perpendicular to forward and up)
-    glm::vec3 right = glm::normalize(glm::cross(forward, up_vector));
+    infrastructure::math::vec3 right = infrastructure::math::normalize(infrastructure::math::cross(forward, up_vector));
 
     float sensitivity = settings::get_instance().get_mouse_sensitivity();
     int pitch_multiplier = settings::get_instance().is_mouse_reversed() ? -1 : 1;
@@ -161,15 +161,15 @@ static void on_mouse_move(const event_engine::mouse_move& event)
     float pitch_angle = delta_y * sensitivity * pitch_multiplier;
 
     // Create rotation matrices
-    glm::mat4 yaw_rotation = glm::rotate(yaw_angle, up_vector);
-    glm::mat4 pitch_rotation = glm::rotate(pitch_angle, right);
+    infrastructure::math::mat4 yaw_rotation = infrastructure::math::rotate(yaw_angle, up_vector);
+    infrastructure::math::mat4 pitch_rotation = infrastructure::math::rotate(pitch_angle, right);
 
     // Apply rotations
-    glm::vec4 rotated = glm::vec4(forward, 0.0f) * yaw_rotation * pitch_rotation;
-    glm::vec3 new_rotation = glm::vec3(rotated.x, rotated.y, rotated.z);
+    infrastructure::math::vec4 rotated = infrastructure::math::vec4{forward, 0.0f} * yaw_rotation * pitch_rotation;
+    infrastructure::math::vec3 new_rotation = infrastructure::math::vec3{rotated.x, rotated.y, rotated.z};
 
     // Prevent looking too far up or down
-    if (glm::abs(new_rotation.z) > 0.99f)
+    if (std::abs(new_rotation.z) > 0.99f)
     {
         new_rotation = forward;
     }

--- a/external/cube_module.cpp
+++ b/external/cube_module.cpp
@@ -50,7 +50,7 @@ static void on_engine_stop(const event_engine::engine_stop& event)
 static void on_frame(const event_engine::frame& event)
 {
     rotation += rotation_speed * (static_cast<float>(get_delta_time()) / 1000);
-    cube->transform.set_rotation(glm::vec3{0.f, 0.f, rotation});
+    cube->transform.set_rotation(infrastructure::math::vec3{0.f, 0.f, rotation});
 }
 
 static void on_render_scene(const event_engine::render_scene& event)

--- a/external/fps_overlay_module.cpp
+++ b/external/fps_overlay_module.cpp
@@ -25,6 +25,7 @@
 #include "api/time.hpp"
 
 #include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/renderables/premade_2d/label.hpp>
 #include <rendering_engine/util/font.hpp>
 
@@ -45,7 +46,7 @@ static double time_since_update_ms = 0.0;
 static void reposition_top_right()
 {
     const float x = 1.0f - fps_label->get_width() - right_margin;
-    fps_label->set_position(glm::vec3{x, top_y, 0.0f});
+    fps_label->set_position(infrastructure::math::vec3{x, top_y, 0.0f});
 }
 
 static void on_engine_start(const event_engine::engine_start& event)

--- a/infrastructure/math/math.hpp
+++ b/infrastructure/math/math.hpp
@@ -1,0 +1,647 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file math.hpp
+ * @brief Engine-owned math types that wrap GLM.
+ *
+ * The wrapper exists so that engine and game code can depend on a stable,
+ * engine-owned API rather than GLM directly. The wrapped types hold their
+ * underlying @c glm::* value as a public member named @c value and provide
+ * component access through an anonymous union. Memory layout is identical
+ * to the corresponding GLM type, so uniform uploads via @c data() do not
+ * need to change.
+ *
+ * GLM is included here publicly: this is an accepted trade for inlining —
+ * the only rule is that @c glm:: must not appear outside
+ * @c infrastructure/math/.
+ */
+
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/quaternion.hpp>
+#include <glm/gtx/transform.hpp>
+
+namespace infrastructure::math
+{
+    // -------------------------------------------------------------------------
+    // Vector types
+    // -------------------------------------------------------------------------
+
+    /** @brief 2D float vector. Layout-compatible with @c glm::vec2. */
+    struct vec2
+    {
+        union
+        {
+            glm::vec2 value;
+            struct
+            {
+                float x, y;
+            };
+        };
+
+        constexpr vec2() noexcept : value{0.0f, 0.0f} {}
+        constexpr explicit vec2(float scalar) noexcept : value{scalar, scalar} {}
+        constexpr vec2(float in_x, float in_y) noexcept : value{in_x, in_y} {}
+        constexpr vec2(const glm::vec2& v) noexcept : value{v} {}
+
+        constexpr vec2(const vec2& other) noexcept : value{other.value} {}
+        constexpr vec2& operator=(const vec2& other) noexcept
+        {
+            value = other.value;
+            return *this;
+        }
+
+        constexpr operator glm::vec2&() noexcept
+        {
+            return value;
+        }
+        constexpr operator const glm::vec2&() const noexcept
+        {
+            return value;
+        }
+
+        const float* data() const noexcept
+        {
+            return &value.x;
+        }
+        float* data() noexcept
+        {
+            return &value.x;
+        }
+    };
+
+    /** @brief 3D float vector. Layout-compatible with @c glm::vec3. */
+    struct vec3
+    {
+        union
+        {
+            glm::vec3 value;
+            struct
+            {
+                float x, y, z;
+            };
+        };
+
+        constexpr vec3() noexcept : value{0.0f, 0.0f, 0.0f} {}
+        constexpr explicit vec3(float scalar) noexcept : value{scalar, scalar, scalar} {}
+        constexpr vec3(float in_x, float in_y, float in_z) noexcept : value{in_x, in_y, in_z} {}
+        constexpr vec3(const glm::vec3& v) noexcept : value{v} {}
+
+        constexpr vec3(const vec3& other) noexcept : value{other.value} {}
+        constexpr vec3& operator=(const vec3& other) noexcept
+        {
+            value = other.value;
+            return *this;
+        }
+
+        constexpr operator glm::vec3&() noexcept
+        {
+            return value;
+        }
+        constexpr operator const glm::vec3&() const noexcept
+        {
+            return value;
+        }
+
+        const float* data() const noexcept
+        {
+            return &value.x;
+        }
+        float* data() noexcept
+        {
+            return &value.x;
+        }
+    };
+
+    /** @brief 4D float vector. Layout-compatible with @c glm::vec4. */
+    struct vec4
+    {
+        union
+        {
+            glm::vec4 value;
+            struct
+            {
+                float x, y, z, w;
+            };
+        };
+
+        constexpr vec4() noexcept : value{0.0f, 0.0f, 0.0f, 0.0f} {}
+        constexpr explicit vec4(float scalar) noexcept : value{scalar, scalar, scalar, scalar} {}
+        constexpr vec4(float in_x, float in_y, float in_z, float in_w) noexcept : value{in_x, in_y, in_z, in_w} {}
+        constexpr vec4(const vec3& xyz, float in_w) noexcept : value{xyz.value, in_w} {}
+        constexpr vec4(const glm::vec4& v) noexcept : value{v} {}
+
+        constexpr vec4(const vec4& other) noexcept : value{other.value} {}
+        constexpr vec4& operator=(const vec4& other) noexcept
+        {
+            value = other.value;
+            return *this;
+        }
+
+        constexpr operator glm::vec4&() noexcept
+        {
+            return value;
+        }
+        constexpr operator const glm::vec4&() const noexcept
+        {
+            return value;
+        }
+
+        const float* data() const noexcept
+        {
+            return &value.x;
+        }
+        float* data() noexcept
+        {
+            return &value.x;
+        }
+    };
+
+    // -------------------------------------------------------------------------
+    // Matrix types
+    // -------------------------------------------------------------------------
+
+    /** @brief 3x3 float matrix (column-major). Layout-compatible with @c glm::mat3. */
+    struct mat3
+    {
+        glm::mat3 value;
+
+        mat3() noexcept : value{1.0f} {}
+        explicit mat3(float diagonal) noexcept : value{diagonal} {}
+        mat3(const glm::mat3& m) noexcept : value{m} {}
+
+        operator glm::mat3&() noexcept
+        {
+            return value;
+        }
+        operator const glm::mat3&() const noexcept
+        {
+            return value;
+        }
+
+        const float* data() const noexcept
+        {
+            return &value[0][0];
+        }
+        float* data() noexcept
+        {
+            return &value[0][0];
+        }
+    };
+
+    /** @brief 4x4 float matrix (column-major). Layout-compatible with @c glm::mat4. */
+    struct mat4
+    {
+        glm::mat4 value;
+
+        mat4() noexcept : value{1.0f} {}
+        explicit mat4(float diagonal) noexcept : value{diagonal} {}
+        mat4(const glm::mat4& m) noexcept : value{m} {}
+
+        operator glm::mat4&() noexcept
+        {
+            return value;
+        }
+        operator const glm::mat4&() const noexcept
+        {
+            return value;
+        }
+
+        const float* data() const noexcept
+        {
+            return &value[0][0];
+        }
+        float* data() noexcept
+        {
+            return &value[0][0];
+        }
+    };
+
+    /** @brief Float quaternion. Layout-compatible with @c glm::quat. */
+    struct quat
+    {
+        glm::quat value;
+
+        quat() noexcept : value{1.0f, 0.0f, 0.0f, 0.0f} {}
+        quat(float w, float x, float y, float z) noexcept : value{w, x, y, z} {}
+        quat(const glm::quat& q) noexcept : value{q} {}
+
+        operator glm::quat&() noexcept
+        {
+            return value;
+        }
+        operator const glm::quat&() const noexcept
+        {
+            return value;
+        }
+    };
+
+    // -------------------------------------------------------------------------
+    // Vector operators
+    // -------------------------------------------------------------------------
+
+    inline vec2 operator+(const vec2& a, const vec2& b) noexcept
+    {
+        return vec2{a.value + b.value};
+    }
+    inline vec2 operator-(const vec2& a, const vec2& b) noexcept
+    {
+        return vec2{a.value - b.value};
+    }
+    inline vec2 operator*(const vec2& a, const vec2& b) noexcept
+    {
+        return vec2{a.value * b.value};
+    }
+    inline vec2 operator/(const vec2& a, const vec2& b) noexcept
+    {
+        return vec2{a.value / b.value};
+    }
+    inline vec2 operator*(const vec2& v, float s) noexcept
+    {
+        return vec2{v.value * s};
+    }
+    inline vec2 operator*(float s, const vec2& v) noexcept
+    {
+        return vec2{s * v.value};
+    }
+    inline vec2 operator/(const vec2& v, float s) noexcept
+    {
+        return vec2{v.value / s};
+    }
+    inline vec2 operator-(const vec2& v) noexcept
+    {
+        return vec2{-v.value};
+    }
+    inline bool operator==(const vec2& a, const vec2& b) noexcept
+    {
+        return a.value == b.value;
+    }
+    inline bool operator!=(const vec2& a, const vec2& b) noexcept
+    {
+        return a.value != b.value;
+    }
+    inline vec2& operator+=(vec2& a, const vec2& b) noexcept
+    {
+        a.value += b.value;
+        return a;
+    }
+    inline vec2& operator-=(vec2& a, const vec2& b) noexcept
+    {
+        a.value -= b.value;
+        return a;
+    }
+    inline vec2& operator*=(vec2& a, float s) noexcept
+    {
+        a.value *= s;
+        return a;
+    }
+    inline vec2& operator/=(vec2& a, float s) noexcept
+    {
+        a.value /= s;
+        return a;
+    }
+
+    inline vec3 operator+(const vec3& a, const vec3& b) noexcept
+    {
+        return vec3{a.value + b.value};
+    }
+    inline vec3 operator-(const vec3& a, const vec3& b) noexcept
+    {
+        return vec3{a.value - b.value};
+    }
+    inline vec3 operator*(const vec3& a, const vec3& b) noexcept
+    {
+        return vec3{a.value * b.value};
+    }
+    inline vec3 operator/(const vec3& a, const vec3& b) noexcept
+    {
+        return vec3{a.value / b.value};
+    }
+    inline vec3 operator*(const vec3& v, float s) noexcept
+    {
+        return vec3{v.value * s};
+    }
+    inline vec3 operator*(float s, const vec3& v) noexcept
+    {
+        return vec3{s * v.value};
+    }
+    inline vec3 operator/(const vec3& v, float s) noexcept
+    {
+        return vec3{v.value / s};
+    }
+    inline vec3 operator-(const vec3& v) noexcept
+    {
+        return vec3{-v.value};
+    }
+    inline bool operator==(const vec3& a, const vec3& b) noexcept
+    {
+        return a.value == b.value;
+    }
+    inline bool operator!=(const vec3& a, const vec3& b) noexcept
+    {
+        return a.value != b.value;
+    }
+    inline vec3& operator+=(vec3& a, const vec3& b) noexcept
+    {
+        a.value += b.value;
+        return a;
+    }
+    inline vec3& operator-=(vec3& a, const vec3& b) noexcept
+    {
+        a.value -= b.value;
+        return a;
+    }
+    inline vec3& operator*=(vec3& a, float s) noexcept
+    {
+        a.value *= s;
+        return a;
+    }
+    inline vec3& operator/=(vec3& a, float s) noexcept
+    {
+        a.value /= s;
+        return a;
+    }
+
+    inline vec4 operator+(const vec4& a, const vec4& b) noexcept
+    {
+        return vec4{a.value + b.value};
+    }
+    inline vec4 operator-(const vec4& a, const vec4& b) noexcept
+    {
+        return vec4{a.value - b.value};
+    }
+    inline vec4 operator*(const vec4& a, const vec4& b) noexcept
+    {
+        return vec4{a.value * b.value};
+    }
+    inline vec4 operator/(const vec4& a, const vec4& b) noexcept
+    {
+        return vec4{a.value / b.value};
+    }
+    inline vec4 operator*(const vec4& v, float s) noexcept
+    {
+        return vec4{v.value * s};
+    }
+    inline vec4 operator*(float s, const vec4& v) noexcept
+    {
+        return vec4{s * v.value};
+    }
+    inline vec4 operator/(const vec4& v, float s) noexcept
+    {
+        return vec4{v.value / s};
+    }
+    inline vec4 operator-(const vec4& v) noexcept
+    {
+        return vec4{-v.value};
+    }
+    inline bool operator==(const vec4& a, const vec4& b) noexcept
+    {
+        return a.value == b.value;
+    }
+    inline bool operator!=(const vec4& a, const vec4& b) noexcept
+    {
+        return a.value != b.value;
+    }
+    inline vec4& operator+=(vec4& a, const vec4& b) noexcept
+    {
+        a.value += b.value;
+        return a;
+    }
+    inline vec4& operator-=(vec4& a, const vec4& b) noexcept
+    {
+        a.value -= b.value;
+        return a;
+    }
+    inline vec4& operator*=(vec4& a, float s) noexcept
+    {
+        a.value *= s;
+        return a;
+    }
+    inline vec4& operator/=(vec4& a, float s) noexcept
+    {
+        a.value /= s;
+        return a;
+    }
+
+    // -------------------------------------------------------------------------
+    // Matrix operators
+    // -------------------------------------------------------------------------
+
+    inline mat3 operator*(const mat3& a, const mat3& b) noexcept
+    {
+        return mat3{a.value * b.value};
+    }
+    inline vec3 operator*(const mat3& m, const vec3& v) noexcept
+    {
+        return vec3{m.value * v.value};
+    }
+    inline bool operator==(const mat3& a, const mat3& b) noexcept
+    {
+        return a.value == b.value;
+    }
+    inline bool operator!=(const mat3& a, const mat3& b) noexcept
+    {
+        return a.value != b.value;
+    }
+
+    inline mat4 operator*(const mat4& a, const mat4& b) noexcept
+    {
+        return mat4{a.value * b.value};
+    }
+    inline vec4 operator*(const mat4& m, const vec4& v) noexcept
+    {
+        return vec4{m.value * v.value};
+    }
+    inline vec4 operator*(const vec4& v, const mat4& m) noexcept
+    {
+        return vec4{v.value * m.value};
+    }
+    inline bool operator==(const mat4& a, const mat4& b) noexcept
+    {
+        return a.value == b.value;
+    }
+    inline bool operator!=(const mat4& a, const mat4& b) noexcept
+    {
+        return a.value != b.value;
+    }
+    inline mat4& operator*=(mat4& a, const mat4& b) noexcept
+    {
+        a.value *= b.value;
+        return a;
+    }
+
+    // -------------------------------------------------------------------------
+    // Free functions
+    // -------------------------------------------------------------------------
+
+    inline float dot(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::dot(a.value, b.value);
+    }
+    inline float dot(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::dot(a.value, b.value);
+    }
+    inline float dot(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::dot(a.value, b.value);
+    }
+
+    inline vec3 cross(const vec3& a, const vec3& b) noexcept
+    {
+        return vec3{glm::cross(a.value, b.value)};
+    }
+
+    inline vec2 normalize(const vec2& v) noexcept
+    {
+        return vec2{glm::normalize(v.value)};
+    }
+    inline vec3 normalize(const vec3& v) noexcept
+    {
+        return vec3{glm::normalize(v.value)};
+    }
+    inline vec4 normalize(const vec4& v) noexcept
+    {
+        return vec4{glm::normalize(v.value)};
+    }
+    inline quat normalize(const quat& q) noexcept
+    {
+        return quat{glm::normalize(q.value)};
+    }
+
+    inline float length(const vec2& v) noexcept
+    {
+        return glm::length(v.value);
+    }
+    inline float length(const vec3& v) noexcept
+    {
+        return glm::length(v.value);
+    }
+    inline float length(const vec4& v) noexcept
+    {
+        return glm::length(v.value);
+    }
+
+    inline float distance(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::distance(a.value, b.value);
+    }
+    inline float distance(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::distance(a.value, b.value);
+    }
+    inline float distance(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::distance(a.value, b.value);
+    }
+
+    inline float lerp(float a, float b, float t) noexcept
+    {
+        return glm::mix(a, b, t);
+    }
+    inline vec2 lerp(const vec2& a, const vec2& b, float t) noexcept
+    {
+        return vec2{glm::mix(a.value, b.value, t)};
+    }
+    inline vec3 lerp(const vec3& a, const vec3& b, float t) noexcept
+    {
+        return vec3{glm::mix(a.value, b.value, t)};
+    }
+    inline vec4 lerp(const vec4& a, const vec4& b, float t) noexcept
+    {
+        return vec4{glm::mix(a.value, b.value, t)};
+    }
+
+    inline mat4 look_at(const vec3& eye, const vec3& center, const vec3& up) noexcept
+    {
+        return mat4{glm::lookAt(eye.value, center.value, up.value)};
+    }
+
+    inline mat4 perspective(float fov_y, float aspect, float near_z, float far_z) noexcept
+    {
+        return mat4{glm::perspective(fov_y, aspect, near_z, far_z)};
+    }
+
+    inline mat4 ortho(float left, float right, float bottom, float top, float near_z, float far_z) noexcept
+    {
+        return mat4{glm::ortho(left, right, bottom, top, near_z, far_z)};
+    }
+
+    inline mat4 translate(const vec3& v) noexcept
+    {
+        return mat4{glm::translate(v.value)};
+    }
+
+    inline mat4 translate(const mat4& m, const vec3& v) noexcept
+    {
+        return mat4{glm::translate(m.value, v.value)};
+    }
+
+    inline mat4 rotate(float angle, const vec3& axis) noexcept
+    {
+        return mat4{glm::rotate(angle, axis.value)};
+    }
+
+    inline mat4 rotate(const mat4& m, float angle, const vec3& axis) noexcept
+    {
+        return mat4{glm::rotate(m.value, angle, axis.value)};
+    }
+
+    inline mat4 scale(const vec3& v) noexcept
+    {
+        return mat4{glm::scale(v.value)};
+    }
+
+    inline mat4 scale(const mat4& m, const vec3& v) noexcept
+    {
+        return mat4{glm::scale(m.value, v.value)};
+    }
+
+    inline mat3 inverse(const mat3& m) noexcept
+    {
+        return mat3{glm::inverse(m.value)};
+    }
+    inline mat4 inverse(const mat4& m) noexcept
+    {
+        return mat4{glm::inverse(m.value)};
+    }
+    inline quat inverse(const quat& q) noexcept
+    {
+        return quat{glm::inverse(q.value)};
+    }
+
+    inline mat3 transpose(const mat3& m) noexcept
+    {
+        return mat3{glm::transpose(m.value)};
+    }
+    inline mat4 transpose(const mat4& m) noexcept
+    {
+        return mat4{glm::transpose(m.value)};
+    }
+} // namespace infrastructure::math

--- a/rendering_engine/camera/camera.cpp
+++ b/rendering_engine/camera/camera.cpp
@@ -20,10 +20,9 @@
  * SOFTWARE.
  */
 
-#include <rendering_engine/camera/camera.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/transform.hpp>
+#include <infrastructure/math/math.hpp>
 #include <infrastructure/settings.hpp>
+#include <rendering_engine/camera/camera.hpp>
 #include <rendering_engine/rendering_engine.hpp>
 
 rendering_engine::camera* rendering_engine::camera::m_current_camera = nullptr;
@@ -56,16 +55,16 @@ void rendering_engine::camera::invalidate_view_matrix()
     m_is_view_matrix_dirty = true;
 }
 
-const glm::mat4 rendering_engine::camera::get_view_matrix() const
+const infrastructure::math::mat4 rendering_engine::camera::get_view_matrix() const
 {
     if (!m_is_view_matrix_dirty)
     {
         return m_view_matrix;
     }
 
-    glm::vec3 up_vector(0.0f, 0.0f, 1.0f);
-    glm::vec3 look_at = transform.get_position() + transform.get_rotation();
-    m_view_matrix = glm::lookAt(transform.get_position(), look_at, up_vector);
+    infrastructure::math::vec3 up_vector{0.0f, 0.0f, 1.0f};
+    infrastructure::math::vec3 look_at_target = transform.get_position() + transform.get_rotation();
+    m_view_matrix = infrastructure::math::look_at(transform.get_position(), look_at_target, up_vector);
     m_is_view_matrix_dirty = false;
     return m_view_matrix;
 }

--- a/rendering_engine/camera/camera.hpp
+++ b/rendering_engine/camera/camera.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/util/transform.hpp>
 
 namespace rendering_engine
@@ -41,15 +41,15 @@ namespace rendering_engine
         rendering_engine::util::transform transform;
 
         void invalidate_view_matrix();
-        const glm::mat4 get_view_matrix() const;
+        const infrastructure::math::mat4 get_view_matrix() const;
 
         void invalidate_projection_matrix();
-        virtual const glm::mat4 get_projection_matrix() const = 0;
+        virtual const infrastructure::math::mat4 get_projection_matrix() const = 0;
 
     protected:
-        mutable glm::mat4 m_view_matrix;
+        mutable infrastructure::math::mat4 m_view_matrix;
         mutable bool m_is_view_matrix_dirty;
-        mutable glm::mat4 m_projection;
+        mutable infrastructure::math::mat4 m_projection;
         mutable bool m_is_projection_matrix_dirty;
 
         // Non-owning observer: lifetime managed elsewhere (e.g. by the creator of the camera).

--- a/rendering_engine/camera/orthographic_camera.cpp
+++ b/rendering_engine/camera/orthographic_camera.cpp
@@ -20,9 +20,8 @@
  * SOFTWARE.
  */
 
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/camera/orthographic_camera.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/transform.hpp>
 
 rendering_engine::orthographic_camera::orthographic_camera()
 {
@@ -32,15 +31,15 @@ rendering_engine::orthographic_camera::orthographic_camera()
     far_clip = 10000.0f;
 }
 
-const glm::mat4 rendering_engine::orthographic_camera::get_projection_matrix() const
+const infrastructure::math::mat4 rendering_engine::orthographic_camera::get_projection_matrix() const
 {
     if (!m_is_projection_matrix_dirty)
     {
         return m_projection;
     }
 
-    m_projection =
-        glm::ortho(-x_magnification, x_magnification, -y_magnification, y_magnification, near_clip, far_clip);
+    m_projection = infrastructure::math::ortho(
+        -x_magnification, x_magnification, -y_magnification, y_magnification, near_clip, far_clip);
     m_is_projection_matrix_dirty = false;
     return m_projection;
 }

--- a/rendering_engine/camera/orthographic_camera.hpp
+++ b/rendering_engine/camera/orthographic_camera.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/camera/camera.hpp>
 
 namespace rendering_engine
@@ -31,7 +31,7 @@ namespace rendering_engine
     {
         orthographic_camera();
 
-        const glm::mat4 get_projection_matrix() const final;
+        const infrastructure::math::mat4 get_projection_matrix() const final;
 
         float x_magnification;
         float y_magnification;

--- a/rendering_engine/camera/perspective_camera.cpp
+++ b/rendering_engine/camera/perspective_camera.cpp
@@ -20,10 +20,9 @@
  * SOFTWARE.
  */
 
-#include <rendering_engine/camera/perspective_camera.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/transform.hpp>
+#include <infrastructure/math/math.hpp>
 #include <infrastructure/settings.hpp>
+#include <rendering_engine/camera/perspective_camera.hpp>
 
 rendering_engine::perspective_camera::perspective_camera()
 {
@@ -35,14 +34,14 @@ rendering_engine::perspective_camera::perspective_camera()
     far_clip = 10000.0f;
 }
 
-const glm::mat4 rendering_engine::perspective_camera::get_projection_matrix() const
+const infrastructure::math::mat4 rendering_engine::perspective_camera::get_projection_matrix() const
 {
     if (!m_is_projection_matrix_dirty)
     {
         return m_projection;
     }
 
-    m_projection = glm::perspective(field_of_view, aspect_ratio, near_clip, far_clip);
+    m_projection = infrastructure::math::perspective(field_of_view, aspect_ratio, near_clip, far_clip);
     m_is_projection_matrix_dirty = false;
     return m_projection;
 }

--- a/rendering_engine/camera/perspective_camera.hpp
+++ b/rendering_engine/camera/perspective_camera.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/camera/camera.hpp>
 
 namespace rendering_engine
@@ -31,7 +31,7 @@ namespace rendering_engine
     {
         perspective_camera();
 
-        const glm::mat4 get_projection_matrix() const final;
+        const infrastructure::math::mat4 get_projection_matrix() const final;
 
         float field_of_view;
         float aspect_ratio;

--- a/rendering_engine/mesh/vertex.hpp
+++ b/rendering_engine/mesh/vertex.hpp
@@ -22,44 +22,44 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 
 namespace rendering_engine
 {
     struct vertex_position
     {
-        glm::vec3 pos;
+        infrastructure::math::vec3 pos;
     };
 
     struct vertex_postion_color
     {
-        glm::vec3 pos;
-        glm::vec3 color;
+        infrastructure::math::vec3 pos;
+        infrastructure::math::vec3 color;
     };
 
     struct vertex_position_uv
     {
-        glm::vec3 pos;
-        glm::vec2 uv;
+        infrastructure::math::vec3 pos;
+        infrastructure::math::vec2 uv;
     };
 
     struct vertex_postion_normal
     {
-        glm::vec3 pos;
-        glm::vec3 normal;
+        infrastructure::math::vec3 pos;
+        infrastructure::math::vec3 normal;
     };
 
     struct vertex_position_color_normal
     {
-        glm::vec3 pos;
-        glm::vec3 color;
-        glm::vec3 normal;
+        infrastructure::math::vec3 pos;
+        infrastructure::math::vec3 color;
+        infrastructure::math::vec3 normal;
     };
 
     struct vertex_position_uv_normal
     {
-        glm::vec3 pos;
-        glm::vec2 uv;
-        glm::vec3 normal;
+        infrastructure::math::vec3 pos;
+        infrastructure::math::vec2 uv;
+        infrastructure::math::vec3 normal;
     };
 } // namespace rendering_engine

--- a/rendering_engine/opengl/program.cpp
+++ b/rendering_engine/opengl/program.cpp
@@ -139,17 +139,17 @@ void rendering_engine::opengl::program::set_uniform(const uniform& uniform, cons
     glUniform1f(uniform, value);
 }
 
-void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const glm::vec2& value)
+void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const infrastructure::math::vec2& value)
 {
     glUniform2f(uniform, value.x, value.y);
 }
 
-void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const glm::vec3& value)
+void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const infrastructure::math::vec3& value)
 {
     glUniform3f(uniform, value.x, value.y, value.z);
 }
 
-void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const glm::vec4& value)
+void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const infrastructure::math::vec4& value)
 {
     glUniform4f(uniform, value.x, value.y, value.z, value.w);
 }
@@ -162,32 +162,32 @@ void rendering_engine::opengl::program::set_uniform(const uniform& uniform,
 }
 
 void rendering_engine::opengl::program::set_uniform(const uniform& uniform,
-                                                    const glm::vec2* values,
+                                                    const infrastructure::math::vec2* values,
                                                     const unsigned int count)
 {
-    glUniform2fv(uniform, count, (float*)values);
+    glUniform2fv(uniform, count, reinterpret_cast<const float*>(values));
 }
 
 void rendering_engine::opengl::program::set_uniform(const uniform& uniform,
-                                                    const glm::vec3* values,
+                                                    const infrastructure::math::vec3* values,
                                                     const unsigned int count)
 {
-    glUniform3fv(uniform, count, (float*)values);
+    glUniform3fv(uniform, count, reinterpret_cast<const float*>(values));
 }
 
 void rendering_engine::opengl::program::set_uniform(const uniform& uniform,
-                                                    const glm::vec4* values,
+                                                    const infrastructure::math::vec4* values,
                                                     const unsigned int count)
 {
-    glUniform4fv(uniform, count, (float*)values);
+    glUniform4fv(uniform, count, reinterpret_cast<const float*>(values));
 }
 
-void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const glm::mat3& value)
+void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const infrastructure::math::mat3& value)
 {
-    glUniformMatrix3fv(uniform, 1, GL_FALSE, &value[0][0]);
+    glUniformMatrix3fv(uniform, 1, GL_FALSE, value.data());
 }
 
-void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const glm::mat4& value)
+void rendering_engine::opengl::program::set_uniform(const uniform& uniform, const infrastructure::math::mat4& value)
 {
-    glUniformMatrix4fv(uniform, 1, GL_FALSE, &value[0][0]);
+    glUniformMatrix4fv(uniform, 1, GL_FALSE, value.data());
 }

--- a/rendering_engine/opengl/program.hpp
+++ b/rendering_engine/opengl/program.hpp
@@ -25,7 +25,7 @@
 #include <rendering_engine/opengl/shader.hpp>
 #include <rendering_engine/opengl/typedef.hpp>
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 #include <map>
 #include <string>
 
@@ -72,15 +72,15 @@ namespace rendering_engine
 
             void set_uniform(const uniform& uniform, int value);
             void set_uniform(const uniform& uniform, float value);
-            void set_uniform(const uniform& uniform, const glm::vec2& value);
-            void set_uniform(const uniform& uniform, const glm::vec3& value);
-            void set_uniform(const uniform& uniform, const glm::vec4& value);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec2& value);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec3& value);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec4& value);
             void set_uniform(const uniform& uniform, const float* values, unsigned int count);
-            void set_uniform(const uniform& uniform, const glm::vec2* values, unsigned int count);
-            void set_uniform(const uniform& uniform, const glm::vec3* values, unsigned int count);
-            void set_uniform(const uniform& uniform, const glm::vec4* values, unsigned int count);
-            void set_uniform(const uniform& uniform, const glm::mat3& value);
-            void set_uniform(const uniform& uniform, const glm::mat4& value);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec2* values, unsigned int count);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec3* values, unsigned int count);
+            void set_uniform(const uniform& uniform, const infrastructure::math::vec4* values, unsigned int count);
+            void set_uniform(const uniform& uniform, const infrastructure::math::mat3& value);
+            void set_uniform(const uniform& uniform, const infrastructure::math::mat4& value);
 
         private:
             unsigned int m_object_id;

--- a/rendering_engine/renderables/model.cpp
+++ b/rendering_engine/renderables/model.cpp
@@ -51,14 +51,14 @@ void rendering_engine::model::upload_mesh(const rendering_engine::mesh& mesh)
                                           rendering_engine::opengl::type::Float,
                                           2,
                                           sizeof(rendering_engine::vertex_position_uv_normal),
-                                          sizeof(glm::vec3));
+                                          sizeof(infrastructure::math::vec3));
 
     m_vertex_array_object->bind_attribute(2,
                                           *m_vertex_buffer_object,
                                           rendering_engine::opengl::type::Float,
                                           3,
                                           sizeof(rendering_engine::vertex_position_uv_normal),
-                                          sizeof(glm::vec3) + sizeof(glm::vec2));
+                                          sizeof(infrastructure::math::vec3) + sizeof(infrastructure::math::vec2));
 }
 
 void rendering_engine::model::render()

--- a/rendering_engine/renderables/premade_2d/label.cpp
+++ b/rendering_engine/renderables/premade_2d/label.cpp
@@ -44,9 +44,9 @@ void rendering_engine::label::set_text(const std::string& text)
     upload();
 }
 
-void rendering_engine::label::set_position(const glm::vec3& position)
+void rendering_engine::label::set_position(const infrastructure::math::vec3& position)
 {
-    const glm::vec3 delta = position - m_position;
+    const infrastructure::math::vec3 delta = position - m_position;
     m_position = position;
     for (auto& p : m_panes)
     {
@@ -75,9 +75,9 @@ void rendering_engine::label::rebuild_panes()
         int x0, y0, x1, y1;
         const rendering_engine::util::image* image = m_font->get_image(c, &x0, &y0, &x1, &y1);
         const float width = ((float)image->get_width() / image->get_height()) * m_size;
-        auto pane = std::make_unique<rendering_engine::pane>(glm::vec2{width, m_size});
+        auto pane = std::make_unique<rendering_engine::pane>(infrastructure::math::vec2{width, m_size});
         pane->set_image(*image);
-        pane->transform.set_position(glm::vec3{m_position.x + cursor, m_position.y, m_position.z});
+        pane->transform.set_position(infrastructure::math::vec3{m_position.x + cursor, m_position.y, m_position.z});
         cursor += width + m_size * 0.1f;
         m_panes.push_back(std::move(pane));
     }

--- a/rendering_engine/renderables/premade_2d/label.hpp
+++ b/rendering_engine/renderables/premade_2d/label.hpp
@@ -39,7 +39,7 @@ namespace rendering_engine
         label(rendering_engine::util::font* font, float size, const std::string& text);
 
         void set_text(const std::string& text);
-        void set_position(const glm::vec3& position);
+        void set_position(const infrastructure::math::vec3& position);
         float get_width() const;
 
         void upload() final;
@@ -50,7 +50,7 @@ namespace rendering_engine
         rendering_engine::util::font* m_font;
         std::string m_text;
         float m_size;
-        glm::vec3 m_position{0.0f};
+        infrastructure::math::vec3 m_position{0.0f};
         float m_width{0.0f};
         std::vector<std::unique_ptr<rendering_engine::pane>> m_panes;
 

--- a/rendering_engine/renderables/premade_2d/pane.cpp
+++ b/rendering_engine/renderables/premade_2d/pane.cpp
@@ -26,7 +26,7 @@
 #include <rendering_engine/renderers/renderer.hpp>
 #include <rendering_engine/rendering_engine.hpp>
 
-rendering_engine::pane::pane(const glm::vec2& size)
+rendering_engine::pane::pane(const infrastructure::math::vec2& size)
     : m_vertex_count{0}, m_vertex_array_object{nullptr}, m_vertex_buffer{nullptr}, m_indicies_buffer{nullptr},
       m_size{size}, m_color{0, 0, 0, 0}, m_texture{nullptr}
 {
@@ -59,17 +59,17 @@ void rendering_engine::pane::upload()
 {
     this->m_vertex_count = 6;
 
-    glm::vec3 position{this->transform.get_position()};
+    infrastructure::math::vec3 position{this->transform.get_position()};
 
     vertex_position_uv vertex[4];
-    vertex[0].pos = glm::vec3{position.x, position.y - m_size.y, -1.0f};
-    vertex[0].uv = glm::vec2{0.0f, 0.0f};
-    vertex[1].pos = glm::vec3{position.x + m_size.x, position.y - m_size.y, -1.0f};
-    vertex[1].uv = glm::vec2{1.0f, 0.0f};
-    vertex[2].pos = glm::vec3{position.x + m_size.x, position.y, -1.0f};
-    vertex[2].uv = glm::vec2{1.0f, 1.0f};
-    vertex[3].pos = glm::vec3{position.x, position.y, -1.0f};
-    vertex[3].uv = glm::vec2{0.0f, 1.0f};
+    vertex[0].pos = infrastructure::math::vec3{position.x, position.y - m_size.y, -1.0f};
+    vertex[0].uv = infrastructure::math::vec2{0.0f, 0.0f};
+    vertex[1].pos = infrastructure::math::vec3{position.x + m_size.x, position.y - m_size.y, -1.0f};
+    vertex[1].uv = infrastructure::math::vec2{1.0f, 0.0f};
+    vertex[2].pos = infrastructure::math::vec3{position.x + m_size.x, position.y, -1.0f};
+    vertex[2].uv = infrastructure::math::vec2{1.0f, 1.0f};
+    vertex[3].pos = infrastructure::math::vec3{position.x, position.y, -1.0f};
+    vertex[3].uv = infrastructure::math::vec2{0.0f, 1.0f};
 
     uint32_t indicies[6] = {3, 0, 1, 3, 1, 2};
 
@@ -82,8 +82,12 @@ void rendering_engine::pane::upload()
     m_vertex_array_object = opengl::context::get_instance().create_vao();
     m_vertex_array_object->bind_attribute(
         0, *m_vertex_buffer, rendering_engine::opengl::type::Float, 3, sizeof(vertex_position_uv), 0);
-    m_vertex_array_object->bind_attribute(
-        1, *m_vertex_buffer, rendering_engine::opengl::type::Float, 2, sizeof(vertex_position_uv), sizeof(glm::vec3));
+    m_vertex_array_object->bind_attribute(1,
+                                          *m_vertex_buffer,
+                                          rendering_engine::opengl::type::Float,
+                                          2,
+                                          sizeof(vertex_position_uv),
+                                          sizeof(infrastructure::math::vec3));
     m_vertex_array_object->bind_elements(*m_indicies_buffer);
 }
 

--- a/rendering_engine/renderables/premade_2d/pane.hpp
+++ b/rendering_engine/renderables/premade_2d/pane.hpp
@@ -32,7 +32,7 @@ namespace rendering_engine
 {
     struct pane : public renderable
     {
-        pane(const glm::vec2& size);
+        pane(const infrastructure::math::vec2& size);
 
         void set_color(const rendering_engine::util::color& color);
         void set_image(const rendering_engine::util::image& image);
@@ -49,7 +49,7 @@ namespace rendering_engine
 
         unsigned int m_vertex_count;
 
-        glm::vec2 m_size;
+        infrastructure::math::vec2 m_size;
         rendering_engine::util::color m_color;
         rendering_engine::opengl::texture* m_texture;
     };

--- a/rendering_engine/renderables/premade_3d/cube.cpp
+++ b/rendering_engine/renderables/premade_3d/cube.cpp
@@ -34,14 +34,14 @@ void rendering_engine::cube::upload()
 
     vertex_postion_normal vertices[8];
 
-    vertices[0].pos = glm::vec3{-1.0f, -1.0f, 1.0f};
-    vertices[1].pos = glm::vec3{1.0f, -1.0f, 1.0f};
-    vertices[2].pos = glm::vec3{1.0f, 1.0f, 1.0f};
-    vertices[3].pos = glm::vec3{-1.0f, 1.0f, 1.0f};
-    vertices[4].pos = glm::vec3{-1.0f, -1.0f, -1.0f};
-    vertices[5].pos = glm::vec3{1.0f, -1.0f, -1.0f};
-    vertices[6].pos = glm::vec3{1.0f, 1.0f, -1.0f};
-    vertices[7].pos = glm::vec3{-1.0f, 1.0f, -1.0f};
+    vertices[0].pos = infrastructure::math::vec3{-1.0f, -1.0f, 1.0f};
+    vertices[1].pos = infrastructure::math::vec3{1.0f, -1.0f, 1.0f};
+    vertices[2].pos = infrastructure::math::vec3{1.0f, 1.0f, 1.0f};
+    vertices[3].pos = infrastructure::math::vec3{-1.0f, 1.0f, 1.0f};
+    vertices[4].pos = infrastructure::math::vec3{-1.0f, -1.0f, -1.0f};
+    vertices[5].pos = infrastructure::math::vec3{1.0f, -1.0f, -1.0f};
+    vertices[6].pos = infrastructure::math::vec3{1.0f, 1.0f, -1.0f};
+    vertices[7].pos = infrastructure::math::vec3{-1.0f, 1.0f, -1.0f};
 
     uint32_t indicies[36] = {0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 7, 6, 5, 5, 4, 7,
                              4, 0, 3, 3, 7, 4, 4, 5, 1, 1, 0, 4, 3, 2, 6, 6, 7, 3};
@@ -57,25 +57,25 @@ void rendering_engine::cube::upload()
         switch (sector)
         {
         case 0:
-            expanded_vertices[i].normal = glm::vec3{0.0f, 0.0f, 1.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{0.0f, 0.0f, 1.0f};
             break;
         case 1:
-            expanded_vertices[i].normal = glm::vec3{1.0f, 0.0f, 0.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{1.0f, 0.0f, 0.0f};
             break;
         case 2:
-            expanded_vertices[i].normal = glm::vec3{0.0f, 0.0f, -1.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{0.0f, 0.0f, -1.0f};
             break;
         case 3:
-            expanded_vertices[i].normal = glm::vec3{-1.0f, 0.0f, 0.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{-1.0f, 0.0f, 0.0f};
             break;
         case 4:
-            expanded_vertices[i].normal = glm::vec3{0.0f, -1.0f, 0.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{0.0f, -1.0f, 0.0f};
             break;
         case 5:
-            expanded_vertices[i].normal = glm::vec3{0.0f, 1.0f, 0.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{0.0f, 1.0f, 0.0f};
             break;
         default:
-            expanded_vertices[i].normal = glm::vec3{0.0f, 0.0f, 0.0f};
+            expanded_vertices[i].normal = infrastructure::math::vec3{0.0f, 0.0f, 0.0f};
         }
     }
 
@@ -92,7 +92,7 @@ void rendering_engine::cube::upload()
                                           rendering_engine::opengl::type::Float,
                                           3,
                                           sizeof(vertex_postion_normal),
-                                          sizeof(glm::vec3));
+                                          sizeof(infrastructure::math::vec3));
 }
 
 void rendering_engine::cube::render()

--- a/rendering_engine/renderers/renderer.cpp
+++ b/rendering_engine/renderers/renderer.cpp
@@ -86,10 +86,10 @@ void rendering_engine::renderer::setup_options(const render_options& options)
 
     for (auto& element : options.colors)
     {
-        auto vector = glm::vec4{(float)element.second.r / 255.0f,
-                                (float)element.second.g / 255.0f,
-                                (float)element.second.b / 255.0f,
-                                (float)element.second.a / 255.0f};
+        auto vector = infrastructure::math::vec4{(float)element.second.r / 255.0f,
+                                                 (float)element.second.g / 255.0f,
+                                                 (float)element.second.b / 255.0f,
+                                                 (float)element.second.a / 255.0f};
 
         this->upload_vector4(element.first, vector);
     }
@@ -125,7 +125,7 @@ void rendering_engine::renderer::upload_coefficient(const std::string& coefficie
     m_program->set_uniform(uniform, coefficient);
 }
 
-void rendering_engine::renderer::upload_matrix3(const std::string& mat3_name, const glm::mat3& matrix)
+void rendering_engine::renderer::upload_matrix3(const std::string& mat3_name, const infrastructure::math::mat3& matrix)
 {
     opengl::uniform uniform = m_program->get_uniform(mat3_name);
     if (uniform == -1)
@@ -136,7 +136,7 @@ void rendering_engine::renderer::upload_matrix3(const std::string& mat3_name, co
     m_program->set_uniform(uniform, matrix);
 }
 
-void rendering_engine::renderer::upload_matrix4(const std::string& mat4_name, const glm::mat4& matrix)
+void rendering_engine::renderer::upload_matrix4(const std::string& mat4_name, const infrastructure::math::mat4& matrix)
 {
     opengl::uniform uniform = m_program->get_uniform(mat4_name);
     if (uniform == -1)
@@ -147,7 +147,7 @@ void rendering_engine::renderer::upload_matrix4(const std::string& mat4_name, co
     m_program->set_uniform(uniform, matrix);
 }
 
-void rendering_engine::renderer::upload_vector2(const std::string& vec2_name, const glm::vec2& vector)
+void rendering_engine::renderer::upload_vector2(const std::string& vec2_name, const infrastructure::math::vec2& vector)
 {
     opengl::uniform uniform = m_program->get_uniform(vec2_name);
     if (uniform == -1)
@@ -158,7 +158,7 @@ void rendering_engine::renderer::upload_vector2(const std::string& vec2_name, co
     m_program->set_uniform(uniform, vector);
 }
 
-void rendering_engine::renderer::upload_vector3(const std::string& vec3_name, const glm::vec3& vector)
+void rendering_engine::renderer::upload_vector3(const std::string& vec3_name, const infrastructure::math::vec3& vector)
 {
     opengl::uniform uniform = m_program->get_uniform(vec3_name);
     if (uniform == -1)
@@ -169,7 +169,7 @@ void rendering_engine::renderer::upload_vector3(const std::string& vec3_name, co
     m_program->set_uniform(uniform, vector);
 }
 
-void rendering_engine::renderer::upload_vector4(const std::string& vec4_name, const glm::vec4& vector)
+void rendering_engine::renderer::upload_vector4(const std::string& vec4_name, const infrastructure::math::vec4& vector)
 {
     opengl::uniform uniform = m_program->get_uniform(vec4_name);
     if (uniform == -1)

--- a/rendering_engine/renderers/renderer.hpp
+++ b/rendering_engine/renderers/renderer.hpp
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
 #include <memory>
 #include <string>
 
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/renderers/render_options.hpp>
 
 namespace rendering_engine
@@ -59,11 +59,11 @@ namespace rendering_engine
 
         void upload_texture_reference(const std::string& texture_name, int position);
         void upload_coefficient(const std::string& coefficient_name, float coefficient);
-        void upload_matrix3(const std::string& mat3_name, const glm::mat3& matrix);
-        void upload_matrix4(const std::string& mat4_name, const glm::mat4& matrix);
-        void upload_vector2(const std::string& vec2_name, const glm::vec2& vector);
-        void upload_vector3(const std::string& vec3_name, const glm::vec3& vector);
-        void upload_vector4(const std::string& vec4_name, const glm::vec4& vector);
+        void upload_matrix3(const std::string& mat3_name, const infrastructure::math::mat3& matrix);
+        void upload_matrix4(const std::string& mat4_name, const infrastructure::math::mat4& matrix);
+        void upload_vector2(const std::string& vec2_name, const infrastructure::math::vec2& vector);
+        void upload_vector3(const std::string& vec3_name, const infrastructure::math::vec3& vector);
+        void upload_vector4(const std::string& vec4_name, const infrastructure::math::vec4& vector);
 
     protected:
         renderer() = default;

--- a/rendering_engine/util/transform.cpp
+++ b/rendering_engine/util/transform.cpp
@@ -20,9 +20,8 @@
  * SOFTWARE.
  */
 
+#include <infrastructure/math/math.hpp>
 #include <rendering_engine/util/transform.hpp>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/transform.hpp>
 
 rendering_engine::util::transform::transform()
     : m_is_transform_matrix_dirty{true}, m_position{0.0f, 0.0f, 0.0f}, m_rotation{0.0f, 0.0f, 0.0f},
@@ -30,52 +29,58 @@ rendering_engine::util::transform::transform()
 {
 }
 
-void rendering_engine::util::transform::set_position(const glm::vec3& position)
+void rendering_engine::util::transform::set_position(const infrastructure::math::vec3& position)
 {
     m_position = position;
     m_is_transform_matrix_dirty = true;
 }
 
-void rendering_engine::util::transform::set_rotation(const glm::vec3& rotation)
+void rendering_engine::util::transform::set_rotation(const infrastructure::math::vec3& rotation)
 {
     m_rotation = rotation;
     m_is_transform_matrix_dirty = true;
 }
 
-void rendering_engine::util::transform::set_scale(const glm::vec3& scale)
+void rendering_engine::util::transform::set_scale(const infrastructure::math::vec3& scale)
 {
     m_scale = scale;
     m_is_transform_matrix_dirty = true;
 }
 
-glm::vec3 rendering_engine::util::transform::get_position() const
+infrastructure::math::vec3 rendering_engine::util::transform::get_position() const
 {
     return m_position;
 }
 
-glm::vec3 rendering_engine::util::transform::get_rotation() const
+infrastructure::math::vec3 rendering_engine::util::transform::get_rotation() const
 {
     return m_rotation;
 }
 
-glm::vec3 rendering_engine::util::transform::get_scale() const
+infrastructure::math::vec3 rendering_engine::util::transform::get_scale() const
 {
     return m_scale;
 }
 
-glm::mat4 rendering_engine::util::transform::get_transform_matrix() const
+infrastructure::math::mat4 rendering_engine::util::transform::get_transform_matrix() const
 {
     if (!m_is_transform_matrix_dirty)
     {
         return m_transform_matrix;
     }
 
-    glm::mat4 pos_matrix = glm::translate(m_position);
-    glm::mat4 rot_x_matrix = glm::rotate(m_rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
-    glm::mat4 rot_y_matrix = glm::rotate(m_rotation.y, glm::vec3(0.0f, 1.0f, 0.0f));
-    glm::mat4 rot_z_matrix = glm::rotate(m_rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
-    glm::mat4 scale_matrix = glm::scale(m_scale);
-    glm::mat4 rot_matrix = rot_z_matrix * rot_y_matrix * rot_x_matrix;
+    using infrastructure::math::mat4;
+    using infrastructure::math::rotate;
+    using infrastructure::math::scale;
+    using infrastructure::math::translate;
+    using infrastructure::math::vec3;
+
+    mat4 pos_matrix = translate(m_position);
+    mat4 rot_x_matrix = rotate(m_rotation.x, vec3{1.0f, 0.0f, 0.0f});
+    mat4 rot_y_matrix = rotate(m_rotation.y, vec3{0.0f, 1.0f, 0.0f});
+    mat4 rot_z_matrix = rotate(m_rotation.z, vec3{0.0f, 0.0f, 1.0f});
+    mat4 scale_matrix = scale(m_scale);
+    mat4 rot_matrix = rot_z_matrix * rot_y_matrix * rot_x_matrix;
 
     m_transform_matrix = pos_matrix * rot_matrix * scale_matrix;
     m_is_transform_matrix_dirty = false;

--- a/rendering_engine/util/transform.hpp
+++ b/rendering_engine/util/transform.hpp
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include <infrastructure/math/math.hpp>
 
 namespace rendering_engine::util
 {
@@ -30,22 +30,22 @@ namespace rendering_engine::util
     {
         transform();
 
-        void set_position(const glm::vec3& position);
-        void set_rotation(const glm::vec3& rotation);
-        void set_scale(const glm::vec3& scale);
+        void set_position(const infrastructure::math::vec3& position);
+        void set_rotation(const infrastructure::math::vec3& rotation);
+        void set_scale(const infrastructure::math::vec3& scale);
 
-        glm::vec3 get_position() const;
-        glm::vec3 get_rotation() const;
-        glm::vec3 get_scale() const;
+        infrastructure::math::vec3 get_position() const;
+        infrastructure::math::vec3 get_rotation() const;
+        infrastructure::math::vec3 get_scale() const;
 
-        glm::mat4 get_transform_matrix() const;
+        infrastructure::math::mat4 get_transform_matrix() const;
 
     private:
-        mutable glm::mat4 m_transform_matrix;
+        mutable infrastructure::math::mat4 m_transform_matrix;
         mutable bool m_is_transform_matrix_dirty;
 
-        glm::vec3 m_position;
-        glm::vec3 m_rotation;
-        glm::vec3 m_scale;
+        infrastructure::math::vec3 m_position;
+        infrastructure::math::vec3 m_rotation;
+        infrastructure::math::vec3 m_scale;
     };
 } // namespace rendering_engine::util


### PR DESCRIPTION
## Summary
- Introduce engine-owned math types in `infrastructure/math/math.hpp`: `vec2`, `vec3`, `vec4`, `mat3`, `mat4`, `quat`, plus snake_case free functions (`dot`, `cross`, `normalize`, `length`, `distance`, `lerp`, `look_at`, `perspective`, `ortho`, `translate`, `rotate`, `scale`, `inverse`, `transpose`). Each type wraps the corresponding `glm::*` as a public `value` member; vectors expose `.x/.y/.z/.w` through an anonymous union; matrices expose raw float data via `data()`. Layout is identical to GLM so uniform uploads are unchanged.
- Migrate `rendering_engine/` (cameras, renderers, renderables, mesh/vertex, opengl/program, util/transform) and `external/` game modules off direct `glm::` usage. `glm::` is now confined to `infrastructure/math/math.hpp`.
- Add CMake glob for `infrastructure/math/*` and add a math section to `CLAUDE.md`.

Closes #43

## Test plan
- [x] `./scripts/check-style.ps1` passes
- [x] `./scripts/check-naming.ps1` runs clean against the new math module (preexisting warnings elsewhere are unchanged)
- [x] `./scripts/build.ps1` succeeds on MSVC/vcpkg