### PR TITLE
feat: add cube_texture wrapper to opengl context

### DIFF
--- a/rendering_engine/opengl/cube_texture.cpp
+++ b/rendering_engine/opengl/cube_texture.cpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/opengl/cube_texture.hpp>
+
+#define PUSHSTATE()                                                                                                    \
+    GLint restoreId;                                                                                                   \
+    glGetIntegerv(GL_TEXTURE_BINDING_CUBE_MAP, &restoreId);
+#define POPSTATE() glBindTexture(GL_TEXTURE_CUBE_MAP, restoreId);
+
+rendering_engine::opengl::cube_texture::cube_texture()
+{
+    glGenTextures(1, &m_object_id);
+}
+
+rendering_engine::opengl::cube_texture::~cube_texture()
+{
+    glDeleteTextures(1, &m_object_id);
+}
+
+const uint32_t rendering_engine::opengl::cube_texture::handle() const
+{
+    return m_object_id;
+}
+
+void rendering_engine::opengl::cube_texture::image2_d(const cube_face face,
+                                                      const void* data,
+                                                      const data_type type,
+                                                      const format format,
+                                                      const uint32_t width,
+                                                      const uint32_t height,
+                                                      const internal_format internal_format)
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glTexImage2D((GLenum)face, 0, (GLint)internal_format, width, height, 0, (GLenum)format, (GLenum)type, data);
+
+    POPSTATE()
+}
+
+void rendering_engine::opengl::cube_texture::set_wrapping_s(const wrapping s)
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, (GLint)s);
+
+    POPSTATE()
+}
+
+void rendering_engine::opengl::cube_texture::set_wrapping_t(const wrapping t)
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, (GLint)t);
+
+    POPSTATE()
+}
+
+void rendering_engine::opengl::cube_texture::set_wrapping_r(const wrapping r)
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, (GLint)r);
+
+    POPSTATE()
+}
+
+void rendering_engine::opengl::cube_texture::set_filters(const filter min, const filter mag)
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, (GLint)min);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, (GLint)mag);
+
+    POPSTATE()
+}
+
+void rendering_engine::opengl::cube_texture::generate_mipmaps()
+{
+    PUSHSTATE()
+
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_object_id);
+    glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
+
+    POPSTATE()
+}

--- a/rendering_engine/opengl/cube_texture.hpp
+++ b/rendering_engine/opengl/cube_texture.hpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/opengl/typedef.hpp>
+
+namespace rendering_engine
+{
+    namespace opengl
+    {
+        // Identifier for one of the six faces of a cube map. Values match
+        // the GL constants so the wrapper can pass them through directly.
+        enum class cube_face
+        {
+            positive_x = GL_TEXTURE_CUBE_MAP_POSITIVE_X,
+            negative_x = GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
+            positive_y = GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
+            negative_y = GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
+            positive_z = GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
+            negative_z = GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
+        };
+
+        // Cube-map texture: a single GL texture object that holds six 2D
+        // face images. Sampled in shaders by 3D direction vector
+        // (samplerCube). Used for environment maps, sky boxes and — for
+        // this engine — planet surfaces wrapped on a cubed sphere, where
+        // it eliminates the polar singularity of an equirectangular layout.
+        class cube_texture
+        {
+            friend class context;
+            cube_texture();
+            ~cube_texture();
+
+            cube_texture(const cube_texture&) = delete;
+            cube_texture(const cube_texture&&) = delete;
+            const cube_texture& operator=(const cube_texture&) = delete;
+            const cube_texture&& operator=(const cube_texture&&) = delete;
+
+        public:
+            const uint32_t handle() const;
+
+            // Uploads pixel data to one of the six faces. Calling for all
+            // six faces (with matching dimensions / formats) populates the
+            // full cube map.
+            void image2_d(cube_face face,
+                          const void* data,
+                          data_type type,
+                          format format,
+                          uint32_t width,
+                          uint32_t height,
+                          internal_format internal_format);
+
+            void set_wrapping_s(wrapping s);
+            void set_wrapping_t(wrapping t);
+            void set_wrapping_r(wrapping r);
+
+            void set_filters(filter min, filter mag);
+
+            void generate_mipmaps();
+
+        private:
+            unsigned int m_object_id;
+        };
+    } // namespace opengl
+} // namespace rendering_engine

--- a/rendering_engine/opengl/opengl.cpp
+++ b/rendering_engine/opengl/opengl.cpp
@@ -85,6 +85,11 @@ rendering_engine::opengl::texture* rendering_engine::opengl::context::create_tex
     return new opengl::texture();
 }
 
+rendering_engine::opengl::cube_texture* rendering_engine::opengl::context::create_cube_texture()
+{
+    return new opengl::cube_texture();
+}
+
 rendering_engine::opengl::vertex_array* rendering_engine::opengl::context::create_vao()
 {
     return new opengl::vertex_array();
@@ -111,6 +116,11 @@ void rendering_engine::opengl::context::delete_shader(const opengl::shader* shad
 }
 
 void rendering_engine::opengl::context::delete_texture(const opengl::texture* texture)
+{
+    delete texture;
+}
+
+void rendering_engine::opengl::context::delete_cube_texture(const opengl::cube_texture* texture)
 {
     delete texture;
 }
@@ -155,6 +165,13 @@ void rendering_engine::opengl::context::bind_texture(const rendering_engine::ope
 {
     glActiveTexture(GL_TEXTURE0 + unit);
     glBindTexture(GL_TEXTURE_2D, texture.handle());
+}
+
+void rendering_engine::opengl::context::bind_cube_texture(const rendering_engine::opengl::cube_texture& texture,
+                                                          const unsigned char unit)
+{
+    glActiveTexture(GL_TEXTURE0 + unit);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, texture.handle());
 }
 
 void rendering_engine::opengl::context::bind_framebuffer(const rendering_engine::opengl::framebuffer& framebuffer)

--- a/rendering_engine/opengl/opengl.hpp
+++ b/rendering_engine/opengl/opengl.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <rendering_engine/opengl/cube_texture.hpp>
 #include <rendering_engine/opengl/framebuffer.hpp>
 #include <rendering_engine/opengl/program.hpp>
 #include <rendering_engine/opengl/shader.hpp>
@@ -44,6 +45,7 @@ namespace rendering_engine
             opengl::program* create_program();
             opengl::shader* create_shader(shader_type);
             opengl::texture* create_texture();
+            opengl::cube_texture* create_cube_texture();
             opengl::vertex_array* create_vao();
             opengl::vertex_buffer* create_vbo();
 
@@ -51,6 +53,7 @@ namespace rendering_engine
             void delete_program(const opengl::program*);
             void delete_shader(const opengl::shader*);
             void delete_texture(const opengl::texture*);
+            void delete_cube_texture(const opengl::cube_texture*);
             void delete_vab(const opengl::vertex_array*);
             void delete_vbo(const opengl::vertex_buffer*);
 
@@ -62,6 +65,7 @@ namespace rendering_engine
             void depth_mask(bool write_enabled);
 
             void bind_texture(const opengl::texture& texture, const unsigned char unit);
+            void bind_cube_texture(const opengl::cube_texture& texture, const unsigned char unit);
             void bind_framebuffer(const opengl::framebuffer& framebuffer);
             void bind_framebuffer();
 


### PR DESCRIPTION
## Summary

- Adds `opengl::cube_texture`, an RAII wrapper around `GL_TEXTURE_CUBE_MAP` mirroring the existing `opengl::texture` shape.
- Surfaces it through `opengl::context` via `create_cube_texture` / `delete_cube_texture` / `bind_cube_texture` so callers stay on the wrapper API.
- Per-face `image2_d` upload, `set_wrapping_{s,t,r}`, `set_filters`, and `generate_mipmaps` cover environment maps and cube-mapped planet surfaces.

## Test plan

- [x] `./scripts/build.ps1` (MSVC + vcpkg, Release) — succeeds
- [x] `./scripts/check-style.ps1` — clean
- [x] `./scripts/check-naming.ps1` — clean