### PR TITLE
feat: add internal_format framebuffer ctor for hdr targets

### DIFF
--- a/rendering_engine/opengl/framebuffer.cpp
+++ b/rendering_engine/opengl/framebuffer.cpp
@@ -99,6 +99,99 @@ rendering_engine::opengl::framebuffer::framebuffer(const uint32_t width,
     POPSTATE()
 }
 
+namespace
+{
+    // Map an internal format to a (format, data_type) pair valid for a null
+    // upload via glTexImage2D. Picks GL_FLOAT for floating-point internal
+    // formats and unsigned_byte for normalized integer formats.
+    void upload_pair_for(rendering_engine::opengl::internal_format f,
+                         rendering_engine::opengl::format& out_format,
+                         rendering_engine::opengl::data_type& out_type)
+    {
+        using rendering_engine::opengl::data_type;
+        using rendering_engine::opengl::format;
+        using rendering_engine::opengl::internal_format;
+
+        switch (f)
+        {
+        case internal_format::rgb_a16_f:
+        case internal_format::rgb_a32_f:
+            out_format = format::rgba;
+            out_type = data_type::Float;
+            break;
+        case internal_format::rg_b16_f:
+        case internal_format::rg_b32_f:
+            out_format = format::rgb;
+            out_type = data_type::Float;
+            break;
+        case internal_format::r16_f:
+        case internal_format::r32_f:
+            out_format = format::red;
+            out_type = data_type::Float;
+            break;
+        case internal_format::rgb:
+        case internal_format::rg_b8:
+        case internal_format::srg_b8:
+            out_format = format::rgb;
+            out_type = data_type::unsigned_byte;
+            break;
+        default:
+            out_format = format::rgba;
+            out_type = data_type::unsigned_byte;
+            break;
+        }
+    }
+} // namespace
+
+rendering_engine::opengl::framebuffer::framebuffer(const uint32_t width,
+                                                   const uint32_t height,
+                                                   const internal_format color_format,
+                                                   const bool with_depth)
+    : m_object_id{0}
+{
+    PUSHSTATE()
+
+    glGenFramebuffers(1, &m_object_id);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_object_id);
+
+    format upload_format;
+    data_type upload_type;
+    upload_pair_for(color_format, upload_format, upload_type);
+
+    m_color_texture.image2_d(nullptr, upload_type, upload_format, width, height, color_format);
+    m_color_texture.set_wrapping_t(opengl::wrapping::clamp_edge);
+    m_color_texture.set_wrapping_s(opengl::wrapping::clamp_edge);
+    m_color_texture.set_filters(opengl::filter::linear, opengl::filter::linear);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_color_texture.handle(), 0);
+
+    if (with_depth)
+    {
+        glBindTexture(GL_TEXTURE_2D, m_depth_texture.handle());
+        glTexImage2D(GL_TEXTURE_2D,
+                     0,
+                     (GLint)internal_format::depth_component24,
+                     width,
+                     height,
+                     0,
+                     GL_DEPTH_COMPONENT,
+                     GL_FLOAT,
+                     0);
+        m_depth_texture.set_wrapping_t(opengl::wrapping::clamp_edge);
+        m_depth_texture.set_wrapping_s(opengl::wrapping::clamp_edge);
+        m_depth_texture.set_filters(opengl::filter::nearest, opengl::filter::nearest);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_depth_texture.handle(), 0);
+    }
+
+    if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+    {
+        LOG_ERR("Framebuffer could not be created (internal_format ctor): 0x%X",
+                glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER));
+        throw std::runtime_error{"Framebuffer could not be created!"};
+    }
+
+    POPSTATE()
+}
+
 rendering_engine::opengl::framebuffer::~framebuffer()
 {
     glDeleteFramebuffers(1, &m_object_id);

--- a/rendering_engine/opengl/framebuffer.hpp
+++ b/rendering_engine/opengl/framebuffer.hpp
@@ -33,6 +33,10 @@ namespace rendering_engine
         {
             friend class context;
             framebuffer(uint32_t width, uint32_t height, uint8_t color = 32u, uint8_t depth = 24u);
+            // Explicit-format ctor: takes the GL internal_format directly so callers
+            // can request HDR formats (e.g. rgb_a16_f) and skip the depth attachment
+            // entirely when only color is needed.
+            framebuffer(uint32_t width, uint32_t height, internal_format color_format, bool with_depth);
             ~framebuffer();
 
             framebuffer(const framebuffer&) = delete;

--- a/rendering_engine/opengl/opengl.cpp
+++ b/rendering_engine/opengl/opengl.cpp
@@ -70,6 +70,12 @@ rendering_engine::opengl::context::create_framebuffer(uint32_t width, uint32_t h
     return new rendering_engine::opengl::framebuffer(width, height, color, depth);
 }
 
+rendering_engine::opengl::framebuffer* rendering_engine::opengl::context::create_framebuffer(
+    uint32_t width, uint32_t height, internal_format color_format, bool with_depth)
+{
+    return new rendering_engine::opengl::framebuffer(width, height, color_format, with_depth);
+}
+
 rendering_engine::opengl::program* rendering_engine::opengl::context::create_program()
 {
     return new opengl::program();

--- a/rendering_engine/opengl/opengl.hpp
+++ b/rendering_engine/opengl/opengl.hpp
@@ -41,6 +41,7 @@ namespace rendering_engine
             void quit();
 
             opengl::framebuffer* create_framebuffer(uint32_t, uint32_t, uint8_t, uint8_t);
+            opengl::framebuffer* create_framebuffer(uint32_t, uint32_t, internal_format, bool with_depth);
             opengl::program* create_program();
             opengl::shader* create_shader(shader_type);
             opengl::texture* create_texture();


### PR DESCRIPTION
## Summary

- Adds an explicit-format `framebuffer` constructor that takes a GL `internal_format` and a `with_depth` flag, so HDR targets (`rgb_a16_f`, `rgb_a32_f`, …) and color-only post-process buffers can be created without smuggling a bit count through the legacy ctor.
- Tiny `upload_pair_for()` helper picks a matching `(format, data_type)` pair for the null upload, so floating-point internal formats use `GL_FLOAT` and normalized integer formats use `GL_UNSIGNED_BYTE`.
- Surfaces the new ctor through a `create_framebuffer` overload on `opengl::context`.

## Test plan

- [x] `./scripts/build.ps1` (MSVC + vcpkg, Release) — succeeds
- [x] `./scripts/check-style.ps1` — clean
- [x] `./scripts/check-naming.ps1` — clean