### PR TITLE
feat: add opengl context helpers for blend, viewport, polygon mode

### DIFF
--- a/rendering_engine/opengl/opengl.cpp
+++ b/rendering_engine/opengl/opengl.cpp
@@ -81,6 +81,24 @@ rendering_engine::opengl::program* rendering_engine::opengl::context::create_pro
     return new opengl::program();
 }
 
+rendering_engine::opengl::program*
+rendering_engine::opengl::context::compile_program(const std::string& vertex_source, const std::string& fragment_source)
+{
+    auto* vs = create_shader(shader_type::vertex);
+    vs->source(vertex_source);
+    vs->compile();
+    auto* fs = create_shader(shader_type::fragment);
+    fs->source(fragment_source);
+    fs->compile();
+    auto* prog = create_program();
+    prog->attach(*vs);
+    prog->attach(*fs);
+    prog->link();
+    delete_shader(vs);
+    delete_shader(fs);
+    return prog;
+}
+
 rendering_engine::opengl::shader* rendering_engine::opengl::context::create_shader(shader_type type)
 {
     return new opengl::shader(type);
@@ -166,6 +184,21 @@ void rendering_engine::opengl::context::depth_mask(const bool write_enabled)
     glDepthMask(write_enabled ? GL_TRUE : GL_FALSE);
 }
 
+void rendering_engine::opengl::context::blend_func(const blend_factor src, const blend_factor dst)
+{
+    glBlendFunc((GLenum)src, (GLenum)dst);
+}
+
+void rendering_engine::opengl::context::set_viewport(const int x, const int y, const int width, const int height)
+{
+    glViewport(x, y, width, height);
+}
+
+void rendering_engine::opengl::context::set_polygon_mode(const polygon_mode mode)
+{
+    glPolygonMode(GL_FRONT_AND_BACK, (GLenum)mode);
+}
+
 void rendering_engine::opengl::context::bind_texture(const rendering_engine::opengl::texture& texture,
                                                      const unsigned char unit)
 {
@@ -197,6 +230,11 @@ void rendering_engine::opengl::context::bind_framebuffer(const rendering_engine:
     glBindTexture(GL_TEXTURE_2D, res);
 
     glViewport(0, 0, width, height);
+}
+
+void rendering_engine::opengl::context::unbind_vao()
+{
+    glBindVertexArray(0);
 }
 
 void rendering_engine::opengl::context::bind_framebuffer()

--- a/rendering_engine/opengl/opengl.hpp
+++ b/rendering_engine/opengl/opengl.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <string>
+
 #include <rendering_engine/opengl/cube_texture.hpp>
 #include <rendering_engine/opengl/framebuffer.hpp>
 #include <rendering_engine/opengl/program.hpp>
@@ -44,6 +46,9 @@ namespace rendering_engine
             opengl::framebuffer* create_framebuffer(uint32_t, uint32_t, uint8_t, uint8_t);
             opengl::framebuffer* create_framebuffer(uint32_t, uint32_t, internal_format, bool with_depth);
             opengl::program* create_program();
+            // Convenience: compile a vertex+fragment program from source strings,
+            // attach, link, and discard the shaders. Throws on compile/link failure.
+            opengl::program* compile_program(const std::string& vertex_source, const std::string& fragment_source);
             opengl::shader* create_shader(shader_type);
             opengl::texture* create_texture();
             opengl::cube_texture* create_cube_texture();
@@ -64,11 +69,21 @@ namespace rendering_engine
             void clear_color(const rendering_engine::util::color& color);
             void clear(opengl::buffer buffers);
             void depth_mask(bool write_enabled);
+            void blend_func(blend_factor src, blend_factor dst);
+            void set_viewport(int x, int y, int width, int height);
+            // Sets the polygon rasterization mode for both faces. Used for
+            // wireframe debug views; pass @c polygon_mode::fill to restore.
+            void set_polygon_mode(polygon_mode mode);
 
             void bind_texture(const opengl::texture& texture, const unsigned char unit);
             void bind_cube_texture(const opengl::cube_texture& texture, const unsigned char unit);
             void bind_framebuffer(const opengl::framebuffer& framebuffer);
             void bind_framebuffer();
+            // Unbinds whichever VAO is currently bound. Useful at the end of
+            // mesh setup so the VAO's state gets committed by the driver
+            // before its first draw — some drivers don't commit VAO state
+            // until the VAO is unbound at least once after configuration.
+            void unbind_vao();
 
             void
             draw_arrays(const opengl::vertex_array& vao, opengl::primitive mode, unsigned int offset, size_t vertices);

--- a/rendering_engine/opengl/typedef.hpp
+++ b/rendering_engine/opengl/typedef.hpp
@@ -224,5 +224,29 @@ namespace rendering_engine
             dynamic_read = GL_DYNAMIC_READ,
             dynamic_copy = GL_DYNAMIC_COPY
         };
+
+        enum class blend_factor
+        {
+            zero = GL_ZERO,
+            one = GL_ONE,
+            src_color = GL_SRC_COLOR,
+            one_minus_src_color = GL_ONE_MINUS_SRC_COLOR,
+            dst_color = GL_DST_COLOR,
+            one_minus_dst_color = GL_ONE_MINUS_DST_COLOR,
+            src_alpha = GL_SRC_ALPHA,
+            one_minus_src_alpha = GL_ONE_MINUS_SRC_ALPHA,
+            dst_alpha = GL_DST_ALPHA,
+            one_minus_dst_alpha = GL_ONE_MINUS_DST_ALPHA
+        };
+
+        // Rasterization mode for the front-and-back of polygons. In a Core
+        // 3.3+ profile only @c GL_FRONT_AND_BACK is valid for the face
+        // parameter, so the abstraction exposes the @c mode only.
+        enum class polygon_mode
+        {
+            fill = GL_FILL,
+            line = GL_LINE,
+            point = GL_POINT
+        };
     } // namespace opengl
 } // namespace rendering_engine


### PR DESCRIPTION
## Summary

- Adds five small helpers on `opengl::context` so callers don't reach past the wrapper for everyday GL state: `blend_func`, `set_viewport`, `set_polygon_mode` (wireframe debug), `unbind_vao` (some drivers won't commit VAO state until it's unbound at least once after configuration), and `compile_program` (build a vertex+fragment program from source strings in one call).
- Adds two supporting enums in `typedef.hpp`: `blend_factor` and `polygon_mode`.

## Test plan

- [x] `./scripts/build.ps1` (MSVC + vcpkg, Release) — succeeds
- [x] `./scripts/check-style.ps1` — clean
- [x] `./scripts/check-naming.ps1` — clean