### PR TITLE
cmake: add -stdlib=libc++ to link options for Clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(AlphaEngine
 # Use C++ standard library
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)
+    target_link_options(AlphaEngine PRIVATE -stdlib=libc++)
 endif()
 
 # SDL3 — fetched and built statically from source


### PR DESCRIPTION
The compile options already set -stdlib=libc++, causing object files to
reference std::__1:: types from libc++. Without the matching linker flag
the final link step falls back to libstdc++ and produces undefined
reference errors. Passing -stdlib=libc++ to target_link_options fixes
Linux/Clang builds without affecting MSVC or AppleClang.