### PR TITLE
refactor: hide GLM behind POD math types

### DIFF
--- a/infrastructure/math/mat3.cpp
+++ b/infrastructure/math/mat3.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/mat3.hpp>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+namespace infrastructure::math
+{
+    mat3 operator*(const mat3& a, const mat3& b) noexcept
+    {
+        glm::mat3 result = glm::make_mat3(a.m) * glm::make_mat3(b.m);
+        mat3 out;
+        const float* p = glm::value_ptr(result);
+        for (int i = 0; i < 9; ++i)
+        {
+            out.m[i] = p[i];
+        }
+        return out;
+    }
+
+    vec3 operator*(const mat3& m, const vec3& v) noexcept
+    {
+        glm::vec3 result = glm::make_mat3(m.m) * glm::vec3{v.x, v.y, v.z};
+        return vec3{result.x, result.y, result.z};
+    }
+
+    bool operator==(const mat3& a, const mat3& b) noexcept
+    {
+        return glm::make_mat3(a.m) == glm::make_mat3(b.m);
+    }
+
+    bool operator!=(const mat3& a, const mat3& b) noexcept
+    {
+        return glm::make_mat3(a.m) != glm::make_mat3(b.m);
+    }
+
+    mat3 inverse(const mat3& m) noexcept
+    {
+        glm::mat3 result = glm::inverse(glm::make_mat3(m.m));
+        mat3 out;
+        const float* p = glm::value_ptr(result);
+        for (int i = 0; i < 9; ++i)
+        {
+            out.m[i] = p[i];
+        }
+        return out;
+    }
+
+    mat3 transpose(const mat3& m) noexcept
+    {
+        glm::mat3 result = glm::transpose(glm::make_mat3(m.m));
+        mat3 out;
+        const float* p = glm::value_ptr(result);
+        for (int i = 0; i < 9; ++i)
+        {
+            out.m[i] = p[i];
+        }
+        return out;
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/mat3.hpp
+++ b/infrastructure/math/mat3.hpp
@@ -20,27 +20,39 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
 #pragma once
 
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/vec2.hpp>
 #include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    /** @brief 3x3 float matrix (column-major). Layout-compatible with @c glm::mat3. */
+    struct mat3
+    {
+        // Column-major storage: m[col * 3 + row].
+        float m[9]{1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+
+        constexpr mat3() noexcept = default;
+        constexpr explicit mat3(float diagonal) noexcept
+            : m{diagonal, 0.0f, 0.0f, 0.0f, diagonal, 0.0f, 0.0f, 0.0f, diagonal}
+        {
+        }
+
+        const float* data() const noexcept
+        {
+            return m;
+        }
+        float* data() noexcept
+        {
+            return m;
+        }
+    };
+
+    mat3 operator*(const mat3& a, const mat3& b) noexcept;
+    vec3 operator*(const mat3& m, const vec3& v) noexcept;
+    bool operator==(const mat3& a, const mat3& b) noexcept;
+    bool operator!=(const mat3& a, const mat3& b) noexcept;
+
+    mat3 inverse(const mat3& m) noexcept;
+    mat3 transpose(const mat3& m) noexcept;
 } // namespace infrastructure::math

--- a/infrastructure/math/mat4.cpp
+++ b/infrastructure/math/mat4.cpp
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/mat4.hpp>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/transform.hpp>
+
+namespace infrastructure::math
+{
+    namespace
+    {
+        mat4 store(const glm::mat4& src) noexcept
+        {
+            mat4 out;
+            const float* p = glm::value_ptr(src);
+            for (int i = 0; i < 16; ++i)
+            {
+                out.m[i] = p[i];
+            }
+            return out;
+        }
+    } // namespace
+
+    mat4 operator*(const mat4& a, const mat4& b) noexcept
+    {
+        return store(glm::make_mat4(a.m) * glm::make_mat4(b.m));
+    }
+
+    vec4 operator*(const mat4& m, const vec4& v) noexcept
+    {
+        glm::vec4 result = glm::make_mat4(m.m) * glm::vec4{v.x, v.y, v.z, v.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+
+    vec4 operator*(const vec4& v, const mat4& m) noexcept
+    {
+        glm::vec4 result = glm::vec4{v.x, v.y, v.z, v.w} * glm::make_mat4(m.m);
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+
+    bool operator==(const mat4& a, const mat4& b) noexcept
+    {
+        return glm::make_mat4(a.m) == glm::make_mat4(b.m);
+    }
+
+    bool operator!=(const mat4& a, const mat4& b) noexcept
+    {
+        return glm::make_mat4(a.m) != glm::make_mat4(b.m);
+    }
+
+    mat4& operator*=(mat4& a, const mat4& b) noexcept
+    {
+        a = a * b;
+        return a;
+    }
+
+    mat4 look_at(const vec3& eye, const vec3& center, const vec3& up) noexcept
+    {
+        return store(glm::lookAt(
+            glm::vec3{eye.x, eye.y, eye.z}, glm::vec3{center.x, center.y, center.z}, glm::vec3{up.x, up.y, up.z}));
+    }
+
+    mat4 perspective(float fov_y, float aspect, float near_z, float far_z) noexcept
+    {
+        return store(glm::perspective(fov_y, aspect, near_z, far_z));
+    }
+
+    mat4 ortho(float left, float right, float bottom, float top, float near_z, float far_z) noexcept
+    {
+        return store(glm::ortho(left, right, bottom, top, near_z, far_z));
+    }
+
+    mat4 translate(const vec3& v) noexcept
+    {
+        return store(glm::translate(glm::vec3{v.x, v.y, v.z}));
+    }
+
+    mat4 translate(const mat4& m, const vec3& v) noexcept
+    {
+        return store(glm::translate(glm::make_mat4(m.m), glm::vec3{v.x, v.y, v.z}));
+    }
+
+    mat4 rotate(float angle, const vec3& axis) noexcept
+    {
+        return store(glm::rotate(angle, glm::vec3{axis.x, axis.y, axis.z}));
+    }
+
+    mat4 rotate(const mat4& m, float angle, const vec3& axis) noexcept
+    {
+        return store(glm::rotate(glm::make_mat4(m.m), angle, glm::vec3{axis.x, axis.y, axis.z}));
+    }
+
+    mat4 scale(const vec3& v) noexcept
+    {
+        return store(glm::scale(glm::vec3{v.x, v.y, v.z}));
+    }
+
+    mat4 scale(const mat4& m, const vec3& v) noexcept
+    {
+        return store(glm::scale(glm::make_mat4(m.m), glm::vec3{v.x, v.y, v.z}));
+    }
+
+    mat4 inverse(const mat4& m) noexcept
+    {
+        return store(glm::inverse(glm::make_mat4(m.m)));
+    }
+
+    mat4 transpose(const mat4& m) noexcept
+    {
+        return store(glm::transpose(glm::make_mat4(m.m)));
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/mat4.hpp
+++ b/infrastructure/math/mat4.hpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/vec3.hpp>
+#include <infrastructure/math/vec4.hpp>
+
+namespace infrastructure::math
+{
+    /** @brief 4x4 float matrix (column-major). Layout-compatible with @c glm::mat4. */
+    struct mat4
+    {
+        // Column-major storage: m[col * 4 + row].
+        float m[16]{1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+
+        constexpr mat4() noexcept = default;
+        constexpr explicit mat4(float diagonal) noexcept
+            : m{diagonal,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                diagonal,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                diagonal,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                diagonal}
+        {
+        }
+
+        const float* data() const noexcept
+        {
+            return m;
+        }
+        float* data() noexcept
+        {
+            return m;
+        }
+    };
+
+    mat4 operator*(const mat4& a, const mat4& b) noexcept;
+    vec4 operator*(const mat4& m, const vec4& v) noexcept;
+    vec4 operator*(const vec4& v, const mat4& m) noexcept;
+    bool operator==(const mat4& a, const mat4& b) noexcept;
+    bool operator!=(const mat4& a, const mat4& b) noexcept;
+    mat4& operator*=(mat4& a, const mat4& b) noexcept;
+
+    mat4 look_at(const vec3& eye, const vec3& center, const vec3& up) noexcept;
+    mat4 perspective(float fov_y, float aspect, float near_z, float far_z) noexcept;
+    mat4 ortho(float left, float right, float bottom, float top, float near_z, float far_z) noexcept;
+
+    mat4 translate(const vec3& v) noexcept;
+    mat4 translate(const mat4& m, const vec3& v) noexcept;
+    mat4 rotate(float angle, const vec3& axis) noexcept;
+    mat4 rotate(const mat4& m, float angle, const vec3& axis) noexcept;
+    mat4 scale(const vec3& v) noexcept;
+    mat4 scale(const mat4& m, const vec3& v) noexcept;
+
+    mat4 inverse(const mat4& m) noexcept;
+    mat4 transpose(const mat4& m) noexcept;
+} // namespace infrastructure::math

--- a/infrastructure/math/math.cpp
+++ b/infrastructure/math/math.cpp
@@ -20,27 +20,14 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
+#include <infrastructure/math/math.hpp>
 
-#pragma once
-
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/vec2.hpp>
-#include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
+#include <glm/glm.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    float lerp(float a, float b, float t) noexcept
+    {
+        return glm::mix(a, b, t);
+    }
 } // namespace infrastructure::math

--- a/infrastructure/math/quat.cpp
+++ b/infrastructure/math/quat.cpp
@@ -20,27 +20,25 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
-#pragma once
-
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
 #include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/vec2.hpp>
-#include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/quaternion.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    quat normalize(const quat& q) noexcept
+    {
+        glm::quat result = glm::normalize(glm::quat{q.w, q.x, q.y, q.z});
+        return quat{result.w, result.x, result.y, result.z};
+    }
+
+    quat inverse(const quat& q) noexcept
+    {
+        glm::quat result = glm::inverse(glm::quat{q.w, q.x, q.y, q.z});
+        return quat{result.w, result.x, result.y, result.z};
+    }
 } // namespace infrastructure::math

--- a/infrastructure/math/quat.hpp
+++ b/infrastructure/math/quat.hpp
@@ -20,27 +20,22 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
 #pragma once
-
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/vec2.hpp>
-#include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    /** @brief Float quaternion. Components are exposed in @c (w, x, y, z) order. */
+    struct quat
+    {
+        float w{1.0f};
+        float x{0.0f};
+        float y{0.0f};
+        float z{0.0f};
+
+        constexpr quat() noexcept = default;
+        constexpr quat(float in_w, float in_x, float in_y, float in_z) noexcept : w{in_w}, x{in_x}, y{in_y}, z{in_z} {}
+    };
+
+    quat normalize(const quat& q) noexcept;
+    quat inverse(const quat& q) noexcept;
 } // namespace infrastructure::math

--- a/infrastructure/math/vec2.cpp
+++ b/infrastructure/math/vec2.cpp
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/vec2.hpp>
+
+#include <glm/glm.hpp>
+
+namespace infrastructure::math
+{
+    vec2 operator+(const vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} + glm::vec2{b.x, b.y};
+        return vec2{result.x, result.y};
+    }
+    vec2 operator-(const vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} - glm::vec2{b.x, b.y};
+        return vec2{result.x, result.y};
+    }
+    vec2 operator*(const vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} * glm::vec2{b.x, b.y};
+        return vec2{result.x, result.y};
+    }
+    vec2 operator/(const vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} / glm::vec2{b.x, b.y};
+        return vec2{result.x, result.y};
+    }
+    vec2 operator*(const vec2& v, float s) noexcept
+    {
+        glm::vec2 result = glm::vec2{v.x, v.y} * s;
+        return vec2{result.x, result.y};
+    }
+    vec2 operator*(float s, const vec2& v) noexcept
+    {
+        glm::vec2 result = s * glm::vec2{v.x, v.y};
+        return vec2{result.x, result.y};
+    }
+    vec2 operator/(const vec2& v, float s) noexcept
+    {
+        glm::vec2 result = glm::vec2{v.x, v.y} / s;
+        return vec2{result.x, result.y};
+    }
+    vec2 operator-(const vec2& v) noexcept
+    {
+        glm::vec2 result = -glm::vec2{v.x, v.y};
+        return vec2{result.x, result.y};
+    }
+    bool operator==(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::vec2{a.x, a.y} == glm::vec2{b.x, b.y};
+    }
+    bool operator!=(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::vec2{a.x, a.y} != glm::vec2{b.x, b.y};
+    }
+    vec2& operator+=(vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} + glm::vec2{b.x, b.y};
+        a.x = result.x;
+        a.y = result.y;
+        return a;
+    }
+    vec2& operator-=(vec2& a, const vec2& b) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} - glm::vec2{b.x, b.y};
+        a.x = result.x;
+        a.y = result.y;
+        return a;
+    }
+    vec2& operator*=(vec2& a, float s) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} * s;
+        a.x = result.x;
+        a.y = result.y;
+        return a;
+    }
+    vec2& operator/=(vec2& a, float s) noexcept
+    {
+        glm::vec2 result = glm::vec2{a.x, a.y} / s;
+        a.x = result.x;
+        a.y = result.y;
+        return a;
+    }
+
+    float dot(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::dot(glm::vec2{a.x, a.y}, glm::vec2{b.x, b.y});
+    }
+
+    vec2 normalize(const vec2& v) noexcept
+    {
+        glm::vec2 result = glm::normalize(glm::vec2{v.x, v.y});
+        return vec2{result.x, result.y};
+    }
+
+    float length(const vec2& v) noexcept
+    {
+        return glm::length(glm::vec2{v.x, v.y});
+    }
+
+    float distance(const vec2& a, const vec2& b) noexcept
+    {
+        return glm::distance(glm::vec2{a.x, a.y}, glm::vec2{b.x, b.y});
+    }
+
+    vec2 lerp(const vec2& a, const vec2& b, float t) noexcept
+    {
+        glm::vec2 result = glm::mix(glm::vec2{a.x, a.y}, glm::vec2{b.x, b.y}, t);
+        return vec2{result.x, result.y};
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/vec2.hpp
+++ b/infrastructure/math/vec2.hpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace infrastructure::math
+{
+    /** @brief 2D float vector. Layout-compatible with @c glm::vec2. */
+    struct vec2
+    {
+        float x{0.0f};
+        float y{0.0f};
+
+        constexpr vec2() noexcept = default;
+        constexpr explicit vec2(float scalar) noexcept : x{scalar}, y{scalar} {}
+        constexpr vec2(float in_x, float in_y) noexcept : x{in_x}, y{in_y} {}
+
+        const float* data() const noexcept
+        {
+            return &x;
+        }
+        float* data() noexcept
+        {
+            return &x;
+        }
+    };
+
+    vec2 operator+(const vec2& a, const vec2& b) noexcept;
+    vec2 operator-(const vec2& a, const vec2& b) noexcept;
+    vec2 operator*(const vec2& a, const vec2& b) noexcept;
+    vec2 operator/(const vec2& a, const vec2& b) noexcept;
+    vec2 operator*(const vec2& v, float s) noexcept;
+    vec2 operator*(float s, const vec2& v) noexcept;
+    vec2 operator/(const vec2& v, float s) noexcept;
+    vec2 operator-(const vec2& v) noexcept;
+    bool operator==(const vec2& a, const vec2& b) noexcept;
+    bool operator!=(const vec2& a, const vec2& b) noexcept;
+    vec2& operator+=(vec2& a, const vec2& b) noexcept;
+    vec2& operator-=(vec2& a, const vec2& b) noexcept;
+    vec2& operator*=(vec2& a, float s) noexcept;
+    vec2& operator/=(vec2& a, float s) noexcept;
+
+    float dot(const vec2& a, const vec2& b) noexcept;
+    vec2 normalize(const vec2& v) noexcept;
+    float length(const vec2& v) noexcept;
+    float distance(const vec2& a, const vec2& b) noexcept;
+    vec2 lerp(const vec2& a, const vec2& b, float t) noexcept;
+} // namespace infrastructure::math

--- a/infrastructure/math/vec3.cpp
+++ b/infrastructure/math/vec3.cpp
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/vec3.hpp>
+
+#include <glm/glm.hpp>
+
+namespace infrastructure::math
+{
+    vec3 operator+(const vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} + glm::vec3{b.x, b.y, b.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator-(const vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} - glm::vec3{b.x, b.y, b.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator*(const vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} * glm::vec3{b.x, b.y, b.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator/(const vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} / glm::vec3{b.x, b.y, b.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator*(const vec3& v, float s) noexcept
+    {
+        glm::vec3 result = glm::vec3{v.x, v.y, v.z} * s;
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator*(float s, const vec3& v) noexcept
+    {
+        glm::vec3 result = s * glm::vec3{v.x, v.y, v.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator/(const vec3& v, float s) noexcept
+    {
+        glm::vec3 result = glm::vec3{v.x, v.y, v.z} / s;
+        return vec3{result.x, result.y, result.z};
+    }
+    vec3 operator-(const vec3& v) noexcept
+    {
+        glm::vec3 result = -glm::vec3{v.x, v.y, v.z};
+        return vec3{result.x, result.y, result.z};
+    }
+    bool operator==(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::vec3{a.x, a.y, a.z} == glm::vec3{b.x, b.y, b.z};
+    }
+    bool operator!=(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::vec3{a.x, a.y, a.z} != glm::vec3{b.x, b.y, b.z};
+    }
+    vec3& operator+=(vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} + glm::vec3{b.x, b.y, b.z};
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        return a;
+    }
+    vec3& operator-=(vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} - glm::vec3{b.x, b.y, b.z};
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        return a;
+    }
+    vec3& operator*=(vec3& a, float s) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} * s;
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        return a;
+    }
+    vec3& operator/=(vec3& a, float s) noexcept
+    {
+        glm::vec3 result = glm::vec3{a.x, a.y, a.z} / s;
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        return a;
+    }
+
+    float dot(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::dot(glm::vec3{a.x, a.y, a.z}, glm::vec3{b.x, b.y, b.z});
+    }
+
+    vec3 cross(const vec3& a, const vec3& b) noexcept
+    {
+        glm::vec3 result = glm::cross(glm::vec3{a.x, a.y, a.z}, glm::vec3{b.x, b.y, b.z});
+        return vec3{result.x, result.y, result.z};
+    }
+
+    vec3 normalize(const vec3& v) noexcept
+    {
+        glm::vec3 result = glm::normalize(glm::vec3{v.x, v.y, v.z});
+        return vec3{result.x, result.y, result.z};
+    }
+
+    float length(const vec3& v) noexcept
+    {
+        return glm::length(glm::vec3{v.x, v.y, v.z});
+    }
+
+    float distance(const vec3& a, const vec3& b) noexcept
+    {
+        return glm::distance(glm::vec3{a.x, a.y, a.z}, glm::vec3{b.x, b.y, b.z});
+    }
+
+    vec3 lerp(const vec3& a, const vec3& b, float t) noexcept
+    {
+        glm::vec3 result = glm::mix(glm::vec3{a.x, a.y, a.z}, glm::vec3{b.x, b.y, b.z}, t);
+        return vec3{result.x, result.y, result.z};
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/vec3.hpp
+++ b/infrastructure/math/vec3.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+namespace infrastructure::math
+{
+    /** @brief 3D float vector. Layout-compatible with @c glm::vec3. */
+    struct vec3
+    {
+        float x{0.0f};
+        float y{0.0f};
+        float z{0.0f};
+
+        constexpr vec3() noexcept = default;
+        constexpr explicit vec3(float scalar) noexcept : x{scalar}, y{scalar}, z{scalar} {}
+        constexpr vec3(float in_x, float in_y, float in_z) noexcept : x{in_x}, y{in_y}, z{in_z} {}
+
+        const float* data() const noexcept
+        {
+            return &x;
+        }
+        float* data() noexcept
+        {
+            return &x;
+        }
+    };
+
+    vec3 operator+(const vec3& a, const vec3& b) noexcept;
+    vec3 operator-(const vec3& a, const vec3& b) noexcept;
+    vec3 operator*(const vec3& a, const vec3& b) noexcept;
+    vec3 operator/(const vec3& a, const vec3& b) noexcept;
+    vec3 operator*(const vec3& v, float s) noexcept;
+    vec3 operator*(float s, const vec3& v) noexcept;
+    vec3 operator/(const vec3& v, float s) noexcept;
+    vec3 operator-(const vec3& v) noexcept;
+    bool operator==(const vec3& a, const vec3& b) noexcept;
+    bool operator!=(const vec3& a, const vec3& b) noexcept;
+    vec3& operator+=(vec3& a, const vec3& b) noexcept;
+    vec3& operator-=(vec3& a, const vec3& b) noexcept;
+    vec3& operator*=(vec3& a, float s) noexcept;
+    vec3& operator/=(vec3& a, float s) noexcept;
+
+    float dot(const vec3& a, const vec3& b) noexcept;
+    vec3 cross(const vec3& a, const vec3& b) noexcept;
+    vec3 normalize(const vec3& v) noexcept;
+    float length(const vec3& v) noexcept;
+    float distance(const vec3& a, const vec3& b) noexcept;
+    vec3 lerp(const vec3& a, const vec3& b, float t) noexcept;
+} // namespace infrastructure::math

--- a/infrastructure/math/vec4.cpp
+++ b/infrastructure/math/vec4.cpp
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/vec4.hpp>
+
+#include <glm/glm.hpp>
+
+namespace infrastructure::math
+{
+    vec4 operator+(const vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} + glm::vec4{b.x, b.y, b.z, b.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator-(const vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} - glm::vec4{b.x, b.y, b.z, b.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator*(const vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} * glm::vec4{b.x, b.y, b.z, b.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator/(const vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} / glm::vec4{b.x, b.y, b.z, b.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator*(const vec4& v, float s) noexcept
+    {
+        glm::vec4 result = glm::vec4{v.x, v.y, v.z, v.w} * s;
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator*(float s, const vec4& v) noexcept
+    {
+        glm::vec4 result = s * glm::vec4{v.x, v.y, v.z, v.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator/(const vec4& v, float s) noexcept
+    {
+        glm::vec4 result = glm::vec4{v.x, v.y, v.z, v.w} / s;
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    vec4 operator-(const vec4& v) noexcept
+    {
+        glm::vec4 result = -glm::vec4{v.x, v.y, v.z, v.w};
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+    bool operator==(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::vec4{a.x, a.y, a.z, a.w} == glm::vec4{b.x, b.y, b.z, b.w};
+    }
+    bool operator!=(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::vec4{a.x, a.y, a.z, a.w} != glm::vec4{b.x, b.y, b.z, b.w};
+    }
+    vec4& operator+=(vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} + glm::vec4{b.x, b.y, b.z, b.w};
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        a.w = result.w;
+        return a;
+    }
+    vec4& operator-=(vec4& a, const vec4& b) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} - glm::vec4{b.x, b.y, b.z, b.w};
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        a.w = result.w;
+        return a;
+    }
+    vec4& operator*=(vec4& a, float s) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} * s;
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        a.w = result.w;
+        return a;
+    }
+    vec4& operator/=(vec4& a, float s) noexcept
+    {
+        glm::vec4 result = glm::vec4{a.x, a.y, a.z, a.w} / s;
+        a.x = result.x;
+        a.y = result.y;
+        a.z = result.z;
+        a.w = result.w;
+        return a;
+    }
+
+    float dot(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::dot(glm::vec4{a.x, a.y, a.z, a.w}, glm::vec4{b.x, b.y, b.z, b.w});
+    }
+
+    vec4 normalize(const vec4& v) noexcept
+    {
+        glm::vec4 result = glm::normalize(glm::vec4{v.x, v.y, v.z, v.w});
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+
+    float length(const vec4& v) noexcept
+    {
+        return glm::length(glm::vec4{v.x, v.y, v.z, v.w});
+    }
+
+    float distance(const vec4& a, const vec4& b) noexcept
+    {
+        return glm::distance(glm::vec4{a.x, a.y, a.z, a.w}, glm::vec4{b.x, b.y, b.z, b.w});
+    }
+
+    vec4 lerp(const vec4& a, const vec4& b, float t) noexcept
+    {
+        glm::vec4 result = glm::mix(glm::vec4{a.x, a.y, a.z, a.w}, glm::vec4{b.x, b.y, b.z, b.w}, t);
+        return vec4{result.x, result.y, result.z, result.w};
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/vec4.hpp
+++ b/infrastructure/math/vec4.hpp
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/vec3.hpp>
+
+namespace infrastructure::math
+{
+    /** @brief 4D float vector. Layout-compatible with @c glm::vec4. */
+    struct vec4
+    {
+        float x{0.0f};
+        float y{0.0f};
+        float z{0.0f};
+        float w{0.0f};
+
+        constexpr vec4() noexcept = default;
+        constexpr explicit vec4(float scalar) noexcept : x{scalar}, y{scalar}, z{scalar}, w{scalar} {}
+        constexpr vec4(float in_x, float in_y, float in_z, float in_w) noexcept : x{in_x}, y{in_y}, z{in_z}, w{in_w} {}
+        constexpr vec4(const vec3& xyz, float in_w) noexcept : x{xyz.x}, y{xyz.y}, z{xyz.z}, w{in_w} {}
+
+        const float* data() const noexcept
+        {
+            return &x;
+        }
+        float* data() noexcept
+        {
+            return &x;
+        }
+    };
+
+    vec4 operator+(const vec4& a, const vec4& b) noexcept;
+    vec4 operator-(const vec4& a, const vec4& b) noexcept;
+    vec4 operator*(const vec4& a, const vec4& b) noexcept;
+    vec4 operator/(const vec4& a, const vec4& b) noexcept;
+    vec4 operator*(const vec4& v, float s) noexcept;
+    vec4 operator*(float s, const vec4& v) noexcept;
+    vec4 operator/(const vec4& v, float s) noexcept;
+    vec4 operator-(const vec4& v) noexcept;
+    bool operator==(const vec4& a, const vec4& b) noexcept;
+    bool operator!=(const vec4& a, const vec4& b) noexcept;
+    vec4& operator+=(vec4& a, const vec4& b) noexcept;
+    vec4& operator-=(vec4& a, const vec4& b) noexcept;
+    vec4& operator*=(vec4& a, float s) noexcept;
+    vec4& operator/=(vec4& a, float s) noexcept;
+
+    float dot(const vec4& a, const vec4& b) noexcept;
+    vec4 normalize(const vec4& v) noexcept;
+    float length(const vec4& v) noexcept;
+    float distance(const vec4& a, const vec4& b) noexcept;
+    vec4 lerp(const vec4& a, const vec4& b, float t) noexcept;
+} // namespace infrastructure::math


### PR DESCRIPTION
Move the GLM include out of `infrastructure/math/math.hpp` and into
`infrastructure/math/math.cpp`, which becomes the only translation
unit that names `glm::`. Every consumer of `math.hpp` now sees only
the small POD types and forward declarations, eliminating the
GLM header pull-through that previously hit most of the engine.

The vector, matrix, and quaternion types are POD structs with named
float members and a column-major `float[N]` for matrices. Memory
layout is identical to the corresponding GLM type, so existing
`data()` uniform uploads continue to work unchanged.

Operators and free functions are declared in the header and defined
in `math.cpp`. Default and value constructors stay `constexpr`;
chained operations no longer are, and operators become indirect
calls without LTO — an accepted trade for the build-time and
coupling reduction.

Reverses the trade made in #43, which kept GLM in the public header
for inlining.

Closes #68