### PR TITLE
feat: add aabb, sphere, frustum math types

### DIFF
--- a/infrastructure/math/aabb.cpp
+++ b/infrastructure/math/aabb.cpp
@@ -20,30 +20,37 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
-#pragma once
-
 #include <infrastructure/math/aabb.hpp>
-#include <infrastructure/math/frustum.hpp>
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/sphere.hpp>
-#include <infrastructure/math/vec2.hpp>
-#include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
+
+#include <algorithm>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    vec3 aabb::center() const noexcept
+    {
+        return vec3{(min.x + max.x) * 0.5f, (min.y + max.y) * 0.5f, (min.z + max.z) * 0.5f};
+    }
+
+    vec3 aabb::extents() const noexcept
+    {
+        return vec3{(max.x - min.x) * 0.5f, (max.y - min.y) * 0.5f, (max.z - min.z) * 0.5f};
+    }
+
+    bool aabb::contains(const vec3& point) const noexcept
+    {
+        return point.x >= min.x && point.x <= max.x && point.y >= min.y && point.y <= max.y && point.z >= min.z &&
+               point.z <= max.z;
+    }
+
+    aabb merge(const aabb& a, const aabb& b) noexcept
+    {
+        return aabb{vec3{std::min(a.min.x, b.min.x), std::min(a.min.y, b.min.y), std::min(a.min.z, b.min.z)},
+                    vec3{std::max(a.max.x, b.max.x), std::max(a.max.y, b.max.y), std::max(a.max.z, b.max.z)}};
+    }
+
+    aabb merge(const aabb& a, const vec3& point) noexcept
+    {
+        return aabb{vec3{std::min(a.min.x, point.x), std::min(a.min.y, point.y), std::min(a.min.z, point.z)},
+                    vec3{std::max(a.max.x, point.x), std::max(a.max.y, point.y), std::max(a.max.z, point.z)}};
+    }
 } // namespace infrastructure::math

--- a/infrastructure/math/aabb.hpp
+++ b/infrastructure/math/aabb.hpp
@@ -20,30 +20,26 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
 #pragma once
 
-#include <infrastructure/math/aabb.hpp>
-#include <infrastructure/math/frustum.hpp>
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/sphere.hpp>
-#include <infrastructure/math/vec2.hpp>
 #include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    /** @brief Axis-aligned bounding box defined by two corner points. */
+    struct aabb
+    {
+        vec3 min{0.0f, 0.0f, 0.0f};
+        vec3 max{0.0f, 0.0f, 0.0f};
+
+        constexpr aabb() noexcept = default;
+        constexpr aabb(const vec3& in_min, const vec3& in_max) noexcept : min{in_min}, max{in_max} {}
+
+        vec3 center() const noexcept;
+        vec3 extents() const noexcept;
+        bool contains(const vec3& point) const noexcept;
+    };
+
+    aabb merge(const aabb& a, const aabb& b) noexcept;
+    aabb merge(const aabb& a, const vec3& point) noexcept;
 } // namespace infrastructure::math

--- a/infrastructure/math/frustum.cpp
+++ b/infrastructure/math/frustum.cpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/frustum.hpp>
+
+#include <cmath>
+
+namespace infrastructure::math
+{
+    namespace
+    {
+        // Read row r of a column-major mat4 (m[col*4 + row]).
+        vec4 row_of(const mat4& m, int r) noexcept
+        {
+            return vec4{m.m[0 * 4 + r], m.m[1 * 4 + r], m.m[2 * 4 + r], m.m[3 * 4 + r]};
+        }
+
+        vec4 normalize_plane(const vec4& p) noexcept
+        {
+            const float length = std::sqrt(p.x * p.x + p.y * p.y + p.z * p.z);
+            if (length <= 0.0f)
+            {
+                return p;
+            }
+            const float inv = 1.0f / length;
+            return vec4{p.x * inv, p.y * inv, p.z * inv, p.w * inv};
+        }
+    } // namespace
+
+    frustum frustum::from_view_projection(const mat4& view_projection) noexcept
+    {
+        const vec4 r0 = row_of(view_projection, 0);
+        const vec4 r1 = row_of(view_projection, 1);
+        const vec4 r2 = row_of(view_projection, 2);
+        const vec4 r3 = row_of(view_projection, 3);
+
+        frustum f;
+        f.planes[left] = normalize_plane(vec4{r3.x + r0.x, r3.y + r0.y, r3.z + r0.z, r3.w + r0.w});
+        f.planes[right] = normalize_plane(vec4{r3.x - r0.x, r3.y - r0.y, r3.z - r0.z, r3.w - r0.w});
+        f.planes[bottom] = normalize_plane(vec4{r3.x + r1.x, r3.y + r1.y, r3.z + r1.z, r3.w + r1.w});
+        f.planes[top] = normalize_plane(vec4{r3.x - r1.x, r3.y - r1.y, r3.z - r1.z, r3.w - r1.w});
+        f.planes[near_p] = normalize_plane(vec4{r3.x + r2.x, r3.y + r2.y, r3.z + r2.z, r3.w + r2.w});
+        f.planes[far_p] = normalize_plane(vec4{r3.x - r2.x, r3.y - r2.y, r3.z - r2.z, r3.w - r2.w});
+        return f;
+    }
+
+    bool frustum::intersects(const aabb& box) const noexcept
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            const vec4& p = planes[i];
+            // Positive vertex: corner of the box farthest along the plane normal.
+            const float px = (p.x >= 0.0f) ? box.max.x : box.min.x;
+            const float py = (p.y >= 0.0f) ? box.max.y : box.min.y;
+            const float pz = (p.z >= 0.0f) ? box.max.z : box.min.z;
+            if (p.x * px + p.y * py + p.z * pz + p.w < 0.0f)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool frustum::intersects(const sphere& s) const noexcept
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            const vec4& p = planes[i];
+            const float distance = p.x * s.center.x + p.y * s.center.y + p.z * s.center.z + p.w;
+            if (distance < -s.radius)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/frustum.hpp
+++ b/infrastructure/math/frustum.hpp
@@ -20,30 +20,48 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
 #pragma once
 
 #include <infrastructure/math/aabb.hpp>
-#include <infrastructure/math/frustum.hpp>
-#include <infrastructure/math/mat3.hpp>
 #include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
 #include <infrastructure/math/sphere.hpp>
-#include <infrastructure/math/vec2.hpp>
-#include <infrastructure/math/vec3.hpp>
 #include <infrastructure/math/vec4.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    /**
+     * @brief View frustum represented by six planes in world space.
+     *
+     * Each plane is stored as @c vec4(n.x, n.y, n.z, d) with the
+     * normal pointing into the visible volume; a point @c p is on
+     * the inside of a plane when @c dot(n, p) + d >= 0. Planes are
+     * normalized so signed-distance tests are valid.
+     *
+     * The @c near_p / @c far_p suffixes avoid the @c near / @c far
+     * macros that some Windows headers still define.
+     */
+    struct frustum
+    {
+        enum plane_index
+        {
+            left = 0,
+            right = 1,
+            bottom = 2,
+            top = 3,
+            near_p = 4,
+            far_p = 5,
+            count = 6
+        };
+
+        vec4 planes[count]{};
+
+        /**
+         * @brief Extract a frustum from a view-projection matrix using
+         *        the Gribb/Hartmann method (planes in world space).
+         */
+        static frustum from_view_projection(const mat4& view_projection) noexcept;
+
+        bool intersects(const aabb& box) const noexcept;
+        bool intersects(const sphere& s) const noexcept;
+    };
 } // namespace infrastructure::math

--- a/infrastructure/math/sphere.cpp
+++ b/infrastructure/math/sphere.cpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infrastructure/math/sphere.hpp>
+
+#include <cmath>
+
+namespace infrastructure::math
+{
+    bool sphere::contains(const vec3& point) const noexcept
+    {
+        const float dx = point.x - center.x;
+        const float dy = point.y - center.y;
+        const float dz = point.z - center.z;
+        return (dx * dx + dy * dy + dz * dz) <= (radius * radius);
+    }
+
+    sphere merge(const sphere& a, const sphere& b) noexcept
+    {
+        const float dx = b.center.x - a.center.x;
+        const float dy = b.center.y - a.center.y;
+        const float dz = b.center.z - a.center.z;
+        const float distance_sq = dx * dx + dy * dy + dz * dz;
+        const float radius_diff = b.radius - a.radius;
+
+        // One sphere already encloses the other; return the larger.
+        if (radius_diff * radius_diff >= distance_sq)
+        {
+            return (a.radius >= b.radius) ? a : b;
+        }
+
+        const float distance = std::sqrt(distance_sq);
+        const float new_radius = (distance + a.radius + b.radius) * 0.5f;
+        const float t = (distance > 0.0f) ? ((new_radius - a.radius) / distance) : 0.0f;
+        return sphere{vec3{a.center.x + dx * t, a.center.y + dy * t, a.center.z + dz * t}, new_radius};
+    }
+
+    sphere merge(const sphere& a, const vec3& point) noexcept
+    {
+        const float dx = point.x - a.center.x;
+        const float dy = point.y - a.center.y;
+        const float dz = point.z - a.center.z;
+        const float distance_sq = dx * dx + dy * dy + dz * dz;
+
+        // Point already inside.
+        if (distance_sq <= a.radius * a.radius)
+        {
+            return a;
+        }
+
+        const float distance = std::sqrt(distance_sq);
+        const float new_radius = (distance + a.radius) * 0.5f;
+        const float t = (new_radius - a.radius) / distance;
+        return sphere{vec3{a.center.x + dx * t, a.center.y + dy * t, a.center.z + dz * t}, new_radius};
+    }
+} // namespace infrastructure::math

--- a/infrastructure/math/sphere.hpp
+++ b/infrastructure/math/sphere.hpp
@@ -20,30 +20,24 @@
  * SOFTWARE.
  */
 
-/**
- * @file math.hpp
- * @brief Umbrella include for the engine-owned math types.
- *
- * Each vector, matrix, and quaternion type lives in its own header next to
- * this one. The implementations are in matching @c .cpp files, which are
- * the only translation units that include and name @c glm:: . Including
- * this header pulls every public math type into scope while keeping GLM
- * out of the consumer's preprocessor input.
- */
-
 #pragma once
 
-#include <infrastructure/math/aabb.hpp>
-#include <infrastructure/math/frustum.hpp>
-#include <infrastructure/math/mat3.hpp>
-#include <infrastructure/math/mat4.hpp>
-#include <infrastructure/math/quat.hpp>
-#include <infrastructure/math/sphere.hpp>
-#include <infrastructure/math/vec2.hpp>
 #include <infrastructure/math/vec3.hpp>
-#include <infrastructure/math/vec4.hpp>
 
 namespace infrastructure::math
 {
-    float lerp(float a, float b, float t) noexcept;
+    /** @brief Bounding sphere defined by a center point and a radius. */
+    struct sphere
+    {
+        vec3 center{0.0f, 0.0f, 0.0f};
+        float radius{0.0f};
+
+        constexpr sphere() noexcept = default;
+        constexpr sphere(const vec3& in_center, float in_radius) noexcept : center{in_center}, radius{in_radius} {}
+
+        bool contains(const vec3& point) const noexcept;
+    };
+
+    sphere merge(const sphere& a, const sphere& b) noexcept;
+    sphere merge(const sphere& a, const vec3& point) noexcept;
 } // namespace infrastructure::math


### PR DESCRIPTION
Add three spatial-primitive math types under `infrastructure/math/`.
`aabb` stores `vec3 min`/`max` with `center` / `extents` / `contains`
and merge helpers. `sphere` stores `vec3 center` plus `float radius`
with `contains` and merge helpers. `frustum` stores six `vec4` planes
`(n.x, n.y, n.z, d)`, normalized after extraction, with a static
`from_view_projection` that runs Gribb/Hartmann on the supplied
view-projection matrix (column-major row reads) and `intersects`
overloads against `aabb` and `sphere` that walk the planes for a
conservative outside test.

Built directly on the POD math types from #68 so no GLM leaks through
the public headers — only the matching `.cpp` files name `glm::`, in
line with the rest of the math module. The frustum's plane-index
enum spells out `near_p` / `far_p` to side-step the `near` / `far`
macros that some Windows headers still define.

No culling is wired up by this change — these are intentionally just
the primitives. Per-renderable cull early-out, a central cull stage,
and any spatial index remain out of scope.

Closes #69