### PR TITLE
feat: add camera::get_frustum() accessor

### DIFF
--- a/rendering_engine/camera/camera.cpp
+++ b/rendering_engine/camera/camera.cpp
@@ -73,3 +73,8 @@ void rendering_engine::camera::invalidate_projection_matrix()
 {
     m_is_projection_matrix_dirty = true;
 }
+
+const infrastructure::math::frustum rendering_engine::camera::get_frustum() const
+{
+    return infrastructure::math::frustum::from_view_projection(get_projection_matrix() * get_view_matrix());
+}

--- a/rendering_engine/camera/camera.hpp
+++ b/rendering_engine/camera/camera.hpp
@@ -46,6 +46,8 @@ namespace rendering_engine
         void invalidate_projection_matrix();
         virtual const infrastructure::math::mat4 get_projection_matrix() const = 0;
 
+        const infrastructure::math::frustum get_frustum() const;
+
     protected:
         mutable infrastructure::math::mat4 m_view_matrix;
         mutable bool m_is_view_matrix_dirty;


### PR DESCRIPTION
Add a `get_frustum()` accessor on the base `rendering_engine::camera`
that returns the camera's current world-space frustum, computed by
running `infrastructure::math::frustum::from_view_projection` on
`get_projection_matrix() * get_view_matrix()`. The multiplication
order matches how the basic renderer composes its MVP for shader
uploads, so the planes come out in world space as Gribb/Hartmann
expects.

The implementation lives on the base class and works unchanged for
both `perspective_camera` and `orthographic_camera` — frustum
extraction depends only on the view-projection matrix, not on which
projection produced it. Recomputed on every call; cheap enough not to
warrant caching, and the existing `m_is_*_dirty` flags on `view` /
`projection` already keep their inputs warm.

Naming follows the surrounding `get_view_matrix()` /
`get_projection_matrix()` accessors. No new includes are needed —
the `infrastructure/math/math.hpp` umbrella header already pulls in
`frustum.hpp` via the change from #80.

This is just the accessor. Anything that consumes the frustum —
per-renderable cull early-out, picking, shadow setups — stays out of
scope.

Closes #70