### PR TITLE
refactor: remove renderer::get_current_renderer static state

### DIFF
--- a/rendering_engine/renderers/renderer.cpp
+++ b/rendering_engine/renderers/renderer.cpp
@@ -27,16 +27,9 @@
 
 namespace rendering_engine::renderers
 {
-    renderer* renderer::m_current_renderer = nullptr;
-
     renderer::~renderer()
     {
         destruct_pipeline();
-    }
-
-    renderer* renderer::get_current_renderer()
-    {
-        return m_current_renderer;
     }
 
     gpu::pipeline renderer::pipeline_handle() const
@@ -56,14 +49,10 @@ namespace rendering_engine::renderers
 
     void renderer::begin(gpu::render_pass_encoder& encoder)
     {
-        m_current_renderer = this;
         encoder.set_pipeline(m_pipeline);
     }
 
-    void renderer::end(gpu::render_pass_encoder& /*encoder*/)
-    {
-        m_current_renderer = nullptr;
-    }
+    void renderer::end(gpu::render_pass_encoder& /*encoder*/) {}
 
     void renderer::construct_pipeline(const std::string& vertex_source,
                                       const std::string& fragment_source,

--- a/rendering_engine/renderers/renderer.hpp
+++ b/rendering_engine/renderers/renderer.hpp
@@ -68,10 +68,6 @@ namespace rendering_engine
             // @c set_pipeline.
             virtual void end(gpu::render_pass_encoder& encoder);
 
-            // Currently-active renderer for the main thread, or null
-            // when no scene/UI pass is being recorded.
-            static renderer* get_current_renderer();
-
         protected:
             renderer() = default;
 
@@ -93,8 +89,6 @@ namespace rendering_engine
             gpu::pipeline m_pipeline{};
             gpu::bind_group_layout m_draw_layout{};
             gpu::bind_group_layout m_frame_layout{};
-
-            static renderer* m_current_renderer;
         };
     } // namespace renderers
 


### PR DESCRIPTION
`renderer::m_current_renderer` was the pre-encoder hand-off slot — uniform-upload helpers used to fetch the active renderer through `get_current_renderer()` and call back into it during a draw. After the GPU device refactor (#64) every recording call already takes the encoder as a parameter, and after the material + pass split (#84) per-frame setup lives on the pass. The static is now only ever written by `begin()` / `end()` and never read.

Drop the declaration, the static-member definition, and both writes. `end()` collapses to a no-op, which matches the doc comment it already carried ("Default is a no-op; the GL backend's pipeline state stays bound until the next `set_pipeline`"). The renderer base class itself stays untouched per the issue — #75 handles its removal along with the rest of `renderers/`.

Verified there are no other call sites with `grep -rn 'm_current_renderer\|get_current_renderer'`; the seven hits the issue listed were the only ones in the tree.

Closes #74

---
_Generated by [Claude Code](https://claude.ai/code/session_015EX9rxJ7Jmmkbq65vXVtor)_