### PR TITLE
feat: extend gpu device with compute, tessellation, storage, indirect, copy, and barriers

### DIFF
--- a/rendering_engine/gpu/backend/opengl/gl_command_encoder.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_command_encoder.cpp
@@ -30,6 +30,99 @@ namespace rendering_engine::gpu::backend::opengl
 {
     namespace
     {
+        const bind_group_layout_entry* find_layout_entry(const bind_group_layout_descriptor& descriptor,
+                                                         uint32_t binding)
+        {
+            for (const auto& entry : descriptor.entries)
+            {
+                if (entry.binding == binding)
+                {
+                    return &entry;
+                }
+            }
+            return nullptr;
+        }
+
+        void apply_bind_group(gl_device& device, const gl_bind_group& bg)
+        {
+            // Bindings come straight from the SPIR-V @c Binding
+            // decoration. UBO / SSBO / texture / image binding
+            // namespaces are disjoint in OpenGL, so the same numeric
+            // binding can appear on entries of different kinds
+            // without collision.
+            const auto* layout = device.lookup_bind_group_layout(bg.layout);
+            for (const auto& value : bg.entries)
+            {
+                switch (value.kind)
+                {
+                case binding_kind::uniform_buffer:
+                {
+                    auto* buf = device.lookup_buffer(value.buffer_value);
+                    if (buf != nullptr && buf->object_id != 0)
+                    {
+                        glBindBufferBase(GL_UNIFORM_BUFFER, value.binding, buf->object_id);
+                    }
+                    break;
+                }
+                case binding_kind::storage_buffer:
+                {
+                    auto* buf = device.lookup_buffer(value.buffer_value);
+                    if (buf != nullptr && buf->object_id != 0)
+                    {
+                        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, value.binding, buf->object_id);
+                    }
+                    break;
+                }
+                case binding_kind::texture:
+                {
+                    auto* tex = device.lookup_texture(value.texture_value);
+                    if (tex != nullptr && tex->object_id != 0)
+                    {
+                        glActiveTexture(GL_TEXTURE0 + value.binding);
+                        glBindTexture(tex->target, tex->object_id);
+                    }
+                    break;
+                }
+                case binding_kind::storage_texture:
+                {
+                    auto* tex = device.lookup_texture(value.texture_value);
+                    if (tex == nullptr || tex->object_id == 0 || layout == nullptr)
+                    {
+                        break;
+                    }
+                    const auto* entry = find_layout_entry(layout->descriptor, value.binding);
+                    if (entry == nullptr)
+                    {
+                        LOG_WRN("set_bind_group: storage_texture has no matching layout entry");
+                        break;
+                    }
+                    const auto fmt = to_gl_texture_format(entry->storage_format);
+                    const GLboolean layered =
+                        (tex->target == GL_TEXTURE_3D || tex->target == GL_TEXTURE_CUBE_MAP) ? GL_TRUE : GL_FALSE;
+                    glBindImageTexture(value.binding,
+                                       tex->object_id,
+                                       0,
+                                       layered,
+                                       0,
+                                       to_gl_storage_access(entry->storage_access_mode),
+                                       static_cast<GLenum>(fmt.internal_format));
+                    break;
+                }
+                case binding_kind::sampler:
+                {
+                    auto* samp = device.lookup_sampler(value.sampler_value);
+                    (void)samp;
+                    // Sampler state is currently baked into the
+                    // texture object at create time — no separate
+                    // sampler object is bound. Reserved here so a
+                    // future Vulkan-style separate-sampler path
+                    // slots in without churning the call sites.
+                    break;
+                }
+                }
+            }
+        }
+
         void apply_pipeline_state(const gl_pipeline& pipe)
         {
             // Blend
@@ -137,6 +230,11 @@ namespace rendering_engine::gpu::backend::opengl
             LOG_WRN("set_pipeline: invalid pipeline handle");
             return;
         }
+        if (pipe->is_compute)
+        {
+            LOG_WRN("set_pipeline: compute pipeline bound on render pass encoder");
+            return;
+        }
         m_pipeline_handle = pipeline_handle;
         m_program_id = pipe->program_id;
         m_vao_id = pipe->vao_id;
@@ -145,6 +243,10 @@ namespace rendering_engine::gpu::backend::opengl
         glUseProgram(m_program_id);
         glBindVertexArray(m_vao_id);
         apply_pipeline_state(*pipe);
+        if (pipe->topology == primitive_topology::patches && pipe->patch_control_points > 0)
+        {
+            glPatchParameteri(GL_PATCH_VERTICES, static_cast<GLint>(pipe->patch_control_points));
+        }
         m_index_buffer_bound = false;
     }
 
@@ -208,50 +310,7 @@ namespace rendering_engine::gpu::backend::opengl
             LOG_WRN("set_bind_group: group index out of range");
             return;
         }
-
-        // Bindings come straight from the SPIR-V's @c Binding
-        // decoration: UBOs are bound at the named UBO unit, textures
-        // are bound at the matching texture image unit, and samplers
-        // (Vulkan-style separate sampler objects) are attached via
-        // @c glBindSampler. UBO and texture/sampler binding namespaces
-        // are disjoint in OpenGL, so the same numeric binding can
-        // appear on entries of different kinds without collision.
-        for (const auto& value : bg->entries)
-        {
-            switch (value.kind)
-            {
-            case binding_kind::uniform_buffer:
-            {
-                auto* buf = m_device.lookup_buffer(value.buffer_value);
-                if (buf != nullptr && buf->object_id != 0)
-                {
-                    glBindBufferBase(GL_UNIFORM_BUFFER, value.binding, buf->object_id);
-                }
-                break;
-            }
-            case binding_kind::texture:
-            {
-                auto* tex = m_device.lookup_texture(value.texture_value);
-                if (tex != nullptr && tex->object_id != 0)
-                {
-                    glActiveTexture(GL_TEXTURE0 + value.binding);
-                    glBindTexture(tex->target, tex->object_id);
-                }
-                break;
-            }
-            case binding_kind::sampler:
-            {
-                auto* samp = m_device.lookup_sampler(value.sampler_value);
-                (void)samp;
-                // Sampler state is currently baked into the texture
-                // object at create time — no separate sampler object
-                // is bound. Reserved here so a future Vulkan-style
-                // separate-sampler path slots in without churning the
-                // call sites.
-                break;
-            }
-            }
-        }
+        apply_bind_group(m_device, *bg);
     }
 
     void gl_render_pass_encoder::set_viewport(int x, int y, int width, int height)
@@ -276,6 +335,48 @@ namespace rendering_engine::gpu::backend::opengl
             m_topology, static_cast<GLsizei>(index_count), m_index_type, reinterpret_cast<const GLvoid*>(byte_offset));
     }
 
+    void gl_render_pass_encoder::draw_indexed_indirect(buffer indirect_buffer, size_t offset)
+    {
+        if (!m_index_buffer_bound)
+        {
+            LOG_WRN("draw_indexed_indirect: no index buffer bound");
+            return;
+        }
+        auto* indirect = m_device.lookup_buffer(indirect_buffer);
+        if (indirect == nullptr || indirect->object_id == 0)
+        {
+            LOG_WRN("draw_indexed_indirect: invalid indirect buffer");
+            return;
+        }
+        glBindBuffer(GL_DRAW_INDIRECT_BUFFER, indirect->object_id);
+        glDrawElementsIndirect(
+            m_topology, m_index_type, reinterpret_cast<const GLvoid*>(static_cast<intptr_t>(offset)));
+    }
+
+    void gl_render_pass_encoder::multi_draw_indexed_indirect(buffer indirect_buffer,
+                                                             size_t offset,
+                                                             uint32_t draw_count,
+                                                             uint32_t stride)
+    {
+        if (!m_index_buffer_bound)
+        {
+            LOG_WRN("multi_draw_indexed_indirect: no index buffer bound");
+            return;
+        }
+        auto* indirect = m_device.lookup_buffer(indirect_buffer);
+        if (indirect == nullptr || indirect->object_id == 0)
+        {
+            LOG_WRN("multi_draw_indexed_indirect: invalid indirect buffer");
+            return;
+        }
+        glBindBuffer(GL_DRAW_INDIRECT_BUFFER, indirect->object_id);
+        glMultiDrawElementsIndirect(m_topology,
+                                    m_index_type,
+                                    reinterpret_cast<const GLvoid*>(static_cast<intptr_t>(offset)),
+                                    static_cast<GLsizei>(draw_count),
+                                    static_cast<GLsizei>(stride));
+    }
+
     void gl_render_pass_encoder::end()
     {
         if (!m_active)
@@ -287,6 +388,73 @@ namespace rendering_engine::gpu::backend::opengl
         m_active = false;
     }
 
+    // -- gl_compute_pass_encoder ----------------------------------
+
+    gl_compute_pass_encoder::gl_compute_pass_encoder(gl_device& device) : m_device{device}, m_active{true} {}
+
+    gl_compute_pass_encoder::~gl_compute_pass_encoder()
+    {
+        if (m_active)
+        {
+            end();
+        }
+    }
+
+    void gl_compute_pass_encoder::set_pipeline(pipeline pipeline_handle)
+    {
+        auto* pipe = m_device.lookup_pipeline(pipeline_handle);
+        if (pipe == nullptr)
+        {
+            LOG_WRN("compute set_pipeline: invalid pipeline handle");
+            return;
+        }
+        if (!pipe->is_compute)
+        {
+            LOG_WRN("compute set_pipeline: graphics pipeline bound on compute pass encoder");
+            return;
+        }
+        m_pipeline_handle = pipeline_handle;
+        m_program_id = pipe->program_id;
+        glUseProgram(m_program_id);
+    }
+
+    void gl_compute_pass_encoder::set_bind_group(uint32_t group, bind_group bind_group_handle)
+    {
+        auto* pipe = m_device.lookup_pipeline(m_pipeline_handle);
+        auto* bg = m_device.lookup_bind_group(bind_group_handle);
+        if (pipe == nullptr || bg == nullptr)
+        {
+            LOG_WRN("compute set_bind_group: invalid pipeline / bind_group");
+            return;
+        }
+        if (group >= pipe->bind_group_layouts.size())
+        {
+            LOG_WRN("compute set_bind_group: group index out of range");
+            return;
+        }
+        apply_bind_group(m_device, *bg);
+    }
+
+    void gl_compute_pass_encoder::dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z)
+    {
+        if (m_program_id == 0)
+        {
+            LOG_WRN("dispatch: no compute pipeline bound");
+            return;
+        }
+        glDispatchCompute(group_count_x, group_count_y, group_count_z);
+    }
+
+    void gl_compute_pass_encoder::end()
+    {
+        if (!m_active)
+        {
+            return;
+        }
+        glUseProgram(0);
+        m_active = false;
+    }
+
     // -- gl_command_encoder -----------------------------------------
 
     gl_command_encoder::gl_command_encoder(gl_device& device) : m_device{device} {}
@@ -294,5 +462,61 @@ namespace rendering_engine::gpu::backend::opengl
     std::unique_ptr<render_pass_encoder> gl_command_encoder::begin_render_pass(const render_pass_descriptor& descriptor)
     {
         return std::make_unique<gl_render_pass_encoder>(m_device, descriptor);
+    }
+
+    std::unique_ptr<compute_pass_encoder> gl_command_encoder::begin_compute_pass()
+    {
+        return std::make_unique<gl_compute_pass_encoder>(m_device);
+    }
+
+    void
+    gl_command_encoder::copy_buffer_to_buffer(buffer src, size_t src_offset, buffer dst, size_t dst_offset, size_t size)
+    {
+        auto* src_record = m_device.lookup_buffer(src);
+        auto* dst_record = m_device.lookup_buffer(dst);
+        if (src_record == nullptr || src_record->object_id == 0 || dst_record == nullptr || dst_record->object_id == 0)
+        {
+            LOG_WRN("copy_buffer_to_buffer: invalid src / dst buffer");
+            return;
+        }
+        glBindBuffer(GL_COPY_READ_BUFFER, src_record->object_id);
+        glBindBuffer(GL_COPY_WRITE_BUFFER, dst_record->object_id);
+        glCopyBufferSubData(GL_COPY_READ_BUFFER,
+                            GL_COPY_WRITE_BUFFER,
+                            static_cast<GLintptr>(src_offset),
+                            static_cast<GLintptr>(dst_offset),
+                            static_cast<GLsizeiptr>(size));
+        glBindBuffer(GL_COPY_READ_BUFFER, 0);
+        glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+    }
+
+    void gl_command_encoder::clear_buffer(buffer buffer_handle, size_t offset, size_t size, uint32_t value)
+    {
+        auto* record = m_device.lookup_buffer(buffer_handle);
+        if (record == nullptr || record->object_id == 0)
+        {
+            LOG_WRN("clear_buffer: invalid buffer handle");
+            return;
+        }
+        glBindBuffer(GL_COPY_WRITE_BUFFER, record->object_id);
+        glClearBufferSubData(GL_COPY_WRITE_BUFFER,
+                             GL_R32UI,
+                             static_cast<GLintptr>(offset),
+                             static_cast<GLsizeiptr>(size),
+                             GL_RED_INTEGER,
+                             GL_UNSIGNED_INT,
+                             &value);
+        glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+    }
+
+    void gl_command_encoder::barrier(pipeline_stage /*src_stage*/,
+                                     pipeline_stage /*dst_stage*/,
+                                     access_flag /*src_access*/,
+                                     access_flag dst_access)
+    {
+        // OpenGL collapses pipeline-stage information into the
+        // memory-barrier bitmask; the @c src / @c dst stages are
+        // present for Vulkan portability and ignored here.
+        glMemoryBarrier(to_gl_memory_barrier_bits(dst_access));
     }
 } // namespace rendering_engine::gpu::backend::opengl

--- a/rendering_engine/gpu/backend/opengl/gl_command_encoder.hpp
+++ b/rendering_engine/gpu/backend/opengl/gl_command_encoder.hpp
@@ -53,6 +53,11 @@ namespace rendering_engine::gpu::backend::opengl
         void set_viewport(int x, int y, int width, int height) override;
         void draw(uint32_t vertex_count, uint32_t first_vertex) override;
         void draw_indexed(uint32_t index_count, uint32_t first_index) override;
+        void draw_indexed_indirect(buffer indirect_buffer, size_t offset) override;
+        void multi_draw_indexed_indirect(buffer indirect_buffer,
+                                         size_t offset,
+                                         uint32_t draw_count,
+                                         uint32_t stride) override;
         void end() override;
 
     private:
@@ -70,12 +75,38 @@ namespace rendering_engine::gpu::backend::opengl
         bool m_active{false};
     };
 
+    struct gl_compute_pass_encoder : public compute_pass_encoder
+    {
+        explicit gl_compute_pass_encoder(gl_device& device);
+        ~gl_compute_pass_encoder() override;
+
+        void set_pipeline(pipeline pipeline_handle) override;
+        void set_bind_group(uint32_t group, bind_group bind_group_handle) override;
+        void dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) override;
+        void end() override;
+
+    private:
+        gl_device& m_device;
+
+        pipeline m_pipeline_handle{};
+        GLuint m_program_id{0};
+        bool m_active{false};
+    };
+
     struct gl_command_encoder : public command_encoder
     {
         explicit gl_command_encoder(gl_device& device);
         ~gl_command_encoder() override = default;
 
         std::unique_ptr<render_pass_encoder> begin_render_pass(const render_pass_descriptor& descriptor) override;
+        std::unique_ptr<compute_pass_encoder> begin_compute_pass() override;
+
+        void copy_buffer_to_buffer(buffer src, size_t src_offset, buffer dst, size_t dst_offset, size_t size) override;
+        void clear_buffer(buffer buffer_handle, size_t offset, size_t size, uint32_t value) override;
+        void barrier(pipeline_stage src_stage,
+                     pipeline_stage dst_stage,
+                     access_flag src_access,
+                     access_flag dst_access) override;
 
     private:
         gl_device& m_device;

--- a/rendering_engine/gpu/backend/opengl/gl_device.hpp
+++ b/rendering_engine/gpu/backend/opengl/gl_device.hpp
@@ -65,6 +65,7 @@ namespace rendering_engine::gpu::backend::opengl
         shader_module create_shader_module(const shader_module_descriptor& descriptor) override;
         bind_group_layout create_bind_group_layout(const bind_group_layout_descriptor& descriptor) override;
         pipeline create_pipeline(const pipeline_descriptor& descriptor) override;
+        pipeline create_compute_pipeline(const compute_pipeline_descriptor& descriptor) override;
         bind_group create_bind_group(const bind_group_descriptor& descriptor) override;
 
         void destroy(buffer handle) override;
@@ -77,6 +78,7 @@ namespace rendering_engine::gpu::backend::opengl
 
         void write_buffer(buffer buffer_handle, const void* data, size_t size, size_t offset) override;
         void write_texture(texture texture_handle, const void* data, size_t size) override;
+        void write_texture_3d(texture texture_handle, const void* data, size_t size) override;
         void write_cube_face(texture texture_handle, cube_face face, const void* data, size_t size) override;
         void generate_mipmaps(texture texture_handle) override;
 

--- a/rendering_engine/gpu/backend/opengl/gl_device_buffer.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_device_buffer.cpp
@@ -40,6 +40,13 @@ namespace rendering_engine::gpu::backend::opengl
         gl_buffer record{};
         record.size = descriptor.size;
         record.usage = descriptor.usage;
+        // Picking a default bind target is purely about which
+        // target @c glBufferData / @c glBufferSubData target during
+        // create / write — buffers are bound by name through
+        // @c glBindBufferBase at draw time, so any target works
+        // for the underlying object. The order below prefers
+        // targets that don't share state with vertex / index
+        // submission to keep the create / write path tidy.
         if ((descriptor.usage & buffer_usage_index) != 0u)
         {
             record.default_target = GL_ELEMENT_ARRAY_BUFFER;
@@ -47,6 +54,14 @@ namespace rendering_engine::gpu::backend::opengl
         else if ((descriptor.usage & buffer_usage_uniform) != 0u)
         {
             record.default_target = GL_UNIFORM_BUFFER;
+        }
+        else if ((descriptor.usage & buffer_usage_storage) != 0u)
+        {
+            record.default_target = GL_SHADER_STORAGE_BUFFER;
+        }
+        else if ((descriptor.usage & buffer_usage_indirect) != 0u)
+        {
+            record.default_target = GL_DRAW_INDIRECT_BUFFER;
         }
         else
         {

--- a/rendering_engine/gpu/backend/opengl/gl_device_pipeline.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_device_pipeline.cpp
@@ -51,10 +51,34 @@ namespace rendering_engine::gpu::backend::opengl
         m_bind_group_layouts.remove(handle.id);
     }
 
+    namespace
+    {
+        void check_program_link(GLuint program_id)
+        {
+            GLint linked = 0;
+            glGetProgramiv(program_id, GL_LINK_STATUS, &linked);
+            if (linked == GL_TRUE)
+            {
+                return;
+            }
+            GLint log_length = 0;
+            glGetProgramiv(program_id, GL_INFO_LOG_LENGTH, &log_length);
+            std::string info_log(log_length > 0 ? static_cast<size_t>(log_length) : 1u, '\0');
+            if (log_length > 0)
+            {
+                glGetProgramInfoLog(program_id, log_length, nullptr, info_log.data());
+            }
+            LOG_ERR("Program link failed: %s", info_log.c_str());
+            glDeleteProgram(program_id);
+            throw std::runtime_error{info_log};
+        }
+    } // namespace
+
     pipeline gl_device::create_pipeline(const pipeline_descriptor& descriptor)
     {
         gl_pipeline record{};
         record.topology = descriptor.topology;
+        record.patch_control_points = descriptor.patch_control_points;
         record.blend = descriptor.blend;
         record.depth = descriptor.depth;
         record.rasterizer = descriptor.rasterizer;
@@ -83,23 +107,11 @@ namespace rendering_engine::gpu::backend::opengl
         attach(descriptor.vertex_shader);
         attach(descriptor.fragment_shader);
         attach(descriptor.geometry_shader);
+        attach(descriptor.tessellation_control_shader);
+        attach(descriptor.tessellation_evaluation_shader);
 
         glLinkProgram(record.program_id);
-        GLint linked = 0;
-        glGetProgramiv(record.program_id, GL_LINK_STATUS, &linked);
-        if (linked != GL_TRUE)
-        {
-            GLint log_length = 0;
-            glGetProgramiv(record.program_id, GL_INFO_LOG_LENGTH, &log_length);
-            std::string info_log(log_length > 0 ? static_cast<size_t>(log_length) : 1u, '\0');
-            if (log_length > 0)
-            {
-                glGetProgramInfoLog(record.program_id, log_length, nullptr, info_log.data());
-            }
-            LOG_ERR("Program link failed: %s", info_log.c_str());
-            glDeleteProgram(record.program_id);
-            throw std::runtime_error{info_log};
-        }
+        check_program_link(record.program_id);
 
         // Build a VAO that owns the vertex format declared by
         // the pipeline. Vertex buffers bound at draw time
@@ -118,6 +130,44 @@ namespace rendering_engine::gpu::backend::opengl
         glBindVertexArray(0);
 
         LOG_INF("Pipeline linked id=%u vao=%u", record.program_id, record.vao_id);
+
+        pipeline h{};
+        h.id = m_pipelines.insert(record);
+        return h;
+    }
+
+    pipeline gl_device::create_compute_pipeline(const compute_pipeline_descriptor& descriptor)
+    {
+        gl_pipeline record{};
+        record.is_compute = true;
+        record.bind_group_layouts = descriptor.bind_group_layouts;
+
+        record.program_id = glCreateProgram();
+        if (record.program_id == 0)
+        {
+            LOG_FTL("create_compute_pipeline: glCreateProgram returned 0");
+            throw std::runtime_error{"program creation failed"};
+        }
+
+        if (!descriptor.compute_shader.valid())
+        {
+            LOG_FTL("create_compute_pipeline: compute_shader is required");
+            glDeleteProgram(record.program_id);
+            throw std::runtime_error{"compute_shader missing"};
+        }
+        auto* shader_record = m_shader_modules.lookup(descriptor.compute_shader.id);
+        if (shader_record == nullptr || shader_record->object_id == 0)
+        {
+            LOG_FTL("create_compute_pipeline: invalid compute shader handle");
+            glDeleteProgram(record.program_id);
+            throw std::runtime_error{"invalid compute shader handle"};
+        }
+        glAttachShader(record.program_id, shader_record->object_id);
+
+        glLinkProgram(record.program_id);
+        check_program_link(record.program_id);
+
+        LOG_INF("Compute pipeline linked id=%u", record.program_id);
 
         pipeline h{};
         h.id = m_pipelines.insert(record);

--- a/rendering_engine/gpu/backend/opengl/gl_device_texture.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_device_texture.cpp
@@ -58,10 +58,11 @@ namespace rendering_engine::gpu::backend::opengl
     texture gl_device::create_texture(const texture_descriptor& descriptor)
     {
         gl_texture record{};
-        record.target = descriptor.dimension == texture_dimension::cube ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D;
+        record.target = to_gl_texture_target(descriptor.dimension);
         record.format = descriptor.format;
         record.width = descriptor.width;
         record.height = descriptor.height;
+        record.depth = descriptor.dimension == texture_dimension::d3 ? descriptor.depth : 1u;
         record.mipmaps = descriptor.mipmaps;
 
         glGenTextures(1, &record.object_id);
@@ -75,12 +76,11 @@ namespace rendering_engine::gpu::backend::opengl
                             descriptor.address_v,
                             descriptor.address_w);
 
-        // Allocate storage. For 2D textures we allocate
-        // mip-0 directly via @c glTexImage2D with a null
-        // pointer; the caller fills it via
-        // @ref write_texture or @ref write_cube_face. For
-        // cube maps we allocate all six faces with null data
-        // so each face can be uploaded independently later.
+        // Allocate storage with null data. The caller fills
+        // each level via @ref write_texture, @ref write_texture_3d,
+        // or @ref write_cube_face. 2D and 3D textures get a
+        // single level-0 allocation; cube maps get all six
+        // faces so each can be uploaded independently.
         const auto fmt = to_gl_texture_format(descriptor.format);
         if (record.target == GL_TEXTURE_2D)
         {
@@ -89,6 +89,19 @@ namespace rendering_engine::gpu::backend::opengl
                          fmt.internal_format,
                          static_cast<GLsizei>(descriptor.width),
                          static_cast<GLsizei>(descriptor.height),
+                         0,
+                         fmt.upload_format,
+                         fmt.upload_type,
+                         nullptr);
+        }
+        else if (record.target == GL_TEXTURE_3D)
+        {
+            glTexImage3D(GL_TEXTURE_3D,
+                         0,
+                         fmt.internal_format,
+                         static_cast<GLsizei>(descriptor.width),
+                         static_cast<GLsizei>(descriptor.height),
+                         static_cast<GLsizei>(record.depth),
                          0,
                          fmt.upload_format,
                          fmt.upload_type,
@@ -149,6 +162,30 @@ namespace rendering_engine::gpu::backend::opengl
                         fmt.upload_type,
                         data);
         glBindTexture(GL_TEXTURE_2D, 0);
+    }
+
+    void gl_device::write_texture_3d(texture handle, const void* data, size_t /*size*/)
+    {
+        auto* record = m_textures.lookup(handle.id);
+        if (record == nullptr || record->object_id == 0 || record->target != GL_TEXTURE_3D)
+        {
+            LOG_WRN("write_texture_3d: invalid 3D texture handle");
+            return;
+        }
+        const auto fmt = to_gl_texture_format(record->format);
+        glBindTexture(GL_TEXTURE_3D, record->object_id);
+        glTexSubImage3D(GL_TEXTURE_3D,
+                        0,
+                        0,
+                        0,
+                        0,
+                        static_cast<GLsizei>(record->width),
+                        static_cast<GLsizei>(record->height),
+                        static_cast<GLsizei>(record->depth),
+                        fmt.upload_format,
+                        fmt.upload_type,
+                        data);
+        glBindTexture(GL_TEXTURE_3D, 0);
     }
 
     void gl_device::write_cube_face(texture handle, cube_face face, const void* data, size_t /*size*/)

--- a/rendering_engine/gpu/backend/opengl/gl_resources.hpp
+++ b/rendering_engine/gpu/backend/opengl/gl_resources.hpp
@@ -49,7 +49,10 @@ namespace rendering_engine::gpu::backend::opengl
     struct gl_buffer
     {
         GLuint object_id{0};
-        GLenum default_target{0}; // GL_ARRAY_BUFFER / _ELEMENT_ARRAY_BUFFER / _UNIFORM_BUFFER
+        // Default bind target; one of @c GL_ARRAY_BUFFER,
+        // @c GL_ELEMENT_ARRAY_BUFFER, @c GL_UNIFORM_BUFFER,
+        // @c GL_SHADER_STORAGE_BUFFER, or @c GL_DRAW_INDIRECT_BUFFER.
+        GLenum default_target{0};
         size_t size{0};
         buffer_usage usage{0};
     };
@@ -57,10 +60,14 @@ namespace rendering_engine::gpu::backend::opengl
     struct gl_texture
     {
         GLuint object_id{0};
-        GLenum target{0}; // GL_TEXTURE_2D or GL_TEXTURE_CUBE_MAP
+        // @c GL_TEXTURE_2D, @c GL_TEXTURE_3D, or
+        // @c GL_TEXTURE_CUBE_MAP.
+        GLenum target{0};
         texture_format format{texture_format::rgba8_unorm};
         uint32_t width{0};
         uint32_t height{0};
+        // Slice count for 3D textures; 1 for 2D / cube.
+        uint32_t depth{1};
         bool mipmaps{false};
     };
 
@@ -87,9 +94,21 @@ namespace rendering_engine::gpu::backend::opengl
     struct gl_pipeline
     {
         GLuint program_id{0};
+        // 0 for compute pipelines — compute dispatches don't need
+        // a vertex array.
         GLuint vao_id{0};
 
+        // True for pipelines built via
+        // @c gl_device::create_compute_pipeline. These are bound
+        // through @c gl_compute_pass_encoder, never through
+        // @c gl_render_pass_encoder.
+        bool is_compute{false};
+
         primitive_topology topology{primitive_topology::triangles};
+        // Per-patch vertex count for tessellation pipelines; 0 if
+        // no tessellation stage is bound.
+        uint32_t patch_control_points{0};
+
         blend_state blend;
         depth_state depth;
         rasterizer_state rasterizer;

--- a/rendering_engine/gpu/backend/opengl/gl_translate.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_translate.cpp
@@ -34,6 +34,8 @@ namespace rendering_engine::gpu::backend::opengl
             return GL_LINES;
         case primitive_topology::points:
             return GL_POINTS;
+        case primitive_topology::patches:
+            return GL_PATCHES;
         }
         return GL_TRIANGLES;
     }
@@ -192,6 +194,12 @@ namespace rendering_engine::gpu::backend::opengl
             return GL_FRAGMENT_SHADER;
         case shader_stage::geometry:
             return GL_GEOMETRY_SHADER;
+        case shader_stage::tessellation_control:
+            return GL_TESS_CONTROL_SHADER;
+        case shader_stage::tessellation_evaluation:
+            return GL_TESS_EVALUATION_SHADER;
+        case shader_stage::compute:
+            return GL_COMPUTE_SHADER;
         }
         return GL_VERTEX_SHADER;
     }
@@ -255,6 +263,88 @@ namespace rendering_engine::gpu::backend::opengl
             return GL_TEXTURE_CUBE_MAP_NEGATIVE_Z;
         }
         return GL_TEXTURE_CUBE_MAP_POSITIVE_X;
+    }
+
+    GLenum to_gl_texture_target(texture_dimension dimension)
+    {
+        switch (dimension)
+        {
+        case texture_dimension::d2:
+            return GL_TEXTURE_2D;
+        case texture_dimension::d3:
+            return GL_TEXTURE_3D;
+        case texture_dimension::cube:
+            return GL_TEXTURE_CUBE_MAP;
+        }
+        return GL_TEXTURE_2D;
+    }
+
+    GLenum to_gl_storage_access(storage_access access)
+    {
+        switch (access)
+        {
+        case storage_access::read_only:
+            return GL_READ_ONLY;
+        case storage_access::write_only:
+            return GL_WRITE_ONLY;
+        case storage_access::read_write:
+            return GL_READ_WRITE;
+        }
+        return GL_READ_WRITE;
+    }
+
+    GLbitfield to_gl_memory_barrier_bits(access_flag dst_access)
+    {
+        GLbitfield bits = 0;
+        if ((dst_access & access_indirect_command_read) != 0u)
+        {
+            bits |= GL_COMMAND_BARRIER_BIT;
+        }
+        if ((dst_access & access_index_read) != 0u)
+        {
+            bits |= GL_ELEMENT_ARRAY_BARRIER_BIT;
+        }
+        if ((dst_access & access_vertex_attribute_read) != 0u)
+        {
+            bits |= GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT;
+        }
+        if ((dst_access & access_uniform_read) != 0u)
+        {
+            bits |= GL_UNIFORM_BARRIER_BIT;
+        }
+        if ((dst_access & access_shader_read) != 0u)
+        {
+            bits |= GL_TEXTURE_FETCH_BARRIER_BIT;
+        }
+        if ((dst_access & (access_storage_buffer_read | access_storage_buffer_write)) != 0u)
+        {
+            bits |= GL_SHADER_STORAGE_BARRIER_BIT;
+        }
+        if ((dst_access & (access_storage_image_read | access_storage_image_write)) != 0u)
+        {
+            bits |= GL_SHADER_IMAGE_ACCESS_BARRIER_BIT;
+        }
+        if ((dst_access & (access_color_attachment_read | access_color_attachment_write |
+                           access_depth_stencil_attachment_read | access_depth_stencil_attachment_write)) != 0u)
+        {
+            bits |= GL_FRAMEBUFFER_BARRIER_BIT;
+        }
+        if ((dst_access & access_transfer_read) != 0u)
+        {
+            bits |= GL_BUFFER_UPDATE_BARRIER_BIT | GL_PIXEL_BUFFER_BARRIER_BIT;
+        }
+        if ((dst_access & access_transfer_write) != 0u)
+        {
+            bits |= GL_BUFFER_UPDATE_BARRIER_BIT | GL_TEXTURE_UPDATE_BARRIER_BIT;
+        }
+        if (bits == 0)
+        {
+            // The caller asked for a barrier with no recognised
+            // category — fall back to the conservative all-bits
+            // form so dependent work observes prior writes.
+            bits = GL_ALL_BARRIER_BITS;
+        }
+        return bits;
     }
 
     gl_texture_format to_gl_texture_format(texture_format format)

--- a/rendering_engine/gpu/backend/opengl/gl_translate.hpp
+++ b/rendering_engine/gpu/backend/opengl/gl_translate.hpp
@@ -50,6 +50,15 @@ namespace rendering_engine::gpu::backend::opengl
     GLenum to_gl_scalar(scalar_type type);
     GLenum to_gl_buffer_usage_hint(buffer_usage_hint hint);
     GLenum to_gl_cube_face(cube_face face);
+    GLenum to_gl_texture_target(texture_dimension dimension);
+    GLenum to_gl_storage_access(storage_access access);
+
+    // Translate the engine's @c access_flag bitmask into the
+    // matching @c GL_*_BARRIER_BIT bitmask consumed by
+    // @c glMemoryBarrier. Only the @c dst_access mask drives the
+    // result; on OpenGL the source mask is implicit (the API
+    // orders all prior writes against the requested category).
+    GLbitfield to_gl_memory_barrier_bits(access_flag dst_access);
 
     // For a texture create: returns the @c (internal_format,
     // upload_format, upload_type) triple suitable for

--- a/rendering_engine/gpu/bind_group.hpp
+++ b/rendering_engine/gpu/bind_group.hpp
@@ -50,16 +50,28 @@ namespace rendering_engine::gpu
         uniform_buffer,
         texture,
         sampler,
+        storage_buffer,
+        storage_texture,
     };
 
     // One slot in a layout. The binding number maps directly onto
     // the SPIR-V @c Binding decoration and onto the OpenGL binding
-    // point (UBO unit for @c uniform_buffer, texture image unit for
-    // @c texture / @c sampler).
+    // point (UBO / SSBO unit for @c uniform_buffer / @c storage_buffer,
+    // texture image unit for @c texture / @c sampler, image unit for
+    // @c storage_texture).
     struct bind_group_layout_entry
     {
         uint32_t binding{0};
         binding_kind kind{binding_kind::uniform_buffer};
+
+        // For @c storage_texture only: the image format used by
+        // @c glBindImageTexture and matched against the SPIR-V
+        // image @c Format decoration. Ignored for other kinds.
+        texture_format storage_format{texture_format::rgba8_unorm};
+
+        // For @c storage_texture only: shader-side access mode.
+        // Ignored for other kinds.
+        storage_access storage_access_mode{storage_access::read_write};
     };
 
     struct bind_group_layout_descriptor

--- a/rendering_engine/gpu/command_encoder.cpp
+++ b/rendering_engine/gpu/command_encoder.cpp
@@ -36,5 +36,7 @@ namespace rendering_engine::gpu
 {
     render_pass_encoder::~render_pass_encoder() = default;
 
+    compute_pass_encoder::~compute_pass_encoder() = default;
+
     command_encoder::~command_encoder() = default;
 } // namespace rendering_engine::gpu

--- a/rendering_engine/gpu/command_encoder.hpp
+++ b/rendering_engine/gpu/command_encoder.hpp
@@ -86,9 +86,55 @@ namespace rendering_engine::gpu
         // at index @p first_index in the bound index buffer.
         virtual void draw_indexed(uint32_t index_count, uint32_t first_index = 0) = 0;
 
+        // Issue an indexed draw whose parameters are sourced from
+        // @p indirect_buffer at @p offset. The buffer record at that
+        // offset is a five-uint32 @c indexCount, @c instanceCount,
+        // @c firstIndex, @c vertexOffset, @c firstInstance — the
+        // shape shared by GL's @c DrawElementsIndirectCommand and
+        // Vulkan's @c VkDrawIndexedIndirectCommand. The buffer must
+        // have been created with @c buffer_usage_indirect.
+        virtual void draw_indexed_indirect(buffer indirect_buffer, size_t offset = 0) = 0;
+
+        // Issue @p draw_count back-to-back indexed indirect draws,
+        // each with the same five-uint32 record described in
+        // @ref draw_indexed_indirect. @p stride is the byte stride
+        // between consecutive records (typically 20 for tightly
+        // packed records). Maps to @c glMultiDrawElementsIndirect
+        // on the OpenGL backend and to @c vkCmdDrawIndexedIndirect
+        // on Vulkan.
+        virtual void
+        multi_draw_indexed_indirect(buffer indirect_buffer, size_t offset, uint32_t draw_count, uint32_t stride) = 0;
+
         // Close the pass. After this call no further methods may be
         // invoked on the encoder. The next pass on the same command
         // encoder may target a different render target.
+        virtual void end() = 0;
+    };
+
+    struct compute_pass_encoder
+    {
+        // Out-of-line virtual destructor: pins the vtable and
+        // typeinfo to @c command_encoder.cpp.
+        virtual ~compute_pass_encoder();
+
+        // Bind the compute pipeline subsequent dispatches will
+        // execute. The pipeline must have been created via
+        // @c device::create_compute_pipeline.
+        virtual void set_pipeline(pipeline pipeline_handle) = 0;
+
+        // Bind a pre-constructed @c bind_group to the layout slot
+        // @p group. The pipeline must have been created with a
+        // matching @c bind_group_layout at the same index.
+        virtual void set_bind_group(uint32_t group, bind_group bind_group_handle) = 0;
+
+        // Dispatch @p group_count_x * @p group_count_y *
+        // @p group_count_z workgroups. Workgroup size comes from
+        // the @c local_size_x / @c local_size_y / @c local_size_z
+        // layout qualifiers baked into the compute shader.
+        virtual void dispatch(uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) = 0;
+
+        // Close the pass. After this call no further methods may be
+        // invoked on the encoder.
         virtual void end() = 0;
     };
 
@@ -106,5 +152,37 @@ namespace rendering_engine::gpu
         // future Vulkan backend the encoder would be a thin handle
         // wrapping a @c VkCommandBuffer scope.
         virtual std::unique_ptr<render_pass_encoder> begin_render_pass(const render_pass_descriptor& descriptor) = 0;
+
+        // Open a new compute pass scope. Compute passes never carry
+        // attachments; bind a pipeline and bind groups, dispatch,
+        // and end. May be opened concurrently with render passes
+        // only on backends that allow it (Vulkan does not — keep
+        // them disjoint).
+        virtual std::unique_ptr<compute_pass_encoder> begin_compute_pass() = 0;
+
+        // Copy @p size bytes from @p src starting at @p src_offset
+        // to @p dst starting at @p dst_offset. The source buffer
+        // must have been created with @c buffer_usage_copy_src and
+        // the destination with @c buffer_usage_copy_dst. The two
+        // ranges must not overlap.
+        virtual void
+        copy_buffer_to_buffer(buffer src, size_t src_offset, buffer dst, size_t dst_offset, size_t size) = 0;
+
+        // Fill @p size bytes of @p buffer_handle starting at
+        // @p offset with the 32-bit pattern @p value (broadcast as
+        // little-endian, matching @c glClearBufferSubData and
+        // Vulkan's @c vkCmdFillBuffer). The buffer must have been
+        // created with @c buffer_usage_copy_dst.
+        virtual void clear_buffer(buffer buffer_handle, size_t offset, size_t size, uint32_t value) = 0;
+
+        // Insert a memory barrier ordering prior @p src_stage work
+        // (which produced data via @p src_access) against
+        // subsequent @p dst_stage work (which consumes data via
+        // @p dst_access). On the OpenGL backend the @p src_stage /
+        // @p src_access pair is informational and the @p dst_access
+        // mask drives @c glMemoryBarrier; on Vulkan all four
+        // arguments map verbatim.
+        virtual void
+        barrier(pipeline_stage src_stage, pipeline_stage dst_stage, access_flag src_access, access_flag dst_access) = 0;
     };
 } // namespace rendering_engine::gpu

--- a/rendering_engine/gpu/device.hpp
+++ b/rendering_engine/gpu/device.hpp
@@ -81,6 +81,7 @@ namespace rendering_engine::gpu
         virtual shader_module create_shader_module(const shader_module_descriptor& descriptor) = 0;
         virtual bind_group_layout create_bind_group_layout(const bind_group_layout_descriptor& descriptor) = 0;
         virtual pipeline create_pipeline(const pipeline_descriptor& descriptor) = 0;
+        virtual pipeline create_compute_pipeline(const compute_pipeline_descriptor& descriptor) = 0;
         virtual bind_group create_bind_group(const bind_group_descriptor& descriptor) = 0;
 
         // -- Resource destruction -----------------------------------------
@@ -103,6 +104,11 @@ namespace rendering_engine::gpu
         // match the @c format the texture was created with. Required
         // before the texture is sampled.
         virtual void write_texture(texture texture_handle, const void* data, size_t size) = 0;
+
+        // Upload pixel data for a 3D texture. @p data lays out the
+        // full volume in slice-major order: each z slice is a 2D
+        // image of @c width * @c height texels.
+        virtual void write_texture_3d(texture texture_handle, const void* data, size_t size) = 0;
 
         // Upload pixel data for one face of a cube-map texture.
         virtual void write_cube_face(texture texture_handle, cube_face face, const void* data, size_t size) = 0;

--- a/rendering_engine/gpu/pipeline.hpp
+++ b/rendering_engine/gpu/pipeline.hpp
@@ -69,9 +69,23 @@ namespace rendering_engine::gpu
         shader_module fragment_shader{};
         shader_module geometry_shader{};
 
+        // Optional tessellation pair. Both must be either set or
+        // both empty. Pipelines that bind tessellation must also
+        // set @c topology to @c primitive_topology::patches and
+        // give @c patch_control_points a non-zero value.
+        shader_module tessellation_control_shader{};
+        shader_module tessellation_evaluation_shader{};
+
         std::vector<vertex_buffer_layout> vertex_buffers;
 
         primitive_topology topology{primitive_topology::triangles};
+
+        // Number of vertices per patch when @c topology is
+        // @c patches. Maps to @c GL_PATCH_VERTICES on the OpenGL
+        // backend and to the equivalent @c VkPipelineTessellationStateCreateInfo
+        // field on Vulkan. Ignored for non-patch topologies.
+        uint32_t patch_control_points{0};
+
         blend_state blend;
         depth_state depth;
         rasterizer_state rasterizer;
@@ -79,6 +93,19 @@ namespace rendering_engine::gpu
         // Bind-group layouts referenced by this pipeline. The index
         // into this vector is the slot number passed to
         // @c render_pass_encoder::set_bind_group.
+        std::vector<bind_group_layout> bind_group_layouts;
+    };
+
+    // Compute-pipeline descriptor. Returned as the same
+    // @c pipeline handle as graphics pipelines but bound only
+    // through @c compute_pass_encoder::set_pipeline.
+    struct compute_pipeline_descriptor
+    {
+        shader_module compute_shader{};
+
+        // Bind-group layouts referenced by this pipeline. The
+        // index into this vector is the slot number passed to
+        // @c compute_pass_encoder::set_bind_group.
         std::vector<bind_group_layout> bind_group_layouts;
     };
 } // namespace rendering_engine::gpu

--- a/rendering_engine/gpu/texture.hpp
+++ b/rendering_engine/gpu/texture.hpp
@@ -41,6 +41,10 @@ namespace rendering_engine::gpu
         uint32_t width{0};
         uint32_t height{0};
 
+        // Volume slice count for @c texture_dimension::d3. Ignored
+        // for 2D and cube textures.
+        uint32_t depth{1};
+
         // When true, the backend allocates a full mip chain and the
         // caller may invoke @c device::generate_mipmaps after
         // uploading the level-0 data. @c false leaves the texture

--- a/rendering_engine/gpu/types.hpp
+++ b/rendering_engine/gpu/types.hpp
@@ -71,12 +71,16 @@ namespace rendering_engine::gpu
         uint32,
     };
 
-    // Draw-call primitive topology.
+    // Draw-call primitive topology. @c patches feeds the
+    // tessellation control stage when the pipeline binds tess
+    // shaders; the per-patch vertex count comes from
+    // @c pipeline_descriptor::patch_control_points.
     enum class primitive_topology
     {
         triangles,
         lines,
         points,
+        patches,
     };
 
     enum class blend_factor
@@ -165,12 +169,26 @@ namespace rendering_engine::gpu
         vertex,
         fragment,
         geometry,
+        tessellation_control,
+        tessellation_evaluation,
+        compute,
     };
 
     enum class texture_dimension
     {
         d2,
+        d3,
         cube,
+    };
+
+    // Shader-side access mode for a storage image binding. Maps to
+    // GL @c access in @c glBindImageTexture and to the SPIR-V
+    // image @c NonReadable / @c NonWritable decorations.
+    enum class storage_access
+    {
+        read_only,
+        write_only,
+        read_write,
     };
 
     // Cube-map face index. Order matches GL convention; the backend
@@ -218,4 +236,51 @@ namespace rendering_engine::gpu
     constexpr buffer_usage buffer_usage_index = 1u << 1;
     constexpr buffer_usage buffer_usage_uniform = 1u << 2;
     constexpr buffer_usage buffer_usage_copy_dst = 1u << 3;
+    constexpr buffer_usage buffer_usage_storage = 1u << 4;
+    constexpr buffer_usage buffer_usage_indirect = 1u << 5;
+    constexpr buffer_usage buffer_usage_copy_src = 1u << 6;
+
+    // Pipeline stages used by @c command_encoder::barrier. A barrier
+    // orders prior @c src_stage work against subsequent @c dst_stage
+    // work; the matching @c access_flag mask selects which memory
+    // accesses are synchronised. Combine with @c |.
+    using pipeline_stage = uint32_t;
+    constexpr pipeline_stage pipeline_stage_none = 0u;
+    constexpr pipeline_stage pipeline_stage_vertex_input = 1u << 0;
+    constexpr pipeline_stage pipeline_stage_vertex_shader = 1u << 1;
+    constexpr pipeline_stage pipeline_stage_tessellation_control_shader = 1u << 2;
+    constexpr pipeline_stage pipeline_stage_tessellation_evaluation_shader = 1u << 3;
+    constexpr pipeline_stage pipeline_stage_geometry_shader = 1u << 4;
+    constexpr pipeline_stage pipeline_stage_fragment_shader = 1u << 5;
+    constexpr pipeline_stage pipeline_stage_compute_shader = 1u << 6;
+    constexpr pipeline_stage pipeline_stage_color_attachment_output = 1u << 7;
+    constexpr pipeline_stage pipeline_stage_early_fragment_tests = 1u << 8;
+    constexpr pipeline_stage pipeline_stage_late_fragment_tests = 1u << 9;
+    constexpr pipeline_stage pipeline_stage_transfer = 1u << 10;
+    constexpr pipeline_stage pipeline_stage_draw_indirect = 1u << 11;
+    constexpr pipeline_stage pipeline_stage_all_graphics = 0x0FFFu;
+    constexpr pipeline_stage pipeline_stage_all_commands = 0xFFFFu;
+
+    // Memory-access categories used by @c command_encoder::barrier.
+    // The OpenGL backend folds @c dst_access into a bitmask of
+    // @c GL_*_BARRIER_BIT flags; a future Vulkan backend uses both
+    // @c src_access and @c dst_access verbatim. Combine with @c |.
+    using access_flag = uint32_t;
+    constexpr access_flag access_none = 0u;
+    constexpr access_flag access_indirect_command_read = 1u << 0;
+    constexpr access_flag access_index_read = 1u << 1;
+    constexpr access_flag access_vertex_attribute_read = 1u << 2;
+    constexpr access_flag access_uniform_read = 1u << 3;
+    constexpr access_flag access_shader_read = 1u << 4;
+    constexpr access_flag access_shader_write = 1u << 5;
+    constexpr access_flag access_color_attachment_read = 1u << 6;
+    constexpr access_flag access_color_attachment_write = 1u << 7;
+    constexpr access_flag access_depth_stencil_attachment_read = 1u << 8;
+    constexpr access_flag access_depth_stencil_attachment_write = 1u << 9;
+    constexpr access_flag access_transfer_read = 1u << 10;
+    constexpr access_flag access_transfer_write = 1u << 11;
+    constexpr access_flag access_storage_buffer_read = 1u << 12;
+    constexpr access_flag access_storage_buffer_write = 1u << 13;
+    constexpr access_flag access_storage_image_read = 1u << 14;
+    constexpr access_flag access_storage_image_write = 1u << 15;
 } // namespace rendering_engine::gpu


### PR DESCRIPTION
The cross-backend feature set every downstream system needs. Each item lands in `gpu::device` / `gpu::command_encoder` / `gpu::render_pass_encoder` and is implemented in the OpenGL 4.6 backend; the same SPIR-V and the same descriptor shapes are portable to a future Vulkan backend without any second front-end work.

## Summary

- **Compute pipelines** — `device::create_compute_pipeline(compute_pipeline_descriptor)` builds a single-stage program from a compute `shader_module`. A dedicated `compute_pass_encoder` (returned by `command_encoder::begin_compute_pass`) exposes `set_pipeline` / `set_bind_group` / `dispatch(x, y, z)` / `end`. `shader_stage::compute` translates to `GL_COMPUTE_SHADER`; dispatches go through `glDispatchCompute`.
- **Tessellation** — `pipeline_descriptor` gains `tessellation_control_shader` / `tessellation_evaluation_shader` and a `patch_control_points` field; `primitive_topology::patches` and `shader_stage::tessellation_control` / `tessellation_evaluation` round out the enums. The GL render-pass encoder issues `glPatchParameteri(GL_PATCH_VERTICES, n)` on bind when the topology is `patches`. Both tess shaders attach to the program at `create_pipeline` time.
- **Storage buffers + storage images** — new `binding_kind::storage_buffer` and `binding_kind::storage_texture` values. Storage-texture bindings need a format / access pair at `glBindImageTexture` time, so `bind_group_layout_entry` gains `storage_format` and `storage_access_mode`; the GL backend looks the entry up by binding number and emits `glBindImageTexture(unit, tex, 0, layered, 0, access, internal_format)`. Storage buffers are bound via `glBindBufferBase(GL_SHADER_STORAGE_BUFFER, …)`. The same SPIR-V layout maps cleanly onto Vulkan's `STORAGE_BUFFER` / `STORAGE_IMAGE` descriptor types.
- **3D textures** — `texture_dimension::d3` plus a `depth` field on `texture_descriptor`. The GL backend allocates `GL_TEXTURE_3D` storage with `glTexImage3D` and exposes `device::write_texture_3d` for the slice-major upload path; cube and 2D paths are unchanged. `to_gl_texture_target` collapses the dimension → target switch.
- **Indirect draws** — `draw_indexed_indirect(indirect_buffer, offset)` and `multi_draw_indexed_indirect(indirect_buffer, offset, draw_count, stride)` on `render_pass_encoder`. The indirect record shape is the standard five-uint32 (`indexCount`, `instanceCount`, `firstIndex`, `vertexOffset`, `firstInstance`) that `VkDrawIndexedIndirectCommand` and OpenGL's `GL_DRAW_INDIRECT_BUFFER` agree on. `buffer_usage` gains `buffer_usage_indirect`, and the GL backend picks `GL_DRAW_INDIRECT_BUFFER` as the default target for indirect-only buffers.
- **Buffer copies + clears** — `command_encoder::copy_buffer_to_buffer(src, src_offset, dst, dst_offset, size)` (`glCopyBufferSubData`) and `command_encoder::clear_buffer(buffer, offset, size, value)` (`glClearBufferSubData(GL_R32UI, …)` with the 32-bit pattern broadcast little-endian — matching `vkCmdFillBuffer`). `buffer_usage` gains `buffer_usage_copy_src`.
- **Memory barriers** — `command_encoder::barrier(src_stage, dst_stage, src_access, dst_access)`. New `pipeline_stage` and `access_flag` bitmasks live in `types.hpp`. The OpenGL backend folds `dst_access` into a `GL_*_BARRIER_BIT` mask (storage buffer, storage image, command, vertex / element, uniform, texture-fetch, framebuffer, buffer / texture / pixel update) and calls `glMemoryBarrier`; `src_stage` / `src_access` are present for Vulkan portability and ignored on GL. A future Vulkan backend feeds all four args verbatim into `vkCmdPipelineBarrier`.

The bind-group apply logic in the GL command encoder is now a shared free function (`apply_bind_group`) so render and compute passes route through the same dispatch — the only difference between them at bind time is the active program. The new render-pass paths refuse compute pipelines with a warning; the new compute-pass paths refuse graphics pipelines.

## Test plan

- [x] `./scripts/build.ps1 -Configuration Debug` (MSVC + vcpkg, Visual Studio 17 2022) configures and builds `Binaries/Debug/AlphaEngine.exe` cleanly.
- [x] `./scripts/check-style.ps1` reports no style issues.
- [x] `./scripts/check-naming.ps1` reports no naming violations.
- [x] Smoke run: `Binaries/Debug/AlphaEngine.exe` boots on the OpenGL 4.6 NVIDIA driver, all three existing pipelines (`lit_material`, `ui_material`, `tonemap_pass`) link, and the cube + tonemap + UI + FPS overlay scene renders identically to the pre-change path. No GL debug-output errors.
- [ ] Real consumption of the new APIs: deferred to follow-up PRs that introduce a compute-driven system, tess-driven terrain, indirect culling, etc. — those are the systems this PR exists to unblock.