### PR TITLE
feat: material base parameter surface (opacity, double-sided, blend, wireframe)

### DIFF
--- a/rendering_engine/materials/lit_material.cpp
+++ b/rendering_engine/materials/lit_material.cpp
@@ -80,21 +80,12 @@ namespace rendering_engine
         gpu::bind_group_layout_descriptor draw_layout{};
         draw_layout.entries.push_back({1, gpu::binding_kind::uniform_buffer});
 
-        gpu::depth_state depth{};
-        depth.test_enabled = true;
-        depth.write_enabled = true;
-        depth.compare = gpu::compare_function::less;
+        material_params params{};
+        params.transparent = true;
+        params.blending = blend_mode::normal;
+        params.depth_test = true;
+        params.depth_write = true;
 
-        gpu::blend_state blend{};
-        blend.enabled = true;
-        blend.src = gpu::blend_factor::src_alpha;
-        blend.dst = gpu::blend_factor::one_minus_src_alpha;
-
-        gpu::rasterizer_state rasterizer{};
-        rasterizer.cull = gpu::cull_mode::back;
-        rasterizer.front = gpu::front_face::counter_clockwise;
-
-        construct_pipeline(
-            vertex_shader, fragment_shader, vertex_layout, draw_layout, frame_layout, depth, blend, rasterizer);
+        construct_pipeline(vertex_shader, fragment_shader, vertex_layout, draw_layout, frame_layout, params);
     }
 } // namespace rendering_engine

--- a/rendering_engine/materials/material.cpp
+++ b/rendering_engine/materials/material.cpp
@@ -26,6 +26,64 @@
 #include <rendering_engine/gpu/device.hpp>
 #include <rendering_engine/gpu/shader_compiler.hpp>
 
+namespace
+{
+    using rendering_engine::blend_mode;
+    using rendering_engine::material_params;
+    namespace gpu = rendering_engine::gpu;
+
+    gpu::depth_state to_depth_state(const material_params& params)
+    {
+        gpu::depth_state depth{};
+        depth.test_enabled = params.depth_test;
+        depth.write_enabled = params.depth_write;
+        depth.compare = params.depth_test ? gpu::compare_function::less : gpu::compare_function::always;
+        return depth;
+    }
+
+    gpu::blend_state to_blend_state(const material_params& params)
+    {
+        gpu::blend_state blend{};
+        blend.enabled = params.transparent && params.blending != blend_mode::none;
+        if (!blend.enabled)
+        {
+            return blend;
+        }
+
+        blend.op = gpu::blend_op::add;
+        switch (params.blending)
+        {
+        case blend_mode::additive:
+            blend.src = gpu::blend_factor::src_alpha;
+            blend.dst = gpu::blend_factor::one;
+            break;
+        case blend_mode::subtractive:
+            blend.src = gpu::blend_factor::zero;
+            blend.dst = gpu::blend_factor::one_minus_src_color;
+            break;
+        case blend_mode::multiply:
+            blend.src = gpu::blend_factor::zero;
+            blend.dst = gpu::blend_factor::src_color;
+            break;
+        case blend_mode::normal:
+        case blend_mode::none:
+            blend.src = gpu::blend_factor::src_alpha;
+            blend.dst = gpu::blend_factor::one_minus_src_alpha;
+            break;
+        }
+        return blend;
+    }
+
+    gpu::rasterizer_state to_rasterizer_state(const material_params& params)
+    {
+        gpu::rasterizer_state rasterizer{};
+        rasterizer.cull = params.double_sided ? gpu::cull_mode::none : gpu::cull_mode::back;
+        rasterizer.front = gpu::front_face::counter_clockwise;
+        rasterizer.polygon = params.wireframe ? gpu::polygon_mode::line : gpu::polygon_mode::fill;
+        return rasterizer;
+    }
+} // namespace
+
 namespace rendering_engine
 {
     material::~material()
@@ -36,6 +94,11 @@ namespace rendering_engine
     gpu::pipeline material::pipeline() const
     {
         return m_pipeline;
+    }
+
+    const material_params& material::params() const
+    {
+        return m_params;
     }
 
     gpu::bind_group_layout material::per_draw_layout() const
@@ -56,6 +119,24 @@ namespace rendering_engine
     uint32_t material::per_material_slot() const
     {
         return per_draw_slot();
+    }
+
+    void material::construct_pipeline(const std::string& vertex_source,
+                                      const std::string& fragment_source,
+                                      const gpu::vertex_buffer_layout& vertex_layout,
+                                      const gpu::bind_group_layout_descriptor& draw_layout,
+                                      gpu::bind_group_layout frame_layout,
+                                      const material_params& params)
+    {
+        m_params = params;
+        construct_pipeline(vertex_source,
+                           fragment_source,
+                           vertex_layout,
+                           draw_layout,
+                           frame_layout,
+                           to_depth_state(params),
+                           to_blend_state(params),
+                           to_rasterizer_state(params));
     }
 
     void material::construct_pipeline(const std::string& vertex_source,

--- a/rendering_engine/materials/material.hpp
+++ b/rendering_engine/materials/material.hpp
@@ -32,6 +32,54 @@
 
 namespace rendering_engine
 {
+    // Named blend equation presets. @c normal is straight alpha
+    // compositing; the rest map onto the matching source/destination
+    // factors. @c none leaves blending disabled regardless of
+    // @c transparent.
+    enum class blend_mode
+    {
+        none,
+        normal,
+        additive,
+        subtractive,
+        multiply,
+    };
+
+    // The shared parameter surface every material inherits. These are
+    // data-only knobs; the base translates them onto the @c gpu::depth_state /
+    // @c gpu::blend_state / @c gpu::rasterizer_state baked into the
+    // pipeline (see @ref material::construct_pipeline). @c opacity is
+    // stored for materials whose shaders consume it; the fixed-function
+    // mapping does not read it on its own.
+    struct material_params
+    {
+        // Whether the surface participates in alpha blending. When
+        // false the pipeline blend stage stays disabled (the object
+        // is opaque) no matter what @c blending selects.
+        bool transparent{false};
+
+        // Surface opacity in [0, 1]. Pure data — consumed by shaders
+        // that read it, not by the blend state.
+        float opacity{1.0f};
+
+        // Disable back-face culling so both faces rasterize. Maps to
+        // @c cull_mode::none; otherwise back faces are culled.
+        bool double_sided{false};
+
+        // Blend equation preset applied when @c transparent is set.
+        blend_mode blending{blend_mode::normal};
+
+        // Rasterize edges only. Maps to @c polygon_mode::line.
+        bool wireframe{false};
+
+        // Depth comparison against the existing buffer. When off the
+        // surface always passes the depth test.
+        bool depth_test{true};
+
+        // Whether passing fragments write their depth back.
+        bool depth_write{true};
+    };
+
     // A material owns a @ref gpu::pipeline (shader + fixed-function
     // state + bind-group layouts) and the per-draw bind-group layout
     // that renderables build their @ref draw_item against. The
@@ -46,6 +94,11 @@ namespace rendering_engine
         material& operator=(const material&) = delete;
 
         gpu::pipeline pipeline() const;
+
+        // The shared base parameters this material was built with.
+        // Reflects whatever @ref construct_pipeline baked; mutating
+        // it does not re-bake the pipeline.
+        const material_params& params() const;
 
         // Layout renderables build their per-draw bind group
         // against (model matrix, per-draw textures, options).
@@ -74,6 +127,18 @@ namespace rendering_engine
     protected:
         material() = default;
 
+        // Build the pipeline + per-draw layout from the shared
+        // @ref material_params surface. The params are stored (see
+        // @ref params) and translated onto the fixed-function depth /
+        // blend / rasterizer state before delegating to the explicit
+        // overload below. Prefer this entry point for new materials.
+        void construct_pipeline(const std::string& vertex_source,
+                                const std::string& fragment_source,
+                                const gpu::vertex_buffer_layout& vertex_layout,
+                                const gpu::bind_group_layout_descriptor& draw_layout,
+                                gpu::bind_group_layout frame_layout,
+                                const material_params& params);
+
         // Build the pipeline + per-draw layout from source. When
         // @p frame_layout is valid, slot 0 is reserved for a
         // per-frame bind group owned by the corresponding pass and
@@ -90,6 +155,7 @@ namespace rendering_engine
 
         void destruct_pipeline();
 
+        material_params m_params{};
         gpu::shader_module m_vertex_shader{};
         gpu::shader_module m_fragment_shader{};
         gpu::pipeline m_pipeline{};

--- a/rendering_engine/materials/ui_material.cpp
+++ b/rendering_engine/materials/ui_material.cpp
@@ -84,28 +84,16 @@ namespace rendering_engine
 
         // Overlay pass disables depth testing entirely so 2D elements
         // draw in submission order; depth writes also stay off so the
-        // overlay never trashes the scene's depth buffer.
-        gpu::depth_state depth{};
-        depth.test_enabled = false;
-        depth.write_enabled = false;
-        depth.compare = gpu::compare_function::always;
+        // overlay never trashes the scene's depth buffer. Double-sided
+        // so panes are visible regardless of winding.
+        material_params params{};
+        params.transparent = true;
+        params.blending = blend_mode::normal;
+        params.double_sided = true;
+        params.depth_test = false;
+        params.depth_write = false;
 
-        gpu::blend_state blend{};
-        blend.enabled = true;
-        blend.src = gpu::blend_factor::src_alpha;
-        blend.dst = gpu::blend_factor::one_minus_src_alpha;
-
-        gpu::rasterizer_state rasterizer{};
-        rasterizer.cull = gpu::cull_mode::none;
-        rasterizer.front = gpu::front_face::counter_clockwise;
-
-        construct_pipeline(vertex_shader,
-                           fragment_shader,
-                           vertex_layout,
-                           draw_layout,
-                           gpu::bind_group_layout{},
-                           depth,
-                           blend,
-                           rasterizer);
+        construct_pipeline(
+            vertex_shader, fragment_shader, vertex_layout, draw_layout, gpu::bind_group_layout{}, params);
     }
 } // namespace rendering_engine


### PR DESCRIPTION
## Summary
- Add `material_params`, the shared parameter surface every material inherits: `transparent` + `opacity`, `double_sided`, `blending` (a `blend_mode` preset enum), `wireframe`, and `depth_test` / `depth_write`.
- Add a `construct_pipeline` overload that stores the params and translates them onto the existing `gpu::depth_state` / `gpu::blend_state` / `gpu::rasterizer_state` baked into the pipeline. A `params()` getter exposes what the material was built with.
- Route the built-in `lit_material` and `ui_material` through the new surface (no behavioural change — the translated state matches what they baked by hand).

Data-only; no shader changes. `opacity` is stored for materials whose shaders consume it.

Closes #99.

## Test plan
- [x] CI: clang-format, clang-tidy, and the Windows MSVC Debug/Release build pass.
- [x] Confirm the rendered scene + UI overlay are unchanged (lit cube renders, FPS overlay composites).