### PR TITLE
feat: lighting system (light objects + per-frame lights UBO)

### DIFF
--- a/rendering_engine/CMakeLists.txt
+++ b/rendering_engine/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(AlphaEngine PRIVATE
 
 add_subdirectory(camera)
 add_subdirectory(gpu)
+add_subdirectory(lighting)
 add_subdirectory(materials)
 add_subdirectory(mesh)
 add_subdirectory(passes)

--- a/rendering_engine/lighting/CMakeLists.txt
+++ b/rendering_engine/lighting/CMakeLists.txt
@@ -1,0 +1,12 @@
+target_sources(AlphaEngine PRIVATE
+    ambient_light.cpp
+    ambient_light.hpp
+    directional_light.cpp
+    directional_light.hpp
+    light.cpp
+    light.hpp
+    lights_ubo.cpp
+    lights_ubo.hpp
+    point_light.cpp
+    point_light.hpp
+)

--- a/rendering_engine/lighting/ambient_light.cpp
+++ b/rendering_engine/lighting/ambient_light.cpp
@@ -20,27 +20,9 @@
  * SOFTWARE.
  */
 
-#pragma once
-
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/lighting/ambient_light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
-    {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
-    };
+    ambient_light::ambient_light() : light(light_type::ambient) {}
 } // namespace rendering_engine

--- a/rendering_engine/lighting/ambient_light.hpp
+++ b/rendering_engine/lighting/ambient_light.hpp
@@ -22,25 +22,16 @@
 
 #pragma once
 
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/lighting/light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
+    // Uniform fill light that reaches every surface from all directions
+    // equally — no position, no direction. The scene pass sums every
+    // ambient light's @c color * @c intensity into a single ambient term
+    // in the lights UBO. Three.js analog: THREE.AmbientLight.
+    struct ambient_light : light
     {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
+        ambient_light();
     };
 } // namespace rendering_engine

--- a/rendering_engine/lighting/directional_light.cpp
+++ b/rendering_engine/lighting/directional_light.cpp
@@ -20,27 +20,9 @@
  * SOFTWARE.
  */
 
-#pragma once
-
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/lighting/directional_light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
-    {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
-    };
+    directional_light::directional_light() : light(light_type::directional) {}
 } // namespace rendering_engine

--- a/rendering_engine/lighting/directional_light.hpp
+++ b/rendering_engine/lighting/directional_light.hpp
@@ -22,25 +22,21 @@
 
 #pragma once
 
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/lighting/light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
+    // Light arriving as parallel rays from a constant direction,
+    // independent of surface position — a distant sun. Three.js analog:
+    // THREE.DirectionalLight.
+    struct directional_light : light
     {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
+        directional_light();
+
+        // World-space direction the light travels along (from the
+        // source toward the scene). Need not be normalized; the scene
+        // pass normalizes before packing it into the UBO.
+        infrastructure::math::vec3 direction{0.0f, 0.0f, -1.0f};
     };
 } // namespace rendering_engine

--- a/rendering_engine/lighting/light.cpp
+++ b/rendering_engine/lighting/light.cpp
@@ -20,27 +20,43 @@
  * SOFTWARE.
  */
 
-#pragma once
+#include <rendering_engine/lighting/light.hpp>
 
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <algorithm>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
+    namespace
     {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
-    };
+        // Function-local static so the registry is alive before any
+        // light's static/global constructor runs and survives until the
+        // last light is destroyed — game modules may create lights at
+        // static-init time through the module pattern.
+        std::vector<light*>& light_registry()
+        {
+            static std::vector<light*> lights;
+            return lights;
+        }
+    } // namespace
+
+    light::light(light_type type) : m_type(type)
+    {
+        light_registry().push_back(this);
+    }
+
+    light::~light()
+    {
+        auto& lights = light_registry();
+        lights.erase(std::remove(lights.begin(), lights.end(), this), lights.end());
+    }
+
+    light_type light::type() const noexcept
+    {
+        return m_type;
+    }
+
+    const std::vector<light*>& registered_lights()
+    {
+        return light_registry();
+    }
 } // namespace rendering_engine

--- a/rendering_engine/lighting/light.hpp
+++ b/rendering_engine/lighting/light.hpp
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+
+namespace rendering_engine
+{
+    // Discriminator for the concrete light kind. The scene pass reads
+    // it to route each registered light into the matching slot of the
+    // packed lights UBO without a dynamic_cast.
+    enum class light_type
+    {
+        ambient,
+        directional,
+        point,
+    };
+
+    // Base for every light source. Carries the colour / intensity every
+    // kind shares; concrete subtypes add their own geometry (direction,
+    // position, attenuation). A light adds itself to the process-wide
+    // registry on construction and removes itself on destruction, so
+    // simply keeping a light alive is enough for the scene pass to see
+    // it. Main-thread-only, like the rest of the engine — no
+    // synchronization.
+    struct light
+    {
+        explicit light(light_type type);
+        virtual ~light();
+
+        light(const light&) = delete;
+        light& operator=(const light&) = delete;
+
+        light_type type() const noexcept;
+
+        // Linear RGB radiance. Multiplied by @ref intensity before
+        // upload.
+        infrastructure::math::vec3 color{1.0f, 1.0f, 1.0f};
+
+        // Scalar multiplier on @ref color. Three.js analog:
+        // Light.intensity.
+        float intensity{1.0f};
+
+    private:
+        light_type m_type;
+    };
+
+    // The lights alive right now, in construction order. Owned by the
+    // lights themselves (the vector holds non-owning back-pointers); the
+    // scene pass walks it once per frame to pack the lights UBO.
+    const std::vector<light*>& registered_lights();
+} // namespace rendering_engine

--- a/rendering_engine/lighting/lights_ubo.cpp
+++ b/rendering_engine/lighting/lights_ubo.cpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/lighting/lights_ubo.hpp>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/lighting/ambient_light.hpp>
+#include <rendering_engine/lighting/directional_light.hpp>
+#include <rendering_engine/lighting/light.hpp>
+#include <rendering_engine/lighting/point_light.hpp>
+
+namespace rendering_engine
+{
+    namespace
+    {
+        void write_vec3(float (&dst)[4], const infrastructure::math::vec3& v, float w)
+        {
+            dst[0] = v.x;
+            dst[1] = v.y;
+            dst[2] = v.z;
+            dst[3] = w;
+        }
+    } // namespace
+
+    void pack_lights(const std::vector<light*>& lights, gpu_lights& out)
+    {
+        out = gpu_lights{};
+
+        infrastructure::math::vec3 ambient{0.0f, 0.0f, 0.0f};
+        uint32_t directional_count = 0;
+        uint32_t point_count = 0;
+
+        for (const light* l : lights)
+        {
+            switch (l->type())
+            {
+            case light_type::ambient:
+            {
+                ambient += l->color * l->intensity;
+                break;
+            }
+            case light_type::directional:
+            {
+                if (directional_count >= max_directional_lights)
+                {
+                    break;
+                }
+                const auto* dl = static_cast<const directional_light*>(l);
+                gpu_directional_light& slot = out.directional[directional_count];
+                write_vec3(slot.direction, infrastructure::math::normalize(dl->direction), 0.0f);
+                write_vec3(slot.color, dl->color * dl->intensity, 0.0f);
+                ++directional_count;
+                break;
+            }
+            case light_type::point:
+            {
+                if (point_count >= max_point_lights)
+                {
+                    break;
+                }
+                const auto* pl = static_cast<const point_light*>(l);
+                gpu_point_light& slot = out.point[point_count];
+                write_vec3(slot.position, pl->position, 0.0f);
+                write_vec3(slot.color, pl->color * pl->intensity, 0.0f);
+                slot.attenuation[0] = pl->range;
+                slot.attenuation[1] = pl->constant_attenuation;
+                slot.attenuation[2] = pl->linear_attenuation;
+                slot.attenuation[3] = pl->quadratic_attenuation;
+                ++point_count;
+                break;
+            }
+            }
+        }
+
+        out.ambient[0] = ambient.x;
+        out.ambient[1] = ambient.y;
+        out.ambient[2] = ambient.z;
+        out.ambient[3] = 0.0f;
+        out.directional_count = static_cast<int32_t>(directional_count);
+        out.point_count = static_cast<int32_t>(point_count);
+    }
+} // namespace rendering_engine

--- a/rendering_engine/lighting/lights_ubo.hpp
+++ b/rendering_engine/lighting/lights_ubo.hpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace rendering_engine
+{
+    struct light;
+
+    // Fixed UBO capacities. Excess lights past these counts are dropped
+    // when packing; bump the constants (and the matching GLSL array
+    // sizes in the consuming material) together if more are needed.
+    inline constexpr uint32_t max_directional_lights = 4;
+    inline constexpr uint32_t max_point_lights = 16;
+
+    // std140 mirror of one directional light entry (32 bytes). Every
+    // member is vec4-aligned so the C++ layout matches the shared
+    // @c DirectionalLight GLSL struct byte-for-byte.
+    struct gpu_directional_light
+    {
+        float direction[4]; // xyz normalized direction, w unused
+        float color[4];     // rgb radiance pre-multiplied by intensity, a unused
+    };
+
+    // std140 mirror of one point light entry (48 bytes).
+    struct gpu_point_light
+    {
+        float position[4];    // xyz world position, w unused
+        float color[4];       // rgb radiance pre-multiplied by intensity, a unused
+        float attenuation[4]; // x range, y constant, z linear, w quadratic
+    };
+
+    // std140 mirror of the per-frame @c Lights block bound at slot 0,
+    // binding 2. The layout it must match in GLSL is:
+    //
+    //   layout(set = 0, binding = 2, std140) uniform Lights
+    //   {
+    //       vec4 ambient;                                // rgb sum, a unused
+    //       ivec4 counts;                                // x directional, y point
+    //       DirectionalLight directional[MAX_DIRECTIONAL];
+    //       PointLight point[MAX_POINT];
+    //   } u_lights;
+    //
+    // The two scalar counts plus padding fill the ivec4 so the light
+    // arrays start on a 16-byte boundary, as std140 requires.
+    struct gpu_lights
+    {
+        float ambient[4];
+
+        int32_t directional_count;
+        int32_t point_count;
+        int32_t pad0;
+        int32_t pad1;
+
+        gpu_directional_light directional[max_directional_lights];
+        gpu_point_light point[max_point_lights];
+    };
+
+    // Accumulate @p lights into @p out: ambient lights sum into a single
+    // term, directional / point lights fill their arrays up to capacity,
+    // and the counts are written. @p out is fully overwritten.
+    void pack_lights(const std::vector<light*>& lights, gpu_lights& out);
+} // namespace rendering_engine

--- a/rendering_engine/lighting/point_light.cpp
+++ b/rendering_engine/lighting/point_light.cpp
@@ -20,27 +20,9 @@
  * SOFTWARE.
  */
 
-#pragma once
-
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/lighting/point_light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
-    {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
-    };
+    point_light::point_light() : light(light_type::point) {}
 } // namespace rendering_engine

--- a/rendering_engine/lighting/point_light.hpp
+++ b/rendering_engine/lighting/point_light.hpp
@@ -22,25 +22,29 @@
 
 #pragma once
 
-#include <rendering_engine/gpu/handle.hpp>
-#include <rendering_engine/materials/material.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/lighting/light.hpp>
 
 namespace rendering_engine
 {
-    // Built-in 3D scene material. Position-only vertex stream, MVP
-    // transform in the vertex shader, flat-white fragment. Per-draw
-    // bind group at slot 1 carries @c modelMatrix; the per-frame group
-    // at slot 0 (camera @c viewMatrix / @c projectionMatrix at binding 0
-    // plus the packed lights block at binding 2) is owned and bound by
-    // the @ref scene_pass. The shading pass that consumes the lights
-    // block is a follow-up; this material still outputs flat white.
-    struct lit_material : public material
+    // Omni-directional light radiating from a world-space point and
+    // falling off with distance. Three.js analog: THREE.PointLight.
+    struct point_light : light
     {
-        // @p frame_layout is the per-frame bind-group layout owned by
-        // the @ref scene_pass. It must match the layout the pass binds
-        // at slot 0 every frame, so the pipeline and the runtime bind
-        // group agree on slot shape.
-        explicit lit_material(gpu::bind_group_layout frame_layout);
-        ~lit_material() override = default;
+        point_light();
+
+        // World-space position the light radiates from.
+        infrastructure::math::vec3 position{0.0f, 0.0f, 0.0f};
+
+        // Distance past which the light contributes nothing. 0 means no
+        // hard cutoff (falloff still applies). Three.js analog:
+        // PointLight.distance.
+        float range{0.0f};
+
+        // Classic constant / linear / quadratic attenuation
+        // coefficients: 1 / (constant + linear*d + quadratic*d*d).
+        float constant_attenuation{1.0f};
+        float linear_attenuation{0.0f};
+        float quadratic_attenuation{1.0f};
     };
 } // namespace rendering_engine

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -34,6 +34,8 @@
 #include <rendering_engine/gpu/buffer.hpp>
 #include <rendering_engine/gpu/device.hpp>
 #include <rendering_engine/gpu/render_target.hpp>
+#include <rendering_engine/lighting/light.hpp>
+#include <rendering_engine/lighting/lights_ubo.hpp>
 #include <rendering_engine/materials/material.hpp>
 #include <rendering_engine/renderables/renderable.hpp>
 
@@ -41,11 +43,20 @@ namespace rendering_engine
 {
     namespace
     {
-        // std140 layout for the per-frame UBO: mat4 viewMatrix at
-        // offset 0, mat4 projectionMatrix at offset 64. mat4 is
+        // std140 layout for the per-frame camera UBO: mat4 viewMatrix
+        // at offset 0, mat4 projectionMatrix at offset 64. mat4 is
         // 16-byte aligned and 64 bytes; no padding needed between
         // the two members.
         constexpr size_t per_frame_ubo_size = 2 * sizeof(infrastructure::math::mat4);
+
+        // Binding numbers within the per-frame bind group (slot 0). The
+        // numbers must stay unique across both descriptor sets in a lit
+        // pipeline because OpenGL flattens UBO bindings into a single
+        // namespace through ARB_gl_spirv: binding 0 = camera here,
+        // binding 1 = the per-draw model matrix (set 1), so the lights
+        // block takes binding 2.
+        constexpr uint32_t camera_binding = 0;
+        constexpr uint32_t lights_binding = 2;
     } // namespace
 
     scene_pass::scene_pass(std::vector<renderable*>* registry) : m_registry(registry)
@@ -53,7 +64,8 @@ namespace rendering_engine
         auto& gpu = *control::current_engine().gpu;
 
         gpu::bind_group_layout_descriptor frame_layout_descriptor{};
-        frame_layout_descriptor.entries.push_back({0, gpu::binding_kind::uniform_buffer});
+        frame_layout_descriptor.entries.push_back({camera_binding, gpu::binding_kind::uniform_buffer});
+        frame_layout_descriptor.entries.push_back({lights_binding, gpu::binding_kind::uniform_buffer});
         m_frame_layout = gpu.create_bind_group_layout(frame_layout_descriptor);
 
         gpu::buffer_descriptor ubo_descriptor{};
@@ -62,13 +74,27 @@ namespace rendering_engine
         ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
         m_frame_ubo = gpu.create_buffer(ubo_descriptor);
 
+        gpu::buffer_descriptor lights_descriptor{};
+        lights_descriptor.size = sizeof(gpu_lights);
+        lights_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        lights_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_lights_ubo = gpu.create_buffer(lights_descriptor);
+
         gpu::bind_group_descriptor frame_bind_group_descriptor{};
         frame_bind_group_descriptor.layout = m_frame_layout;
-        gpu::binding_value frame_slot{};
-        frame_slot.binding = 0;
-        frame_slot.kind = gpu::binding_kind::uniform_buffer;
-        frame_slot.buffer_value = m_frame_ubo;
-        frame_bind_group_descriptor.entries.push_back(frame_slot);
+
+        gpu::binding_value camera_slot{};
+        camera_slot.binding = camera_binding;
+        camera_slot.kind = gpu::binding_kind::uniform_buffer;
+        camera_slot.buffer_value = m_frame_ubo;
+        frame_bind_group_descriptor.entries.push_back(camera_slot);
+
+        gpu::binding_value lights_slot{};
+        lights_slot.binding = lights_binding;
+        lights_slot.kind = gpu::binding_kind::uniform_buffer;
+        lights_slot.buffer_value = m_lights_ubo;
+        frame_bind_group_descriptor.entries.push_back(lights_slot);
+
         m_frame_bind_group = gpu.create_bind_group(frame_bind_group_descriptor);
     }
 
@@ -79,6 +105,11 @@ namespace rendering_engine
         {
             gpu.destroy(m_frame_bind_group);
             m_frame_bind_group = {};
+        }
+        if (m_lights_ubo.valid())
+        {
+            gpu.destroy(m_lights_ubo);
+            m_lights_ubo = {};
         }
         if (m_frame_ubo.valid())
         {
@@ -134,6 +165,14 @@ namespace rendering_engine
         std::memcpy(ubo_payload.data(), view.data(), sizeof(infrastructure::math::mat4));
         std::memcpy(ubo_payload.data() + 16, projection.data(), sizeof(infrastructure::math::mat4));
         gpu.write_buffer(m_frame_ubo, ubo_payload.data(), per_frame_ubo_size, 0);
+
+        // Pack every live light into the std140 lights block and upload
+        // it alongside the camera UBO. Lit materials read this from the
+        // per-frame group; the scene pass owns it so light objects never
+        // touch the GPU directly.
+        gpu_lights lights_payload{};
+        pack_lights(registered_lights(), lights_payload);
+        gpu.write_buffer(m_lights_ubo, &lights_payload, sizeof(gpu_lights), 0);
 
         // Collect every renderable's draw items into a single per-frame
         // list, then sort by pipeline id so the dispatch loop only

--- a/rendering_engine/passes/scene_pass.hpp
+++ b/rendering_engine/passes/scene_pass.hpp
@@ -40,9 +40,10 @@ namespace rendering_engine
      *        hatch for debug / gizmo callers.
      *
      * Owns the per-frame bind-group layout (camera @c viewMatrix /
-     * @c projectionMatrix at slot 0). The matching @c lit_material
-     * reads the layout via @ref frame_bind_group_layout so the
-     * pipeline and the runtime bind group agree on slot shape.
+     * @c projectionMatrix at binding 0 and the packed lights block at
+     * binding 2, both in slot 0). The matching @c lit_material reads the
+     * layout via @ref frame_bind_group_layout so the pipeline and the
+     * runtime bind group agree on slot shape.
      *
      * Skipped when no camera is attached (matches the previous
      * @c if (camera != nullptr) gate).
@@ -70,11 +71,14 @@ namespace rendering_engine
 
         // Per-frame state — owned by the pass; created once and
         // refilled every record(). Released in the destructor before
-        // the device tears its pools down. The UBO carries the
+        // the device tears its pools down. The camera UBO carries the
         // {viewMatrix, projectionMatrix} pair packed std140 (two
-        // mat4s = 128 bytes).
+        // mat4s = 128 bytes) at binding 0; the lights UBO carries the
+        // packed @ref gpu_lights block at binding 2. Both live in the
+        // single per-frame bind group bound at slot 0.
         gpu::bind_group_layout m_frame_layout{};
         gpu::buffer m_frame_ubo{};
+        gpu::buffer m_lights_ubo{};
         gpu::bind_group m_frame_bind_group{};
 
         // Reused across frames so the underlying allocation persists.


### PR DESCRIPTION
## Summary
Implements #101 — the lighting plumbing every lit material will consume.

- New `rendering_engine/lighting/` module:
  - `light` base + a process-wide registry (lights add/remove themselves on construct/destruct).
  - `ambient_light`, `directional_light`, `point_light` (Three.js analogs: `AmbientLight` / `DirectionalLight` / `PointLight`).
  - `lights_ubo` — fixed-capacity std140 mirror structs (`gpu_lights`, capacities `max_directional_lights = 4`, `max_point_lights = 16`) plus `pack_lights()`.
- `scene_pass` now owns a lights UBO alongside the camera UBO in the per-frame bind group at slot 0 (camera at binding 0, lights at binding 2 to stay clear of the per-draw model matrix at binding 1 under OpenGL's flat UBO namespace). It packs every live light and uploads the block each frame.
- `lit_material` inherits the extended per-frame layout. Consuming the block for actual shading is deferred to the Phong material follow-up; the fragment shader still outputs flat white.

## Notes
- `snake_case` throughout; main-thread-only, no synchronization.
- Light arrays past capacity are dropped when packing; bump the constants and the matching GLSL array sizes together.

## Test plan
- [x] `./scripts/build.ps1` configures and builds clean (MSVC + vcpkg, Release).
- [x] `./scripts/check-style.ps1` — no style issues.
- [x] `./scripts/check-naming.ps1` — no naming violations.
- [x] Visual verification deferred until a lit material consumes the block (Phong follow-up).