### PR TITLE
feat: transform quaternion + look_at (transform & camera)

### DIFF
--- a/infrastructure/math/quat.cpp
+++ b/infrastructure/math/quat.cpp
@@ -23,22 +23,75 @@
 #include <infrastructure/math/quat.hpp>
 
 #include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/quaternion.hpp>
 
 namespace infrastructure::math
 {
+    namespace
+    {
+        glm::quat to_glm(const quat& q) noexcept
+        {
+            return glm::quat{q.w, q.x, q.y, q.z};
+        }
+
+        quat from_glm(const glm::quat& q) noexcept
+        {
+            return quat{q.w, q.x, q.y, q.z};
+        }
+    } // namespace
+
     quat normalize(const quat& q) noexcept
     {
-        glm::quat result = glm::normalize(glm::quat{q.w, q.x, q.y, q.z});
-        return quat{result.w, result.x, result.y, result.z};
+        return from_glm(glm::normalize(to_glm(q)));
     }
 
     quat inverse(const quat& q) noexcept
     {
-        glm::quat result = glm::inverse(glm::quat{q.w, q.x, q.y, q.z});
-        return quat{result.w, result.x, result.y, result.z};
+        return from_glm(glm::inverse(to_glm(q)));
+    }
+
+    quat operator*(const quat& a, const quat& b) noexcept
+    {
+        return from_glm(to_glm(a) * to_glm(b));
+    }
+
+    vec3 operator*(const quat& q, const vec3& v) noexcept
+    {
+        glm::vec3 result = to_glm(q) * glm::vec3{v.x, v.y, v.z};
+        return vec3{result.x, result.y, result.z};
+    }
+
+    quat quat_from_euler(const vec3& euler_radians) noexcept
+    {
+        return from_glm(glm::quat{glm::vec3{euler_radians.x, euler_radians.y, euler_radians.z}});
+    }
+
+    vec3 euler_from_quat(const quat& q) noexcept
+    {
+        glm::vec3 result = glm::eulerAngles(to_glm(q));
+        return vec3{result.x, result.y, result.z};
+    }
+
+    quat quat_look_at(const vec3& direction, const vec3& up) noexcept
+    {
+        return from_glm(glm::quatLookAt(glm::normalize(glm::vec3{direction.x, direction.y, direction.z}),
+                                        glm::vec3{up.x, up.y, up.z}));
+    }
+
+    mat4 to_mat4(const quat& q) noexcept
+    {
+        glm::mat4 result = glm::mat4_cast(to_glm(q));
+        mat4 out;
+        const float* p = glm::value_ptr(result);
+        for (int i = 0; i < 16; ++i)
+        {
+            out.m[i] = p[i];
+        }
+        return out;
     }
 } // namespace infrastructure::math

--- a/infrastructure/math/quat.hpp
+++ b/infrastructure/math/quat.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <infrastructure/math/mat4.hpp>
+#include <infrastructure/math/vec3.hpp>
+
 namespace infrastructure::math
 {
     /** @brief Float quaternion. Components are exposed in @c (w, x, y, z) order. */
@@ -38,4 +41,18 @@ namespace infrastructure::math
 
     quat normalize(const quat& q) noexcept;
     quat inverse(const quat& q) noexcept;
+
+    /** @brief Hamilton product: composes two rotations (@p a applied after @p b). */
+    quat operator*(const quat& a, const quat& b) noexcept;
+    /** @brief Rotates @p v by the rotation @p q. */
+    vec3 operator*(const quat& q, const vec3& v) noexcept;
+
+    /** @brief Builds a quaternion from intrinsic Tait-Bryan euler angles (radians). */
+    quat quat_from_euler(const vec3& euler_radians) noexcept;
+    /** @brief Extracts intrinsic Tait-Bryan euler angles (radians) from @p q. */
+    vec3 euler_from_quat(const quat& q) noexcept;
+    /** @brief Orientation whose forward (-Z) axis points along @p direction, with @p up as the reference up. */
+    quat quat_look_at(const vec3& direction, const vec3& up) noexcept;
+    /** @brief Rotation matrix equivalent to @p q. */
+    mat4 to_mat4(const quat& q) noexcept;
 } // namespace infrastructure::math

--- a/rendering_engine/camera/camera.cpp
+++ b/rendering_engine/camera/camera.cpp
@@ -50,6 +50,20 @@ rendering_engine::camera* rendering_engine::camera::get_current_camera()
     return rendering_engine::camera::m_current_camera;
 }
 
+void rendering_engine::camera::look_at(const infrastructure::math::vec3& target)
+{
+    infrastructure::math::vec3 direction = target - transform.get_position();
+    if (infrastructure::math::length(direction) <= 0.0f)
+    {
+        return;
+    }
+
+    // The view matrix derives its look-at target from the position plus the rotation vector, so the
+    // camera's orientation lives in that rotation as a forward direction (see get_view_matrix).
+    transform.set_rotation(infrastructure::math::normalize(direction));
+    invalidate_view_matrix();
+}
+
 void rendering_engine::camera::invalidate_view_matrix()
 {
     m_is_view_matrix_dirty = true;

--- a/rendering_engine/camera/camera.hpp
+++ b/rendering_engine/camera/camera.hpp
@@ -40,6 +40,9 @@ namespace rendering_engine
 
         rendering_engine::util::transform transform;
 
+        // Orients the camera so it faces @p target, using the engine up axis (+Z).
+        void look_at(const infrastructure::math::vec3& target);
+
         void invalidate_view_matrix();
         const infrastructure::math::mat4 get_view_matrix() const;
 

--- a/rendering_engine/util/transform.cpp
+++ b/rendering_engine/util/transform.cpp
@@ -24,7 +24,7 @@
 #include <rendering_engine/util/transform.hpp>
 
 rendering_engine::util::transform::transform()
-    : m_is_transform_matrix_dirty{true}, m_position{0.0f, 0.0f, 0.0f}, m_rotation{0.0f, 0.0f, 0.0f},
+    : m_is_transform_matrix_dirty{true}, m_position{0.0f, 0.0f, 0.0f}, m_rotation{0.0f, 0.0f, 0.0f}, m_quaternion{},
       m_scale{1.0f, 1.0f, 1.0f}
 {
 }
@@ -38,6 +38,14 @@ void rendering_engine::util::transform::set_position(const infrastructure::math:
 void rendering_engine::util::transform::set_rotation(const infrastructure::math::vec3& rotation)
 {
     m_rotation = rotation;
+    m_quaternion = infrastructure::math::quat_from_euler(rotation);
+    m_is_transform_matrix_dirty = true;
+}
+
+void rendering_engine::util::transform::set_quaternion(const infrastructure::math::quat& rotation)
+{
+    m_quaternion = infrastructure::math::normalize(rotation);
+    m_rotation = infrastructure::math::euler_from_quat(m_quaternion);
     m_is_transform_matrix_dirty = true;
 }
 
@@ -57,9 +65,43 @@ infrastructure::math::vec3 rendering_engine::util::transform::get_rotation() con
     return m_rotation;
 }
 
+infrastructure::math::quat rendering_engine::util::transform::get_quaternion() const
+{
+    return m_quaternion;
+}
+
 infrastructure::math::vec3 rendering_engine::util::transform::get_scale() const
 {
     return m_scale;
+}
+
+void rendering_engine::util::transform::look_at(const infrastructure::math::vec3& target,
+                                                const infrastructure::math::vec3& up)
+{
+    infrastructure::math::vec3 direction = target - m_position;
+    if (infrastructure::math::length(direction) <= 0.0f)
+    {
+        return;
+    }
+
+    m_quaternion = infrastructure::math::quat_look_at(direction, up);
+    m_rotation = infrastructure::math::euler_from_quat(m_quaternion);
+    m_is_transform_matrix_dirty = true;
+}
+
+infrastructure::math::vec3 rendering_engine::util::transform::get_forward() const
+{
+    return infrastructure::math::normalize(m_quaternion * infrastructure::math::vec3{0.0f, 0.0f, -1.0f});
+}
+
+infrastructure::math::vec3 rendering_engine::util::transform::get_right() const
+{
+    return infrastructure::math::normalize(m_quaternion * infrastructure::math::vec3{1.0f, 0.0f, 0.0f});
+}
+
+infrastructure::math::vec3 rendering_engine::util::transform::get_up() const
+{
+    return infrastructure::math::normalize(m_quaternion * infrastructure::math::vec3{0.0f, 1.0f, 0.0f});
 }
 
 infrastructure::math::mat4 rendering_engine::util::transform::get_transform_matrix() const
@@ -70,19 +112,20 @@ infrastructure::math::mat4 rendering_engine::util::transform::get_transform_matr
     }
 
     using infrastructure::math::mat4;
-    using infrastructure::math::rotate;
     using infrastructure::math::scale;
+    using infrastructure::math::to_mat4;
     using infrastructure::math::translate;
-    using infrastructure::math::vec3;
 
     mat4 pos_matrix = translate(m_position);
-    mat4 rot_x_matrix = rotate(m_rotation.x, vec3{1.0f, 0.0f, 0.0f});
-    mat4 rot_y_matrix = rotate(m_rotation.y, vec3{0.0f, 1.0f, 0.0f});
-    mat4 rot_z_matrix = rotate(m_rotation.z, vec3{0.0f, 0.0f, 1.0f});
+    mat4 rot_matrix = to_mat4(m_quaternion);
     mat4 scale_matrix = scale(m_scale);
-    mat4 rot_matrix = rot_z_matrix * rot_y_matrix * rot_x_matrix;
 
     m_transform_matrix = pos_matrix * rot_matrix * scale_matrix;
     m_is_transform_matrix_dirty = false;
     return m_transform_matrix;
+}
+
+infrastructure::math::mat4 rendering_engine::util::transform::get_world_matrix() const
+{
+    return get_transform_matrix();
 }

--- a/rendering_engine/util/transform.hpp
+++ b/rendering_engine/util/transform.hpp
@@ -32,13 +32,26 @@ namespace rendering_engine::util
 
         void set_position(const infrastructure::math::vec3& position);
         void set_rotation(const infrastructure::math::vec3& rotation);
+        void set_quaternion(const infrastructure::math::quat& rotation);
         void set_scale(const infrastructure::math::vec3& scale);
 
         infrastructure::math::vec3 get_position() const;
         infrastructure::math::vec3 get_rotation() const;
+        infrastructure::math::quat get_quaternion() const;
         infrastructure::math::vec3 get_scale() const;
 
+        // Orients the transform so its forward (-Z) axis points from the current position towards @p target.
+        void look_at(const infrastructure::math::vec3& target,
+                     const infrastructure::math::vec3& up = infrastructure::math::vec3{0.0f, 1.0f, 0.0f});
+
+        // Basis vectors of the current orientation, in world space.
+        infrastructure::math::vec3 get_forward() const;
+        infrastructure::math::vec3 get_right() const;
+        infrastructure::math::vec3 get_up() const;
+
         infrastructure::math::mat4 get_transform_matrix() const;
+        // World-space matrix. No parenting yet, so this matches the local transform matrix.
+        infrastructure::math::mat4 get_world_matrix() const;
 
     private:
         mutable infrastructure::math::mat4 m_transform_matrix;
@@ -46,6 +59,7 @@ namespace rendering_engine::util
 
         infrastructure::math::vec3 m_position;
         infrastructure::math::vec3 m_rotation;
+        infrastructure::math::quat m_quaternion;
         infrastructure::math::vec3 m_scale;
     };
 } // namespace rendering_engine::util


### PR DESCRIPTION
## Summary
Implements #102. Gives `util/transform` a quaternion-based rotation and the orientation helpers needed for stable orientation and the future scene graph, mirroring Three.js's `Object3D` transform.

- **`util/transform`** — quaternion is now the canonical rotation driving the transform matrix. Adds `set_quaternion` / `get_quaternion`, `look_at(target, up)`, `get_forward` / `get_right` / `get_up` basis helpers, and `get_world_matrix` (matches the local matrix until parenting exists). Euler `set_rotation` / `get_rotation` are kept and stay in sync.
- **`camera`** — adds a `look_at(target)` convenience that orients the camera through its existing rotation-as-forward view path.
- **math layer** — extends `quat` with `quat_from_euler`, `euler_from_quat`, `quat_look_at`, `to_mat4`, quaternion composition (`operator*`), and `quat * vec3` rotation. GLM stays confined to `infrastructure/math/`.

## Notes
- `snake_case` throughout.
- Pure single-axis Euler rotations (e.g. the cube module's Z spin) round-trip through the quaternion unchanged.

## Test plan
- [x] `./scripts/build.ps1` (MSVC Release) succeeds
- [x] `./scripts/check-style.ps1` — no style issues
- [x] `./scripts/check-naming.ps1` — no naming violations