### PR TITLE
feat: standard_material (PBR metallic-roughness)

### DIFF
--- a/rendering_engine/materials/CMakeLists.txt
+++ b/rendering_engine/materials/CMakeLists.txt
@@ -5,6 +5,8 @@ target_sources(AlphaEngine PRIVATE
     material.hpp
     phong_material.cpp
     phong_material.hpp
+    standard_material.cpp
+    standard_material.hpp
     ui_material.cpp
     ui_material.hpp
 )

--- a/rendering_engine/materials/standard_material.cpp
+++ b/rendering_engine/materials/standard_material.cpp
@@ -1,0 +1,575 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/materials/standard_material.hpp>
+
+#include <array>
+#include <string>
+
+#include <control/engine.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/mesh/tangent.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+
+namespace
+{
+    // Binding numbers. UBOs share a single namespace across every
+    // descriptor set on the OpenGL backend (ARB_gl_spirv), so they must
+    // stay globally unique: the scene_pass owns camera = 0 and lights = 2
+    // in the per-frame set, the per-draw model matrix takes 1, leaving 3
+    // for the per-material params block. The five samplers live in their
+    // own namespace but must still differ from the UBO within the Vulkan
+    // per-material set, so they run 4..8.
+    constexpr uint32_t draw_model_binding = 1;
+    constexpr uint32_t material_params_binding = 3;
+    constexpr uint32_t material_albedo_map_binding = 4;
+    constexpr uint32_t material_normal_map_binding = 5;
+    constexpr uint32_t material_metalness_map_binding = 6;
+    constexpr uint32_t material_roughness_map_binding = 7;
+    constexpr uint32_t material_emissive_map_binding = 8;
+
+    // std140 layout for the per-material params UBO, five vec4 rows:
+    //   0  baseColor   (rgb tint, a alpha)
+    //   16 emissive    (rgb colour, a intensity)
+    //   32 params      (x metalness, y roughness, z opacity)
+    //   48 mapFlags    (x albedo, y normal, z metalness, w roughness)
+    //   64 mapFlags2   (x emissive)
+    // 80 bytes total.
+    constexpr size_t material_ubo_size = 80;
+
+    const std::string vertex_shader = R"vs(
+        #version 450
+
+        layout(location = 0) in vec3 position;
+        layout(location = 1) in vec2 uv;
+        layout(location = 2) in vec3 normal;
+        layout(location = 3) in vec4 tangent;
+
+        layout(location = 0) out vec3 worldPosition;
+        layout(location = 1) out vec3 worldNormal;
+        layout(location = 2) out vec2 texCoord;
+        layout(location = 3) out vec3 cameraPosition;
+        layout(location = 4) out vec4 worldTangent;
+
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+        } u_frame;
+
+        layout(set = 1, binding = 1, std140) uniform PerDraw
+        {
+            mat4 modelMatrix;
+        } u_draw;
+
+        void main()
+        {
+            vec4 world = u_draw.modelMatrix * vec4(position, 1.0);
+            worldPosition = world.xyz;
+            // Inverse-transpose of the upper-left 3x3 so non-uniform
+            // scale does not skew the shading normal.
+            mat3 normalMatrix = transpose(inverse(mat3(u_draw.modelMatrix)));
+            worldNormal = normalMatrix * normal;
+            // The tangent is a direction along the surface, so it rides
+            // the model matrix directly; the handedness sign passes
+            // through in .w to rebuild the bitangent.
+            worldTangent = vec4(mat3(u_draw.modelMatrix) * tangent.xyz, tangent.w);
+            texCoord = uv;
+            // Camera world position is the translation column of the
+            // inverse view matrix; derived here so the shared per-frame
+            // UBO need not carry it.
+            cameraPosition = inverse(u_frame.viewMatrix)[3].xyz;
+            gl_Position = u_frame.projectionMatrix * u_frame.viewMatrix * world;
+        }
+)vs";
+
+    const std::string fragment_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec3 worldPosition;
+        layout(location = 1) in vec3 worldNormal;
+        layout(location = 2) in vec2 texCoord;
+        layout(location = 3) in vec3 cameraPosition;
+        layout(location = 4) in vec4 worldTangent;
+
+        layout(location = 0) out vec4 fragColor;
+
+        const int MAX_DIRECTIONAL = 4;
+        const int MAX_POINT = 16;
+        const float PI = 3.14159265359;
+
+        struct DirectionalLight
+        {
+            vec4 direction; // xyz normalized, w unused
+            vec4 color;     // rgb radiance * intensity, a unused
+        };
+
+        struct PointLight
+        {
+            vec4 position;    // xyz world, w unused
+            vec4 color;       // rgb radiance * intensity, a unused
+            vec4 attenuation; // x range, y constant, z linear, w quadratic
+        };
+
+        layout(set = 0, binding = 2, std140) uniform Lights
+        {
+            vec4 ambient;
+            ivec4 counts; // x directional, y point
+            DirectionalLight directional[MAX_DIRECTIONAL];
+            PointLight point[MAX_POINT];
+        } u_lights;
+
+        layout(set = 2, binding = 3, std140) uniform Material
+        {
+            vec4 baseColor;
+            vec4 emissive; // rgb colour, a intensity
+            vec4 params;   // x metalness, y roughness, z opacity
+            vec4 mapFlags; // x albedo, y normal, z metalness, w roughness
+            vec4 mapFlags2; // x emissive
+        } u_material;
+
+        layout(set = 2, binding = 4) uniform sampler2D albedoMap;
+        layout(set = 2, binding = 5) uniform sampler2D normalMap;
+        layout(set = 2, binding = 6) uniform sampler2D metalnessMap;
+        layout(set = 2, binding = 7) uniform sampler2D roughnessMap;
+        layout(set = 2, binding = 8) uniform sampler2D emissiveMap;
+
+        vec3 shading_normal()
+        {
+            vec3 N = normalize(worldNormal);
+            if (u_material.mapFlags.y == 0.0)
+            {
+                return N;
+            }
+            // Gram-Schmidt re-orthonormalize the interpolated tangent
+            // against the normal, then rebuild the bitangent with the
+            // stored handedness.
+            vec3 T = normalize(worldTangent.xyz - N * dot(N, worldTangent.xyz));
+            vec3 B = cross(N, T) * worldTangent.w;
+            vec3 sampled = texture(normalMap, texCoord).xyz * 2.0 - 1.0;
+            return normalize(mat3(T, B, N) * sampled);
+        }
+
+        float distribution_ggx(vec3 N, vec3 H, float roughness)
+        {
+            float a = roughness * roughness;
+            float a2 = a * a;
+            float nDotH = max(dot(N, H), 0.0);
+            float denom = nDotH * nDotH * (a2 - 1.0) + 1.0;
+            return a2 / (PI * denom * denom);
+        }
+
+        float geometry_schlick_ggx(float nDotX, float roughness)
+        {
+            float r = roughness + 1.0;
+            float k = (r * r) / 8.0;
+            return nDotX / (nDotX * (1.0 - k) + k);
+        }
+
+        float geometry_smith(vec3 N, vec3 V, vec3 L, float roughness)
+        {
+            float nDotV = max(dot(N, V), 0.0);
+            float nDotL = max(dot(N, L), 0.0);
+            return geometry_schlick_ggx(nDotV, roughness) * geometry_schlick_ggx(nDotL, roughness);
+        }
+
+        vec3 fresnel_schlick(float cosTheta, vec3 F0)
+        {
+            return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+        }
+
+        vec3 brdf(vec3 N, vec3 V, vec3 L, vec3 radiance, vec3 albedo, float metalness, float roughness, vec3 F0)
+        {
+            float nDotL = max(dot(N, L), 0.0);
+            if (nDotL <= 0.0)
+            {
+                return vec3(0.0);
+            }
+            vec3 H = normalize(V + L);
+            float NDF = distribution_ggx(N, H, roughness);
+            float G = geometry_smith(N, V, L, roughness);
+            vec3 F = fresnel_schlick(max(dot(H, V), 0.0), F0);
+
+            vec3 numerator = NDF * G * F;
+            float denominator = 4.0 * max(dot(N, V), 0.0) * nDotL + 0.0001;
+            vec3 specular = numerator / denominator;
+
+            // Energy left over after the Fresnel reflection becomes
+            // diffuse; pure metals have no diffuse term.
+            vec3 kD = (vec3(1.0) - F) * (1.0 - metalness);
+            return (kD * albedo / PI + specular) * radiance * nDotL;
+        }
+
+        void main()
+        {
+            vec3 albedo = u_material.baseColor.rgb;
+            if (u_material.mapFlags.x != 0.0)
+            {
+                albedo *= texture(albedoMap, texCoord).rgb;
+            }
+            float metalness = u_material.params.x;
+            if (u_material.mapFlags.z != 0.0)
+            {
+                metalness *= texture(metalnessMap, texCoord).r;
+            }
+            float roughness = u_material.params.y;
+            if (u_material.mapFlags.w != 0.0)
+            {
+                roughness *= texture(roughnessMap, texCoord).r;
+            }
+            // Clamp roughness away from zero so the GGX denominator and
+            // the specular highlight stay finite.
+            roughness = clamp(roughness, 0.04, 1.0);
+
+            vec3 N = shading_normal();
+            vec3 V = normalize(cameraPosition - worldPosition);
+            vec3 F0 = mix(vec3(0.04), albedo, metalness);
+
+            vec3 Lo = vec3(0.0);
+
+            for (int i = 0; i < u_lights.counts.x; ++i)
+            {
+                vec3 L = normalize(-u_lights.directional[i].direction.xyz);
+                vec3 radiance = u_lights.directional[i].color.rgb;
+                Lo += brdf(N, V, L, radiance, albedo, metalness, roughness, F0);
+            }
+
+            for (int i = 0; i < u_lights.counts.y; ++i)
+            {
+                vec3 toLight = u_lights.point[i].position.xyz - worldPosition;
+                float dist = length(toLight);
+                float range = u_lights.point[i].attenuation.x;
+                if (range > 0.0 && dist > range)
+                {
+                    continue;
+                }
+                vec3 L = toLight / max(dist, 0.0001);
+                float constant = u_lights.point[i].attenuation.y;
+                float linear = u_lights.point[i].attenuation.z;
+                float quadratic = u_lights.point[i].attenuation.w;
+                float atten = 1.0 / (constant + linear * dist + quadratic * dist * dist);
+                vec3 radiance = u_lights.point[i].color.rgb * atten;
+                Lo += brdf(N, V, L, radiance, albedo, metalness, roughness, F0);
+            }
+
+            // Flat ambient stand-in until image-based lighting lands;
+            // pure metals reflect nothing without an environment, so the
+            // ambient diffuse fades out as metalness rises.
+            vec3 ambient = u_lights.ambient.rgb * albedo * (1.0 - metalness);
+
+            vec3 emissive = u_material.emissive.rgb * u_material.emissive.a;
+            if (u_material.mapFlags2.x != 0.0)
+            {
+                emissive *= texture(emissiveMap, texCoord).rgb;
+            }
+
+            vec3 color = ambient + Lo + emissive;
+            fragColor = vec4(color, u_material.baseColor.a * u_material.params.z);
+        }
+)fs";
+} // namespace
+
+namespace rendering_engine
+{
+    standard_material::standard_material(gpu::bind_group_layout frame_layout)
+    {
+        // Position+uv+normal+tangent stream; the layout helper bakes the
+        // attribute offsets that match vertex_position_uv_normal_tangent.
+        gpu::vertex_buffer_layout vertex_layout = vertex_position_uv_normal_tangent_layout();
+        vertex_layout.stride = 0;
+
+        // Per-draw layout (slot 1): the model matrix UBO at binding 1,
+        // matching every 3D renderable's bind group.
+        gpu::bind_group_layout_descriptor draw_layout{};
+        draw_layout.entries.push_back({draw_model_binding, gpu::binding_kind::uniform_buffer});
+
+        // Per-material layout (slot 2): the params UBO plus the five PBR
+        // samplers, all owned by this material.
+        gpu::bind_group_layout_descriptor material_layout{};
+        material_layout.entries.push_back({material_params_binding, gpu::binding_kind::uniform_buffer});
+        material_layout.entries.push_back({material_albedo_map_binding, gpu::binding_kind::texture});
+        material_layout.entries.push_back({material_normal_map_binding, gpu::binding_kind::texture});
+        material_layout.entries.push_back({material_metalness_map_binding, gpu::binding_kind::texture});
+        material_layout.entries.push_back({material_roughness_map_binding, gpu::binding_kind::texture});
+        material_layout.entries.push_back({material_emissive_map_binding, gpu::binding_kind::texture});
+
+        // Opaque lit surface: depth tested and written, no blending.
+        material_params params{};
+        params.transparent = false;
+        params.depth_test = true;
+        params.depth_write = true;
+
+        construct_pipeline(
+            vertex_shader, fragment_shader, vertex_layout, draw_layout, frame_layout, params, material_layout);
+
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = material_ubo_size;
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        auto& gpu = *control::current_engine().gpu;
+        m_material_ubo = gpu.create_buffer(ubo_descriptor);
+
+        rebuild_bind_group();
+    }
+
+    standard_material::~standard_material()
+    {
+        // Drop the bind group before the buffers / textures it
+        // references, then null it so the base destructor's
+        // destruct_pipeline does not double-free.
+        auto& gpu = *control::current_engine().gpu;
+        if (m_per_material_bind_group.valid())
+        {
+            gpu.destroy(m_per_material_bind_group);
+            m_per_material_bind_group = {};
+        }
+        release_map(m_emissive_map);
+        release_map(m_roughness_map);
+        release_map(m_metalness_map);
+        release_map(m_normal_map);
+        release_map(m_albedo_map);
+        if (m_material_ubo.valid())
+        {
+            gpu.destroy(m_material_ubo);
+            m_material_ubo = {};
+        }
+    }
+
+    uint32_t standard_material::per_material_slot() const
+    {
+        return per_draw_slot() + 1u;
+    }
+
+    void standard_material::set_base_color(const util::color& color)
+    {
+        m_base_color = color;
+        upload_params();
+    }
+
+    void standard_material::set_metalness(float metalness)
+    {
+        m_metalness = metalness;
+        upload_params();
+    }
+
+    void standard_material::set_roughness(float roughness)
+    {
+        m_roughness = roughness;
+        upload_params();
+    }
+
+    void standard_material::set_emissive(const util::color& color)
+    {
+        m_emissive = color;
+        upload_params();
+    }
+
+    void standard_material::set_emissive_intensity(float intensity)
+    {
+        m_emissive_intensity = intensity;
+        upload_params();
+    }
+
+    void standard_material::set_albedo_map(const util::image& image)
+    {
+        release_map(m_albedo_map);
+        m_albedo_map = upload_map(image);
+        rebuild_bind_group();
+    }
+
+    void standard_material::clear_albedo_map()
+    {
+        if (!m_albedo_map.valid())
+        {
+            return;
+        }
+        release_map(m_albedo_map);
+        rebuild_bind_group();
+    }
+
+    void standard_material::set_normal_map(const util::image& image)
+    {
+        release_map(m_normal_map);
+        m_normal_map = upload_map(image);
+        rebuild_bind_group();
+    }
+
+    void standard_material::clear_normal_map()
+    {
+        if (!m_normal_map.valid())
+        {
+            return;
+        }
+        release_map(m_normal_map);
+        rebuild_bind_group();
+    }
+
+    void standard_material::set_metalness_map(const util::image& image)
+    {
+        release_map(m_metalness_map);
+        m_metalness_map = upload_map(image);
+        rebuild_bind_group();
+    }
+
+    void standard_material::clear_metalness_map()
+    {
+        if (!m_metalness_map.valid())
+        {
+            return;
+        }
+        release_map(m_metalness_map);
+        rebuild_bind_group();
+    }
+
+    void standard_material::set_roughness_map(const util::image& image)
+    {
+        release_map(m_roughness_map);
+        m_roughness_map = upload_map(image);
+        rebuild_bind_group();
+    }
+
+    void standard_material::clear_roughness_map()
+    {
+        if (!m_roughness_map.valid())
+        {
+            return;
+        }
+        release_map(m_roughness_map);
+        rebuild_bind_group();
+    }
+
+    void standard_material::set_emissive_map(const util::image& image)
+    {
+        release_map(m_emissive_map);
+        m_emissive_map = upload_map(image);
+        rebuild_bind_group();
+    }
+
+    void standard_material::clear_emissive_map()
+    {
+        if (!m_emissive_map.valid())
+        {
+            return;
+        }
+        release_map(m_emissive_map);
+        rebuild_bind_group();
+    }
+
+    gpu::texture standard_material::upload_map(const util::image& image)
+    {
+        auto& gpu = *control::current_engine().gpu;
+
+        gpu::texture_descriptor descriptor{};
+        descriptor.dimension = gpu::texture_dimension::d2;
+        descriptor.format = gpu::texture_format::rgba8_unorm;
+        descriptor.width = image.get_width();
+        descriptor.height = image.get_height();
+        descriptor.mipmaps = true;
+        descriptor.min_filter = gpu::filter_mode::linear;
+        descriptor.mag_filter = gpu::filter_mode::linear;
+        descriptor.address_u = gpu::address_mode::repeat;
+        descriptor.address_v = gpu::address_mode::repeat;
+        descriptor.address_w = gpu::address_mode::repeat;
+        gpu::texture map = gpu.create_texture(descriptor);
+
+        const size_t pixel_bytes =
+            static_cast<size_t>(image.get_width()) * static_cast<size_t>(image.get_height()) * sizeof(util::color);
+        gpu.write_texture(map, image.get_pixels(), pixel_bytes);
+        gpu.generate_mipmaps(map);
+        return map;
+    }
+
+    void standard_material::release_map(gpu::texture& map)
+    {
+        if (!map.valid())
+        {
+            return;
+        }
+        auto& gpu = *control::current_engine().gpu;
+        gpu.destroy(map);
+        map = {};
+    }
+
+    void standard_material::rebuild_bind_group()
+    {
+        auto& gpu = *control::current_engine().gpu;
+        if (m_per_material_bind_group.valid())
+        {
+            gpu.destroy(m_per_material_bind_group);
+            m_per_material_bind_group = {};
+        }
+
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_per_material_layout;
+
+        gpu::binding_value ubo_slot{};
+        ubo_slot.binding = material_params_binding;
+        ubo_slot.kind = gpu::binding_kind::uniform_buffer;
+        ubo_slot.buffer_value = m_material_ubo;
+        bg_descriptor.entries.push_back(ubo_slot);
+
+        const std::array<std::pair<uint32_t, gpu::texture>, 5> maps = {{
+            {material_albedo_map_binding, m_albedo_map},
+            {material_normal_map_binding, m_normal_map},
+            {material_metalness_map_binding, m_metalness_map},
+            {material_roughness_map_binding, m_roughness_map},
+            {material_emissive_map_binding, m_emissive_map},
+        }};
+        for (const auto& [binding, texture] : maps)
+        {
+            gpu::binding_value tex_slot{};
+            tex_slot.binding = binding;
+            tex_slot.kind = gpu::binding_kind::texture;
+            tex_slot.texture_value = texture;
+            bg_descriptor.entries.push_back(tex_slot);
+        }
+
+        m_per_material_bind_group = gpu.create_bind_group(bg_descriptor);
+
+        upload_params();
+    }
+
+    void standard_material::upload_params()
+    {
+        std::array<float, 20> payload{};
+        payload[0] = static_cast<float>(m_base_color.r) / 255.0f;
+        payload[1] = static_cast<float>(m_base_color.g) / 255.0f;
+        payload[2] = static_cast<float>(m_base_color.b) / 255.0f;
+        payload[3] = static_cast<float>(m_base_color.a) / 255.0f;
+        payload[4] = static_cast<float>(m_emissive.r) / 255.0f;
+        payload[5] = static_cast<float>(m_emissive.g) / 255.0f;
+        payload[6] = static_cast<float>(m_emissive.b) / 255.0f;
+        payload[7] = m_emissive_intensity;
+        payload[8] = m_metalness;
+        payload[9] = m_roughness;
+        payload[10] = m_params.opacity;
+        payload[12] = m_albedo_map.valid() ? 1.0f : 0.0f;
+        payload[13] = m_normal_map.valid() ? 1.0f : 0.0f;
+        payload[14] = m_metalness_map.valid() ? 1.0f : 0.0f;
+        payload[15] = m_roughness_map.valid() ? 1.0f : 0.0f;
+        payload[16] = m_emissive_map.valid() ? 1.0f : 0.0f;
+
+        auto& gpu = *control::current_engine().gpu;
+        gpu.write_buffer(m_material_ubo, payload.data(), material_ubo_size, 0);
+    }
+} // namespace rendering_engine

--- a/rendering_engine/materials/standard_material.hpp
+++ b/rendering_engine/materials/standard_material.hpp
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/util/color.hpp>
+#include <rendering_engine/util/image.hpp>
+
+namespace rendering_engine
+{
+    // Built-in physically-based lit 3D scene material — the analogue of
+    // @c THREE.MeshStandardMaterial (metallic-roughness workflow). Cook-
+    // Torrance specular (GGX distribution, Smith geometry, Schlick-
+    // Fresnel) plus a Lambertian diffuse, driven by the per-frame lights
+    // UBO the @ref scene_pass uploads at slot 0, binding 2. The modern
+    // default surface: more expensive than @ref phong_material but the
+    // single biggest step toward Three.js visual parity.
+    //
+    // Consumes the position+uv+normal+tangent vertex stream (the tangent
+    // feeds the normal-map TBN basis). Slot layout matches the other 3D
+    // materials: the per-frame group at slot 0 (camera + lights, owned by
+    // the @ref scene_pass) and the per-draw group at slot 1 (@c
+    // modelMatrix, built by each renderable). The PBR scalars and the
+    // optional albedo / normal / metalness / roughness / emissive maps
+    // live in the per-material group at slot 2 owned by this material.
+    //
+    // Ambient is a flat term for now (@c ambient * albedo); image-based
+    // lighting is layered in by the skybox/IBL issue.
+    struct standard_material : public material
+    {
+        // @p frame_layout is the per-frame bind-group layout owned by
+        // the @ref scene_pass; it must match the layout the pass binds
+        // at slot 0 every frame so the pipeline and the runtime bind
+        // group agree on slot shape.
+        explicit standard_material(gpu::bind_group_layout frame_layout);
+        ~standard_material() override;
+
+        // Base (albedo) colour. When an albedo map is set the sampled
+        // texel modulates this tint (white leaves it unchanged). The
+        // alpha channel carries through to the output.
+        void set_base_color(const util::color& color);
+
+        // Metalness in [0, 1]. 0 is a dielectric (plastic, wood), 1 is a
+        // raw metal whose diffuse term vanishes and whose specular tints
+        // toward the base colour. Three.js analog: metalness.
+        void set_metalness(float metalness);
+
+        // Perceptual roughness in [0, 1]. 0 is a mirror-smooth surface,
+        // 1 is fully diffuse. Three.js analog: roughness.
+        void set_roughness(float roughness);
+
+        // Emissive colour added after shading (unaffected by lights).
+        // Black (the default) emits nothing.
+        void set_emissive(const util::color& color);
+
+        // Scalar multiplier on the emissive colour. Three.js analog:
+        // emissiveIntensity.
+        void set_emissive_intensity(float intensity);
+
+        // Bind an albedo (base-colour) texture; multiplied into the base
+        // colour. Replaces any previous map and rebuilds the per-material
+        // bind group.
+        void set_albedo_map(const util::image& image);
+        void clear_albedo_map();
+
+        // Bind a tangent-space normal map; perturbs the shading normal
+        // through the per-vertex TBN basis. Requires tangents on the
+        // vertex stream (this material's layout supplies them).
+        void set_normal_map(const util::image& image);
+        void clear_normal_map();
+
+        // Bind a metalness map; its red channel multiplies the metalness
+        // scalar.
+        void set_metalness_map(const util::image& image);
+        void clear_metalness_map();
+
+        // Bind a roughness map; its red channel multiplies the roughness
+        // scalar.
+        void set_roughness_map(const util::image& image);
+        void clear_roughness_map();
+
+        // Bind an emissive map; multiplied into the emissive term.
+        void set_emissive_map(const util::image& image);
+        void clear_emissive_map();
+
+        // The per-material group trails the per-frame and per-draw
+        // groups, so it occupies slot 2 (per-frame at 0, per-draw at 1).
+        uint32_t per_material_slot() const override;
+
+    private:
+        // (Re)create the per-material bind group against the current map
+        // handles, then push the latest params into the UBO.
+        void rebuild_bind_group();
+
+        // Push the PBR scalars + per-map enable flags into the per-
+        // material UBO.
+        void upload_params();
+
+        // Upload an RGBA8 image to a fresh mipmapped, repeat-addressed
+        // 2D texture. Shared by every set_*_map.
+        gpu::texture upload_map(const util::image& image);
+
+        // Destroy @p map if valid and null it. Shared by every clear_*_map
+        // and set_*_map (which replaces the previous map).
+        void release_map(gpu::texture& map);
+
+        util::color m_base_color{255, 255, 255, 255};
+        util::color m_emissive{0, 0, 0, 255};
+        float m_metalness{0.0f};
+        float m_roughness{1.0f};
+        float m_emissive_intensity{1.0f};
+
+        gpu::buffer m_material_ubo{};
+        gpu::texture m_albedo_map{};
+        gpu::texture m_normal_map{};
+        gpu::texture m_metalness_map{};
+        gpu::texture m_roughness_map{};
+        gpu::texture m_emissive_map{};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -30,6 +30,7 @@
 #include <rendering_engine/gpu/device.hpp>
 #include <rendering_engine/materials/basic_material.hpp>
 #include <rendering_engine/materials/phong_material.hpp>
+#include <rendering_engine/materials/standard_material.hpp>
 #include <rendering_engine/materials/ui_material.hpp>
 #include <rendering_engine/passes/debug_pass.hpp>
 #include <rendering_engine/passes/pass.hpp>
@@ -94,8 +95,9 @@ void rendering_engine::context::init()
     // has no per-frame group.
     m_basic_material = std::make_unique<basic_material>(scene_frame_layout);
     m_phong_material = std::make_unique<phong_material>(scene_frame_layout);
+    m_standard_material = std::make_unique<standard_material>(scene_frame_layout);
     m_ui_material = std::make_unique<ui_material>();
-    LOG_INF("Rendering Engine: basic_material, phong_material and ui_material constructed");
+    LOG_INF("Rendering Engine: basic_material, phong_material, standard_material and ui_material constructed");
 
     // Register the built-in passes in render order: scene writes into
     // the HDR target, the tonemap post pass maps it to LDR on the
@@ -127,6 +129,7 @@ void rendering_engine::context::quit()
     // Then materials, which own pipelines that reference the device.
     // Release them before the device tears its pools down.
     m_ui_material.reset();
+    m_standard_material.reset();
     m_phong_material.reset();
     m_basic_material.reset();
 
@@ -214,6 +217,11 @@ rendering_engine::basic_material& rendering_engine::context::get_basic_material(
 rendering_engine::phong_material& rendering_engine::context::get_phong_material()
 {
     return *m_phong_material;
+}
+
+rendering_engine::standard_material& rendering_engine::context::get_standard_material()
+{
+    return *m_standard_material;
 }
 
 rendering_engine::ui_material& rendering_engine::context::get_ui_material()

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -38,6 +38,7 @@ namespace rendering_engine
     struct renderable;
     struct basic_material;
     struct phong_material;
+    struct standard_material;
     struct ui_material;
 
     /**
@@ -120,6 +121,9 @@ namespace rendering_engine
         /** @brief Built-in Blinn-Phong lit 3D scene material. Constructed in @ref init. */
         phong_material& get_phong_material();
 
+        /** @brief Built-in PBR metallic-roughness lit 3D scene material. Constructed in @ref init. */
+        standard_material& get_standard_material();
+
         /** @brief Built-in 2D overlay material. Constructed in @ref init. */
         ui_material& get_ui_material();
 
@@ -139,6 +143,7 @@ namespace rendering_engine
         // layouts. Released after the passes in @ref quit.
         std::unique_ptr<basic_material> m_basic_material;
         std::unique_ptr<phong_material> m_phong_material;
+        std::unique_ptr<standard_material> m_standard_material;
         std::unique_ptr<ui_material> m_ui_material;
 
         // Off-screen HDR target the scene pass renders into.


### PR DESCRIPTION
## Summary
- Adds `standard_material` (`rendering_engine/materials/`), the analogue of `THREE.MeshStandardMaterial` and the modern default lit surface. Closes #105.
- Cook-Torrance specular (GGX NDF, Smith geometry, Schlick-Fresnel) plus a Lambertian diffuse, shaded over the position+uv+normal+tangent vertex stream and driven by the per-frame lights UBO the scene pass uploads at slot 0.
- Exposes base colour, metalness, roughness, emissive colour/intensity scalars, plus optional albedo / normal / metalness / roughness / emissive maps in the per-material group at slot 2. Normal maps ride the per-vertex tangent (`#100`) TBN basis.
- Registered as a built-in via `context::get_standard_material()`, mirroring `phong_material`; constructed in `rendering_engine::context::init` and torn down in reverse.
- Ambient is a flat stand-in (`ambient * albedo`, faded out by metalness) until image-based lighting lands per the skybox/IBL issue.

## Notes
- `snake_case` throughout; Vulkan-style GLSL compiled to SPIR-V at construction.
- Builds upon the closed dependencies: material base params (#99), tangent vertex attribute (#100), lighting system (#101).

## Test plan
- [x] `./scripts/check-style.ps1` — no style issues
- [x] `./scripts/check-naming.ps1` — no naming violations
- [x] `./scripts/build.ps1` (MSVC + vcpkg, Release) — configure + build succeed; the material's shaders compile to SPIR-V when the built-in is constructed at engine init