### PR TITLE
feat: plane primitive

### DIFF
--- a/rendering_engine/renderables/premade_3d/CMakeLists.txt
+++ b/rendering_engine/renderables/premade_3d/CMakeLists.txt
@@ -3,6 +3,8 @@ target_sources(AlphaEngine PRIVATE
     cube.hpp
     cubed_sphere.cpp
     cubed_sphere.hpp
+    plane.cpp
+    plane.hpp
     sphere.cpp
     sphere.hpp
 )

--- a/rendering_engine/renderables/premade_3d/plane.cpp
+++ b/rendering_engine/renderables/premade_3d/plane.cpp
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/plane.hpp>
+
+#include <vector>
+
+#include <control/engine.hpp>
+#include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+
+rendering_engine::plane::plane(
+    material* mat, float width, float height, unsigned int width_segments, unsigned int height_segments)
+    : m_material{mat}, m_width{width}, m_height{height}, m_width_segments{width_segments},
+      m_height_segments{height_segments}
+{
+}
+
+rendering_engine::plane::~plane()
+{
+    auto& gpu = *control::current_engine().gpu;
+    if (m_draw_bind_group.valid())
+    {
+        gpu.destroy(m_draw_bind_group);
+        m_draw_bind_group = {};
+    }
+    if (m_draw_ubo.valid())
+    {
+        gpu.destroy(m_draw_ubo);
+        m_draw_ubo = {};
+    }
+    if (m_index_buffer.valid())
+    {
+        gpu.destroy(m_index_buffer);
+        m_index_buffer = {};
+    }
+    if (m_vertex_buffer.valid())
+    {
+        gpu.destroy(m_vertex_buffer);
+        m_vertex_buffer = {};
+    }
+}
+
+void rendering_engine::plane::upload()
+{
+    const unsigned int columns = m_width_segments + 1;
+    const unsigned int rows = m_height_segments + 1;
+
+    std::vector<vertex_position_uv_normal> vertices;
+    vertices.reserve(columns * rows);
+
+    const float half_width = m_width * 0.5f;
+    const float half_height = m_height * 0.5f;
+
+    for (unsigned int i = 0; i < rows; ++i)
+    {
+        const float v = static_cast<float>(i) / static_cast<float>(m_height_segments);
+        const float y = v * m_height - half_height;
+
+        for (unsigned int j = 0; j < columns; ++j)
+        {
+            const float u = static_cast<float>(j) / static_cast<float>(m_width_segments);
+            const float x = u * m_width - half_width;
+
+            vertex_position_uv_normal vertex;
+            vertex.pos = infrastructure::math::vec3{x, y, 0.0f};
+            vertex.uv = infrastructure::math::vec2{u, 1.0f - v};
+            vertex.normal = infrastructure::math::vec3{0.0f, 0.0f, 1.0f};
+            vertices.push_back(vertex);
+        }
+    }
+
+    std::vector<uint32_t> indices;
+    indices.reserve(m_width_segments * m_height_segments * 6);
+
+    for (unsigned int i = 0; i < m_height_segments; ++i)
+    {
+        for (unsigned int j = 0; j < m_width_segments; ++j)
+        {
+            const uint32_t a = i * columns + j;
+            const uint32_t b = a + 1;
+            const uint32_t c = a + columns;
+            const uint32_t d = c + 1;
+
+            // CCW winding when viewed from the +Z side (the front face),
+            // so the +Z normal points toward the camera looking down -Z.
+            indices.push_back(a);
+            indices.push_back(b);
+            indices.push_back(d);
+
+            indices.push_back(a);
+            indices.push_back(d);
+            indices.push_back(c);
+        }
+    }
+
+    m_index_count = static_cast<unsigned int>(indices.size());
+    m_vertex_stride = sizeof(vertex_position_uv_normal);
+
+    auto& gpu = *control::current_engine().gpu;
+
+    gpu::buffer_descriptor vertex_descriptor{};
+    vertex_descriptor.size = vertices.size() * sizeof(vertex_position_uv_normal);
+    vertex_descriptor.usage = gpu::buffer_usage_vertex;
+    vertex_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    vertex_descriptor.initial_data = vertices.data();
+    m_vertex_buffer = gpu.create_buffer(vertex_descriptor);
+
+    gpu::buffer_descriptor index_descriptor{};
+    index_descriptor.size = indices.size() * sizeof(uint32_t);
+    index_descriptor.usage = gpu::buffer_usage_index;
+    index_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    index_descriptor.initial_data = indices.data();
+    m_index_buffer = gpu.create_buffer(index_descriptor);
+}
+
+void rendering_engine::plane::collect_draw_items(std::vector<draw_item>& out)
+{
+    if (m_material == nullptr)
+    {
+        LOG_WRN("plane::collect_draw_items: no material");
+        return;
+    }
+    if (!m_vertex_buffer.valid() || !m_index_buffer.valid())
+    {
+        return;
+    }
+
+    auto& gpu = *control::current_engine().gpu;
+
+    if (!m_draw_ubo.valid())
+    {
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = sizeof(infrastructure::math::mat4);
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_draw_ubo = gpu.create_buffer(ubo_descriptor);
+    }
+
+    if (!m_draw_bind_group.valid())
+    {
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_material->per_draw_layout();
+        gpu::binding_value model_slot{};
+        model_slot.binding = 1;
+        model_slot.kind = gpu::binding_kind::uniform_buffer;
+        model_slot.buffer_value = m_draw_ubo;
+        bg_descriptor.entries.push_back(model_slot);
+        m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
+    }
+
+    const auto model_matrix = transform.get_transform_matrix();
+    gpu.write_buffer(m_draw_ubo, model_matrix.data(), sizeof(infrastructure::math::mat4), 0);
+
+    draw_item item{};
+    item.mat = m_material;
+    item.vertex_buffer = m_vertex_buffer;
+    item.index_buffer = m_index_buffer;
+    item.per_draw_bind_group = m_draw_bind_group;
+    item.index_count = m_index_count;
+    item.vertex_stride = m_vertex_stride;
+    out.push_back(item);
+}
+
+rendering_engine::gpu::buffer rendering_engine::plane::get_vertex_buffer() const
+{
+    return m_vertex_buffer;
+}
+
+rendering_engine::gpu::buffer rendering_engine::plane::get_index_buffer() const
+{
+    return m_index_buffer;
+}
+
+unsigned int rendering_engine::plane::get_index_count() const
+{
+    return m_index_count;
+}

--- a/rendering_engine/renderables/premade_3d/plane.hpp
+++ b/rendering_engine/renderables/premade_3d/plane.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/renderables/renderable.hpp>
+#include <rendering_engine/util/transform.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Flat subdivided plane lying in the XY plane, centred on the origin.
+    // Mirrors Three.js PlaneGeometry(width, height, widthSegments,
+    // heightSegments). Vertex format is position + uv + normal; every
+    // normal points along +Z and UVs span [0, 1] across the surface.
+    struct plane : public renderable
+    {
+        explicit plane(material* mat,
+                       float width = 1.0f,
+                       float height = 1.0f,
+                       unsigned int width_segments = 1,
+                       unsigned int height_segments = 1);
+        ~plane() override;
+
+        rendering_engine::util::transform transform;
+
+        void upload() final;
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+        gpu::buffer get_vertex_buffer() const;
+        gpu::buffer get_index_buffer() const;
+        unsigned int get_index_count() const;
+
+    private:
+        material* m_material{nullptr};
+        float m_width;
+        float m_height;
+        unsigned int m_width_segments;
+        unsigned int m_height_segments;
+        unsigned int m_index_count{0};
+        uint32_t m_vertex_stride{0};
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_index_buffer{};
+        gpu::buffer m_draw_ubo{};
+        gpu::bind_group m_draw_bind_group{};
+    };
+} // namespace rendering_engine


### PR DESCRIPTION
## Summary

Adds a flat 3D `plane` renderable under `rendering_engine/renderables/premade_3d/`, mirroring Three.js `PlaneGeometry(width, height, widthSegments, heightSegments)`.

- Lies in the XY plane, centred on the origin, with all normals pointing +Z.
- Per-axis subdivision via `width_segments` / `height_segments`.
- UVs span `[0, 1]` across the surface.
- CCW winding so the +Z face is front-facing (matches the winding convention documented in `sphere.cpp`).

Follows the existing premade_3d indexed-mesh pattern (`sphere`): builds `std::vector<vertex_position_uv_normal>` + `std::vector<uint32_t>`, creates vertex/index buffers in `upload()`, lazily creates the per-draw UBO + bind group in `collect_draw_items()`, and cleans up GPU resources in the destructor. Public `transform` member and the same getter accessors.

Constructor: `explicit plane(material* mat, float width = 1.0f, float height = 1.0f, unsigned int width_segments = 1, unsigned int height_segments = 1);`

`plane.cpp` / `plane.hpp` are appended to the directory's `CMakeLists.txt` (kept alphabetical).

Closes #106

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU4Lc5HSxVeBgqFkHsme9Q)_