### PR TITLE
feat: polyhedron primitives (tetra/octa/icosa/dodecahedron)

### DIFF
--- a/rendering_engine/renderables/premade_3d/CMakeLists.txt
+++ b/rendering_engine/renderables/premade_3d/CMakeLists.txt
@@ -3,10 +3,20 @@ target_sources(AlphaEngine PRIVATE
     box.hpp
     cubed_sphere.cpp
     cubed_sphere.hpp
+    dodecahedron.cpp
+    dodecahedron.hpp
+    icosahedron.cpp
+    icosahedron.hpp
+    octahedron.cpp
+    octahedron.hpp
     plane.cpp
     plane.hpp
+    polyhedron.cpp
+    polyhedron.hpp
     sphere.cpp
     sphere.hpp
+    tetrahedron.cpp
+    tetrahedron.hpp
     torus.cpp
     torus.hpp
 )

--- a/rendering_engine/renderables/premade_3d/dodecahedron.cpp
+++ b/rendering_engine/renderables/premade_3d/dodecahedron.cpp
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/dodecahedron.hpp>
+
+#include <cmath>
+
+namespace rendering_engine
+{
+    namespace
+    {
+        // Golden ratio t = (1 + sqrt(5)) / 2 and its reciprocal r = 1 / t,
+        // matching three.js DodecahedronGeometry.
+        const float t = (1.0f + std::sqrt(5.0f)) / 2.0f;
+        const float r = 1.0f / t;
+
+        // Canonical three.js DodecahedronGeometry base vertices (20). The
+        // polyhedron generator normalises these onto the sphere.
+        const std::vector<float> base_vertices = {
+            // (+-1, +-1, +-1)
+            -1.0f,
+            -1.0f,
+            -1.0f,
+            -1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            -1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            -1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            -1.0f,
+            1.0f,
+            1.0f,
+            1.0f,
+            // (0, +-r, +-t)
+            0.0f,
+            -r,
+            -t,
+            0.0f,
+            -r,
+            t,
+            0.0f,
+            r,
+            -t,
+            0.0f,
+            r,
+            t,
+            // (+-r, +-t, 0)
+            -r,
+            -t,
+            0.0f,
+            -r,
+            t,
+            0.0f,
+            r,
+            -t,
+            0.0f,
+            r,
+            t,
+            0.0f,
+            // (+-t, 0, +-r)
+            -t,
+            0.0f,
+            -r,
+            t,
+            0.0f,
+            -r,
+            -t,
+            0.0f,
+            r,
+            t,
+            0.0f,
+            r,
+        };
+
+        // Canonical three.js DodecahedronGeometry faces: 12 pentagons, each
+        // triangulated into three triangles (36 triangles / 108 indices).
+        const std::vector<uint32_t> base_indices = {
+            3,  11, 7,  3,  7,  15, 3,  15, 13, 7,  19, 17, 7,  17, 6,  7,  6,  15, 17, 4,  8,  17, 8,  10, 17, 10, 6,
+            8,  0,  16, 8,  16, 2,  8,  2,  10, 0,  12, 1,  0,  1,  18, 0,  18, 16, 6,  10, 2,  6,  2,  13, 6,  13, 15,
+            2,  16, 18, 2,  18, 3,  2,  3,  13, 18, 1,  9,  18, 9,  11, 18, 11, 3,  4,  14, 12, 4,  12, 0,  4,  0,  8,
+            11, 9,  5,  11, 5,  19, 11, 19, 7,  19, 5,  14, 19, 14, 4,  19, 4,  17, 1,  12, 14, 1,  14, 5,  1,  5,  9,
+        };
+    } // namespace
+
+    dodecahedron::dodecahedron(material* mat, float radius, unsigned int detail)
+        : polyhedron{mat, base_vertices, base_indices, radius, detail}
+    {
+    }
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/dodecahedron.hpp
+++ b/rendering_engine/renderables/premade_3d/dodecahedron.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Regular dodecahedron (20 vertices, 12 pentagonal faces triangulated into
+    // 36 triangles) built on the shared polyhedron generator with the canonical
+    // three.js base table.
+    struct dodecahedron : public polyhedron
+    {
+        explicit dodecahedron(material* mat, float radius = 1.0f, unsigned int detail = 0);
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/icosahedron.cpp
+++ b/rendering_engine/renderables/premade_3d/icosahedron.cpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/icosahedron.hpp>
+
+#include <cmath>
+
+namespace rendering_engine
+{
+    namespace
+    {
+        // Golden ratio t = (1 + sqrt(5)) / 2, matching three.js
+        // IcosahedronGeometry.
+        const float t = (1.0f + std::sqrt(5.0f)) / 2.0f;
+
+        // Canonical three.js IcosahedronGeometry base vertices (12) and faces
+        // (20). The polyhedron generator normalises these onto the sphere.
+        const std::vector<float> base_vertices = {
+            -1.0f, t,  0.0f, 1.0f, t,  0.0f, -1.0f, -t,    0.0f, 1.0f, -t,   0.0f, 0.0f, -1.0f, t,  0.0f, 1.0f, t, 0.0f,
+            -1.0f, -t, 0.0f, 1.0f, -t, t,    0.0f,  -1.0f, t,    0.0f, 1.0f, -t,   0.0f, -1.0f, -t, 0.0f, 1.0f,
+        };
+
+        const std::vector<uint32_t> base_indices = {
+            0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11, 1, 5, 9, 5, 11, 4,  11, 10, 2,  10, 7, 6, 7, 1, 8,
+            3, 9,  4, 3, 4, 2, 3, 2, 6, 3, 6, 8,  3, 8,  9,  4, 9, 5, 2, 4,  11, 6,  2,  10, 8,  6, 7, 9, 8, 1,
+        };
+    } // namespace
+
+    icosahedron::icosahedron(material* mat, float radius, unsigned int detail)
+        : polyhedron{mat, base_vertices, base_indices, radius, detail}
+    {
+    }
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/icosahedron.hpp
+++ b/rendering_engine/renderables/premade_3d/icosahedron.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Regular icosahedron (12 vertices, 20 triangular faces) built on the
+    // shared polyhedron generator with the canonical three.js base table.
+    struct icosahedron : public polyhedron
+    {
+        explicit icosahedron(material* mat, float radius = 1.0f, unsigned int detail = 0);
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/octahedron.cpp
+++ b/rendering_engine/renderables/premade_3d/octahedron.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/octahedron.hpp>
+
+namespace rendering_engine
+{
+    namespace
+    {
+        // Canonical three.js OctahedronGeometry base vertices and faces.
+        const std::vector<float> base_vertices = {
+            1.0f,
+            0.0f,
+            0.0f,
+            -1.0f,
+            0.0f,
+            0.0f,
+            0.0f,
+            1.0f,
+            0.0f,
+            0.0f,
+            -1.0f,
+            0.0f,
+            0.0f,
+            0.0f,
+            1.0f,
+            0.0f,
+            0.0f,
+            -1.0f,
+        };
+
+        const std::vector<uint32_t> base_indices = {
+            0, 2, 4, 0, 4, 3, 0, 3, 5, 0, 5, 2, 1, 2, 5, 1, 5, 3, 1, 3, 4, 1, 4, 2,
+        };
+    } // namespace
+
+    octahedron::octahedron(material* mat, float radius, unsigned int detail)
+        : polyhedron{mat, base_vertices, base_indices, radius, detail}
+    {
+    }
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/octahedron.hpp
+++ b/rendering_engine/renderables/premade_3d/octahedron.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Regular octahedron (6 vertices, 8 triangular faces) built on the shared
+    // polyhedron generator with the canonical three.js base table.
+    struct octahedron : public polyhedron
+    {
+        explicit octahedron(material* mat, float radius = 1.0f, unsigned int detail = 0);
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/polyhedron.cpp
+++ b/rendering_engine/renderables/premade_3d/polyhedron.cpp
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include <control/engine.hpp>
+#include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+
+namespace
+{
+    constexpr float pi = 3.14159265358979323846f;
+
+    // Spherical UV from a unit-length position, matching three.js
+    // PolyhedronGeometry: azimuth = atan2(z, -x), inclination = acos(-y).
+    // u = azimuth / (2*pi) + 0.5, v = inclination / pi + 0.5.
+    infrastructure::math::vec2 spherical_uv(const infrastructure::math::vec3& dir)
+    {
+        const float azimuth = std::atan2(dir.z, -dir.x);
+        const float inclination = std::acos(-dir.y);
+        return infrastructure::math::vec2{azimuth / (2.0f * pi) + 0.5f, inclination / pi + 0.5f};
+    }
+} // namespace
+
+namespace rendering_engine
+{
+    polyhedron::polyhedron(material* mat,
+                           std::vector<float> base_vertices,
+                           std::vector<uint32_t> base_indices,
+                           float radius,
+                           unsigned int detail)
+        : m_material{mat}, m_base_vertices{std::move(base_vertices)}, m_base_indices{std::move(base_indices)},
+          m_radius{radius}, m_detail{detail}
+    {
+    }
+
+    polyhedron::~polyhedron()
+    {
+        auto& gpu = *control::current_engine().gpu;
+        if (m_draw_bind_group.valid())
+        {
+            gpu.destroy(m_draw_bind_group);
+            m_draw_bind_group = {};
+        }
+        if (m_draw_ubo.valid())
+        {
+            gpu.destroy(m_draw_ubo);
+            m_draw_ubo = {};
+        }
+        if (m_index_buffer.valid())
+        {
+            gpu.destroy(m_index_buffer);
+            m_index_buffer = {};
+        }
+        if (m_vertex_buffer.valid())
+        {
+            gpu.destroy(m_vertex_buffer);
+            m_vertex_buffer = {};
+        }
+    }
+
+    void polyhedron::upload()
+    {
+        using infrastructure::math::vec2;
+        using infrastructure::math::vec3;
+
+        // Pull the base direction (unit) for a base vertex index.
+        const auto base_dir = [this](uint32_t i) -> vec3
+        {
+            const vec3 v{m_base_vertices[i * 3 + 0], m_base_vertices[i * 3 + 1], m_base_vertices[i * 3 + 2]};
+            return infrastructure::math::normalize(v);
+        };
+
+        // Subdivision count per edge: 2^detail segments.
+        const unsigned int cols = 1u << m_detail;
+
+        std::vector<vertex_position_uv_normal> vertices;
+        std::vector<uint32_t> indices;
+
+        // Each base triangle is subdivided into a triangular grid. We build a
+        // fresh (non-indexed) vertex list so per-triangle UV seam corrections
+        // do not bleed across shared edges, then emit sequential indices. This
+        // mirrors three.js, which produces a non-indexed buffer geometry.
+        for (size_t f = 0; f < m_base_indices.size(); f += 3)
+        {
+            const vec3 a = base_dir(m_base_indices[f + 0]);
+            const vec3 b = base_dir(m_base_indices[f + 1]);
+            const vec3 c = base_dir(m_base_indices[f + 2]);
+
+            // Build a grid of unit-length directions over the triangle (a, b, c)
+            // using slerp-equivalent linear interpolation + renormalize, matching
+            // three.js subdivision. v[i][j] for i in [0, cols], j in [0, i].
+            std::vector<std::vector<vec3>> grid(cols + 1);
+            for (unsigned int i = 0; i <= cols; ++i)
+            {
+                const vec3 ai =
+                    infrastructure::math::normalize(a + (c - a) * (static_cast<float>(i) / static_cast<float>(cols)));
+                const vec3 bi =
+                    infrastructure::math::normalize(b + (c - b) * (static_cast<float>(i) / static_cast<float>(cols)));
+
+                const unsigned int rows = cols - i;
+                grid[i].resize(rows + 1);
+                for (unsigned int j = 0; j <= rows; ++j)
+                {
+                    if (j == 0 && i == cols)
+                    {
+                        grid[i][j] = ai;
+                    }
+                    else
+                    {
+                        grid[i][j] = infrastructure::math::normalize(
+                            ai + (bi - ai) * (static_cast<float>(j) / static_cast<float>(rows)));
+                    }
+                }
+            }
+
+            // Emit triangles from the grid (two orientations per cell), matching
+            // three.js winding so the outward normal faces away from the centre.
+            const auto push_vertex = [&](const vec3& dir)
+            {
+                vertex_position_uv_normal vertex;
+                vertex.pos = dir * m_radius;
+                vertex.normal = dir;
+                vertex.uv = spherical_uv(dir);
+                vertices.push_back(vertex);
+                indices.push_back(static_cast<uint32_t>(indices.size()));
+            };
+
+            for (unsigned int i = 0; i < cols; ++i)
+            {
+                for (unsigned int j = 0; j < 2 * (cols - i) - 1; ++j)
+                {
+                    const unsigned int k = j / 2;
+                    if (j % 2 == 0)
+                    {
+                        push_vertex(grid[i][k + 1]);
+                        push_vertex(grid[i + 1][k]);
+                        push_vertex(grid[i][k]);
+                    }
+                    else
+                    {
+                        push_vertex(grid[i][k + 1]);
+                        push_vertex(grid[i + 1][k + 1]);
+                        push_vertex(grid[i + 1][k]);
+                    }
+                }
+            }
+        }
+
+        // Basic seam / pole UV correction, mirroring three.js correctUVs +
+        // correctPoles at a per-triangle level. Because the vertex buffer is
+        // non-indexed, each triangle owns three consecutive vertices, so we can
+        // fix wrap-around and pole singularities without affecting neighbours.
+        for (size_t t = 0; t + 3 <= vertices.size(); t += 3)
+        {
+            vec2& uv0 = vertices[t + 0].uv;
+            vec2& uv1 = vertices[t + 1].uv;
+            vec2& uv2 = vertices[t + 2].uv;
+
+            // Wrap-around seam: if a triangle straddles the u = 0/1 boundary the
+            // azimuth values jump by ~1; nudge the small ones up by 1.
+            const float max_u = std::max({uv0.x, uv1.x, uv2.x});
+            const float min_u = std::min({uv0.x, uv1.x, uv2.x});
+            if (max_u - min_u > 0.5f)
+            {
+                if (uv0.x < 0.5f)
+                {
+                    uv0.x += 1.0f;
+                }
+                if (uv1.x < 0.5f)
+                {
+                    uv1.x += 1.0f;
+                }
+                if (uv2.x < 0.5f)
+                {
+                    uv2.x += 1.0f;
+                }
+            }
+
+            // Pole correction: a vertex sitting exactly on a pole has an
+            // ill-defined azimuth; bias its u toward the average of the other
+            // two so the texture does not pinch into a single column.
+            const auto fix_pole = [&](vec3& pos, vec2& uv, const vec2& a, const vec2& b)
+            {
+                if (std::abs(pos.x) < 1e-5f && std::abs(pos.z) < 1e-5f)
+                {
+                    uv.x = (a.x + b.x) * 0.5f;
+                }
+            };
+            fix_pole(vertices[t + 0].pos, uv0, uv1, uv2);
+            fix_pole(vertices[t + 1].pos, uv1, uv0, uv2);
+            fix_pole(vertices[t + 2].pos, uv2, uv0, uv1);
+        }
+
+        m_index_count = static_cast<unsigned int>(indices.size());
+        m_vertex_stride = sizeof(vertex_position_uv_normal);
+
+        auto& gpu = *control::current_engine().gpu;
+
+        gpu::buffer_descriptor vertex_descriptor{};
+        vertex_descriptor.size = vertices.size() * sizeof(vertex_position_uv_normal);
+        vertex_descriptor.usage = gpu::buffer_usage_vertex;
+        vertex_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        vertex_descriptor.initial_data = vertices.data();
+        m_vertex_buffer = gpu.create_buffer(vertex_descriptor);
+
+        gpu::buffer_descriptor index_descriptor{};
+        index_descriptor.size = indices.size() * sizeof(uint32_t);
+        index_descriptor.usage = gpu::buffer_usage_index;
+        index_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        index_descriptor.initial_data = indices.data();
+        m_index_buffer = gpu.create_buffer(index_descriptor);
+    }
+
+    void polyhedron::collect_draw_items(std::vector<draw_item>& out)
+    {
+        if (m_material == nullptr)
+        {
+            LOG_WRN("polyhedron::collect_draw_items: no material");
+            return;
+        }
+        if (!m_vertex_buffer.valid() || !m_index_buffer.valid())
+        {
+            return;
+        }
+
+        auto& gpu = *control::current_engine().gpu;
+
+        if (!m_draw_ubo.valid())
+        {
+            gpu::buffer_descriptor ubo_descriptor{};
+            ubo_descriptor.size = sizeof(infrastructure::math::mat4);
+            ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+            ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+            m_draw_ubo = gpu.create_buffer(ubo_descriptor);
+        }
+
+        if (!m_draw_bind_group.valid())
+        {
+            gpu::bind_group_descriptor bg_descriptor{};
+            bg_descriptor.layout = m_material->per_draw_layout();
+            gpu::binding_value model_slot{};
+            model_slot.binding = 1;
+            model_slot.kind = gpu::binding_kind::uniform_buffer;
+            model_slot.buffer_value = m_draw_ubo;
+            bg_descriptor.entries.push_back(model_slot);
+            m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
+        }
+
+        const auto model_matrix = transform.get_transform_matrix();
+        gpu.write_buffer(m_draw_ubo, model_matrix.data(), sizeof(infrastructure::math::mat4), 0);
+
+        draw_item item{};
+        item.mat = m_material;
+        item.vertex_buffer = m_vertex_buffer;
+        item.index_buffer = m_index_buffer;
+        item.per_draw_bind_group = m_draw_bind_group;
+        item.index_count = m_index_count;
+        item.vertex_stride = m_vertex_stride;
+        out.push_back(item);
+    }
+
+    gpu::buffer polyhedron::get_vertex_buffer() const
+    {
+        return m_vertex_buffer;
+    }
+
+    gpu::buffer polyhedron::get_index_buffer() const
+    {
+        return m_index_buffer;
+    }
+
+    unsigned int polyhedron::get_index_count() const
+    {
+        return m_index_count;
+    }
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/polyhedron.hpp
+++ b/rendering_engine/renderables/premade_3d/polyhedron.hpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/renderables/renderable.hpp>
+#include <rendering_engine/util/transform.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Generic polyhedron generator, mirroring three.js PolyhedronGeometry.
+    // Takes a base mesh expressed as a flat list of vertex positions (x, y, z
+    // triplets) and a flat list of triangle indices, subdivides each base
+    // triangle @c detail times, projects every resulting vertex onto the
+    // sphere of the given @c radius, and derives smooth (sphere) normals plus
+    // spherical UVs.
+    //
+    // Vertex format is position + uv + normal. Triangles are emitted with CCW
+    // outward winding, matching the convention documented in sphere.cpp. The
+    // four platonic-solid wrappers (tetrahedron, octahedron, icosahedron,
+    // dodecahedron) feed canonical base tables into this generator.
+    struct polyhedron : public renderable
+    {
+        polyhedron(material* mat,
+                   std::vector<float> base_vertices,
+                   std::vector<uint32_t> base_indices,
+                   float radius = 1.0f,
+                   unsigned int detail = 0);
+        ~polyhedron() override;
+
+        rendering_engine::util::transform transform;
+
+        void upload() final;
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+        gpu::buffer get_vertex_buffer() const;
+        gpu::buffer get_index_buffer() const;
+        unsigned int get_index_count() const;
+
+    private:
+        material* m_material{nullptr};
+        std::vector<float> m_base_vertices;
+        std::vector<uint32_t> m_base_indices;
+        float m_radius;
+        unsigned int m_detail;
+        unsigned int m_index_count{0};
+        uint32_t m_vertex_stride{0};
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_index_buffer{};
+        gpu::buffer m_draw_ubo{};
+        gpu::bind_group m_draw_bind_group{};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/tetrahedron.cpp
+++ b/rendering_engine/renderables/premade_3d/tetrahedron.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/premade_3d/tetrahedron.hpp>
+
+namespace rendering_engine
+{
+    namespace
+    {
+        // Canonical three.js TetrahedronGeometry base vertices and faces.
+        const std::vector<float> base_vertices = {
+            1.0f,
+            1.0f,
+            1.0f,
+            -1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            1.0f,
+            -1.0f,
+            -1.0f,
+        };
+
+        const std::vector<uint32_t> base_indices = {
+            2,
+            1,
+            0,
+            0,
+            3,
+            2,
+            1,
+            3,
+            0,
+            2,
+            3,
+            1,
+        };
+    } // namespace
+
+    tetrahedron::tetrahedron(material* mat, float radius, unsigned int detail)
+        : polyhedron{mat, base_vertices, base_indices, radius, detail}
+    {
+    }
+} // namespace rendering_engine

--- a/rendering_engine/renderables/premade_3d/tetrahedron.hpp
+++ b/rendering_engine/renderables/premade_3d/tetrahedron.hpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Regular tetrahedron (4 vertices, 4 triangular faces) built on the shared
+    // polyhedron generator with the canonical three.js base table.
+    struct tetrahedron : public polyhedron
+    {
+        explicit tetrahedron(material* mat, float radius = 1.0f, unsigned int detail = 0);
+    };
+} // namespace rendering_engine


### PR DESCRIPTION
## Summary

Adds a shared `polyhedron` renderable generator under `rendering_engine/renderables/premade_3d/`, mirroring three.js `PolyhedronGeometry`, plus the four named platonic-solid wrappers requested in #112.

### `polyhedron`
`polyhedron(material* mat, std::vector<float> base_vertices, std::vector<uint32_t> base_indices, float radius = 1.0f, unsigned int detail = 0)`

- Subdivides each base triangle into a `2^detail` triangular grid (linear interpolation + renormalize, matching three.js).
- Projects every vertex onto the sphere of the given `radius`; per-vertex normal is the normalized position (smooth sphere normal).
- Spherical UVs from azimuth/inclination: `azimuth = atan2(z, -x)`, `inclination = acos(-y)`, `u = azimuth/(2*pi)+0.5`, `v = inclination/pi+0.5`.
- Builds a non-indexed vertex buffer (each triangle owns three consecutive vertices) so a brief per-triangle seam/pole UV correction pass can run without bleeding across shared edges. The simplification versus three.js (per-triangle rather than global correction) is documented in a comment.
- Emits triangles with CCW outward winding, matching the convention documented in `sphere.cpp`.

Follows the `sphere` renderable pattern exactly: public `transform` member, `upload()` + `collect_draw_items()`, lazy per-draw UBO + bind group, destructor cleanup, indexed `draw_item` with vertex + index buffers, `vertex_position_uv_normal` format.

### Wrappers (thin subclasses forwarding canonical three.js base tables)
- `tetrahedron` — 4 verts / 4 faces
- `octahedron` — 6 verts / 8 faces
- `icosahedron` — 12 verts (golden ratio `t = (1 + sqrt(5)) / 2`) / 20 faces
- `dodecahedron` — 20 verts (golden ratio) / 12 pentagons triangulated into 36 triangles

### Verification
- Base tables validated: correct vertex/face counts and all faces CCW outward (centroid-dot-normal test).
- Generator validated: triangle counts scale as `4^detail` per base face and winding stays CCW outward at detail 0/1/2.
- `clang-format-18 -i` applied; stable on a second `--dry-run --Werror` run.
- Full Windows/Vulkan build not run on this Linux container per task instructions; code re-checked against `sphere.cpp` for compile correctness.

Closes #112

https://claude.ai/code/session_01YU4Lc5HSxVeBgqFkHsme9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01YU4Lc5HSxVeBgqFkHsme9Q)_