### PR TITLE
fix: include &lt;algorithm&gt; in polyhedron

### DIFF
--- a/rendering_engine/renderables/premade_3d/polyhedron.cpp
+++ b/rendering_engine/renderables/premade_3d/polyhedron.cpp
@@ -22,6 +22,7 @@
 
 #include <rendering_engine/renderables/premade_3d/polyhedron.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
## Why

`polyhedron.cpp` uses the `std::min` / `std::max` `initializer_list` overloads to compute the per-face UV bounds:

```cpp
const float max_u = std::max({uv0.x, uv1.x, uv2.x});
const float min_u = std::min({uv0.x, uv1.x, uv2.x});
```

but the translation unit only included `<cmath>`, `<utility>` and `<vector>`. Those overloads are declared in `<algorithm>`, which was being pulled in only transitively, so the file fails to compile under libstdc++ (g++):

```
error: no matching function for call to 'max(<brace-enclosed initializer list>)'
```

## What

Add the explicit `#include <algorithm>`, placed in alphabetical order with the other standard-library headers.

## Verification

- Full `cmake --build` (Ninja, Debug) now completes and links `AlphaEngine` cleanly; it previously stopped at `polyhedron.cpp`.
- `clang-format` passes on the changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJpBCTaehkAVxpL9Lf6YHA)_