### PR TITLE
feat: FXAA post pass

### DIFF
--- a/rendering_engine/passes/pass.hpp
+++ b/rendering_engine/passes/pass.hpp
@@ -59,6 +59,14 @@ namespace rendering_engine
         // passes sample @ref scene_color_texture as their input.
         gpu::render_target scene_color_target{};
         gpu::texture scene_color_texture{};
+
+        // Off-screen LDR colour target the tonemap pass resolves into.
+        // The swapchain is not sampleable as a shader input, so the
+        // final post effect (FXAA) reads its tonemapped source from this
+        // intermediate rgba8 target and writes the result to
+        // @ref swapchain_target. Also owned by @ref context.
+        gpu::render_target ldr_color_target{};
+        gpu::texture ldr_color_texture{};
     };
 
     /**

--- a/rendering_engine/passes/post/CMakeLists.txt
+++ b/rendering_engine/passes/post/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(AlphaEngine PRIVATE
     bloom_pass.cpp
     bloom_pass.hpp
     fullscreen_triangle.hpp
+    fxaa_pass.cpp
+    fxaa_pass.hpp
     tonemap_pass.cpp
     tonemap_pass.hpp
 )

--- a/rendering_engine/passes/post/fxaa_pass.cpp
+++ b/rendering_engine/passes/post/fxaa_pass.cpp
@@ -20,8 +20,9 @@
  * SOFTWARE.
  */
 
-#include <rendering_engine/passes/post/tonemap_pass.hpp>
+#include <rendering_engine/passes/post/fxaa_pass.hpp>
 
+#include <array>
 #include <string>
 
 #include <control/engine.hpp>
@@ -36,49 +37,93 @@
 
 namespace
 {
-    // Krzysztof Narkowicz's ACES filmic approximation with an
-    // explicit gamma-2.2 encode. The swapchain is regular
-    // GL_RGBA8 (no SDL sRGB attribute, no GL_FRAMEBUFFER_SRGB),
-    // so the framebuffer is treated as linear and the encode has
-    // to happen here. Gamma 2.2 is visually indistinguishable
-    // from the piecewise sRGB curve at these magnitudes and is
-    // the standard chain partner for ACES.
+    // The canonical compact FXAA (Timothy Lottes, NVIDIA whitepaper),
+    // operating on the gamma-encoded LDR image tonemap leaves behind.
+    // A 3x3 luma neighbourhood around the centre texel chooses the edge
+    // direction; two pairs of bilinear taps along that direction give a
+    // narrow (rgbA) and a wider (rgbB) blend, and the wider one is kept
+    // only while its luma stays inside the local min/max so high-contrast
+    // detail is not over-smeared. clamp_edge sampling on the LDR
+    // render-target texture keeps the off-centre taps well-defined at the
+    // borders, and its linear filter is what makes the sub-texel taps
+    // actually average neighbours.
+    //
+    // u_fxaa.rcp_frame.xy is (1/width, 1/height) — the per-texel step the
+    // edge search walks by — baked once at construction.
     const std::string fragment_shader = R"fs(
         #version 450
 
         layout(location = 0) in vec2 texCoord;
         layout(location = 0) out vec4 fragColor;
 
-        layout(set = 0, binding = 0) uniform sampler2D sceneColor;
+        layout(set = 0, binding = 0) uniform sampler2D ldrColor;
 
-        layout(set = 0, binding = 1, std140) uniform Tonemap
+        layout(set = 0, binding = 1, std140) uniform Fxaa
         {
-            float exposure;
-        } u_tonemap;
+            vec4 rcp_frame; // xy = 1/resolution, zw unused
+        } u_fxaa;
 
-        vec3 aces_filmic(vec3 x)
-        {
-            const float a = 2.51;
-            const float b = 0.03;
-            const float c = 2.43;
-            const float d = 0.59;
-            const float e = 0.14;
-            return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
-        }
+        // Largest distance, in texels, the edge blend may reach.
+        const float span_max = 8.0;
+        // Scales the neighbourhood luma into the directional reduce term so
+        // near-uniform regions stop searching; the floor keeps the divide
+        // below well-conditioned on a perfectly flat patch.
+        const float reduce_mul = 1.0 / 8.0;
+        const float reduce_min = 1.0 / 128.0;
 
         void main()
         {
-            vec3 hdr = texture(sceneColor, texCoord).rgb * u_tonemap.exposure;
-            vec3 ldr = aces_filmic(hdr);
-            vec3 srgb = pow(ldr, vec3(1.0 / 2.2));
-            fragColor = vec4(srgb, 1.0);
+            vec2 inv = u_fxaa.rcp_frame.xy;
+
+            vec3 rgb_m = texture(ldrColor, texCoord).rgb;
+            vec3 rgb_nw = texture(ldrColor, texCoord + vec2(-1.0, -1.0) * inv).rgb;
+            vec3 rgb_ne = texture(ldrColor, texCoord + vec2(1.0, -1.0) * inv).rgb;
+            vec3 rgb_sw = texture(ldrColor, texCoord + vec2(-1.0, 1.0) * inv).rgb;
+            vec3 rgb_se = texture(ldrColor, texCoord + vec2(1.0, 1.0) * inv).rgb;
+
+            const vec3 luma_weights = vec3(0.299, 0.587, 0.114);
+            float luma_m = dot(rgb_m, luma_weights);
+            float luma_nw = dot(rgb_nw, luma_weights);
+            float luma_ne = dot(rgb_ne, luma_weights);
+            float luma_sw = dot(rgb_sw, luma_weights);
+            float luma_se = dot(rgb_se, luma_weights);
+
+            float luma_min = min(luma_m, min(min(luma_nw, luma_ne), min(luma_sw, luma_se)));
+            float luma_max = max(luma_m, max(max(luma_nw, luma_ne), max(luma_sw, luma_se)));
+
+            // Edge direction is the gradient of the corner lumas, rotated
+            // 90 degrees so the blend runs *along* the edge, not across it.
+            vec2 dir;
+            dir.x = -((luma_nw + luma_ne) - (luma_sw + luma_se));
+            dir.y = ((luma_nw + luma_sw) - (luma_ne + luma_se));
+
+            float dir_reduce = max((luma_nw + luma_ne + luma_sw + luma_se) * (0.25 * reduce_mul), reduce_min);
+            float rcp_dir_min = 1.0 / (min(abs(dir.x), abs(dir.y)) + dir_reduce);
+            dir = clamp(dir * rcp_dir_min, vec2(-span_max), vec2(span_max)) * inv;
+
+            // Narrow blend: the two inner taps (+/- 1/6 of the span).
+            vec3 rgb_a = 0.5 * (texture(ldrColor, texCoord + dir * (1.0 / 3.0 - 0.5)).rgb +
+                                texture(ldrColor, texCoord + dir * (2.0 / 3.0 - 0.5)).rgb);
+            // Wider blend: average in the two outer taps (+/- 1/2 of span).
+            vec3 rgb_b = rgb_a * 0.5 + 0.25 * (texture(ldrColor, texCoord + dir * -0.5).rgb +
+                                               texture(ldrColor, texCoord + dir * 0.5).rgb);
+
+            float luma_b = dot(rgb_b, luma_weights);
+            if (luma_b < luma_min || luma_b > luma_max)
+            {
+                fragColor = vec4(rgb_a, 1.0);
+            }
+            else
+            {
+                fragColor = vec4(rgb_b, 1.0);
+            }
         }
 )fs";
 } // namespace
 
 namespace rendering_engine
 {
-    tonemap_pass::tonemap_pass(gpu::texture input_color)
+    fxaa_pass::fxaa_pass(gpu::texture input_color, uint32_t width, uint32_t height)
     {
         auto& gpu = *control::current_engine().gpu;
 
@@ -100,17 +145,19 @@ namespace rendering_engine
         vb_descriptor.initial_data = fullscreen_triangle_vertices.data();
         m_vertex_buffer = gpu.create_buffer(vb_descriptor);
 
-        // Captured once at construction; live tuning is out of
-        // scope per the issue. A future auto-exposure pass will
-        // update this UBO per-frame via write_buffer. std140 rounds
-        // a single float UBO up to a 16-byte allocation.
-        const float exposure = 1.0f;
+        // Per-texel edge step baked once from the backbuffer size. A
+        // degenerate target bakes a zero step, collapsing every off-centre
+        // tap onto the centre texel so the pass copies straight through.
+        // std140 rounds the vec2 up to a 16-byte vec4 allocation.
+        const float rcp_x = (width != 0) ? 1.0f / static_cast<float>(width) : 0.0f;
+        const float rcp_y = (height != 0) ? 1.0f / static_cast<float>(height) : 0.0f;
+        const std::array<float, 4> rcp_frame = {rcp_x, rcp_y, 0.0f, 0.0f};
         gpu::buffer_descriptor ubo_descriptor{};
         ubo_descriptor.size = 16;
         ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
         ubo_descriptor.hint = gpu::buffer_usage_hint::static_data;
-        ubo_descriptor.initial_data = &exposure;
-        m_exposure_ubo = gpu.create_buffer(ubo_descriptor);
+        ubo_descriptor.initial_data = rcp_frame.data();
+        m_rcp_frame_ubo = gpu.create_buffer(ubo_descriptor);
 
         gpu::bind_group_layout_descriptor input_layout{};
         input_layout.entries.push_back({0, gpu::binding_kind::texture});
@@ -120,24 +167,23 @@ namespace rendering_engine
         gpu::bind_group_descriptor input_bind_group_descriptor{};
         input_bind_group_descriptor.layout = m_input_layout;
 
-        gpu::binding_value scene_color_slot{};
-        scene_color_slot.binding = 0;
-        scene_color_slot.kind = gpu::binding_kind::texture;
-        scene_color_slot.texture_value = input_color;
-        input_bind_group_descriptor.entries.push_back(scene_color_slot);
+        gpu::binding_value ldr_color_slot{};
+        ldr_color_slot.binding = 0;
+        ldr_color_slot.kind = gpu::binding_kind::texture;
+        ldr_color_slot.texture_value = input_color;
+        input_bind_group_descriptor.entries.push_back(ldr_color_slot);
 
-        gpu::binding_value exposure_slot{};
-        exposure_slot.binding = 1;
-        exposure_slot.kind = gpu::binding_kind::uniform_buffer;
-        exposure_slot.buffer_value = m_exposure_ubo;
-        input_bind_group_descriptor.entries.push_back(exposure_slot);
+        gpu::binding_value rcp_frame_slot{};
+        rcp_frame_slot.binding = 1;
+        rcp_frame_slot.kind = gpu::binding_kind::uniform_buffer;
+        rcp_frame_slot.buffer_value = m_rcp_frame_ubo;
+        input_bind_group_descriptor.entries.push_back(rcp_frame_slot);
 
         m_input_bind_group = gpu.create_bind_group(input_bind_group_descriptor);
 
-        // Fullscreen triangle: depth disabled, blend disabled, no
-        // culling so the triangle's winding is irrelevant. The
-        // vertex shader reads a single vec2 attribute from
-        // @ref m_vertex_buffer.
+        // Fullscreen triangle: depth disabled, blend disabled, no culling
+        // so the triangle's winding is irrelevant. The vertex shader reads
+        // a single vec2 attribute from @ref m_vertex_buffer.
         gpu::vertex_buffer_layout vertex_layout{};
         vertex_layout.stride = sizeof(float) * 2;
         vertex_layout.attributes.push_back({0, 2, gpu::scalar_type::float32, 0});
@@ -167,7 +213,7 @@ namespace rendering_engine
         m_pipeline = gpu.create_pipeline(pipeline_descriptor);
     }
 
-    tonemap_pass::~tonemap_pass()
+    fxaa_pass::~fxaa_pass()
     {
         auto& gpu = *control::current_engine().gpu;
         if (m_pipeline.valid())
@@ -185,10 +231,10 @@ namespace rendering_engine
             gpu.destroy(m_input_layout);
             m_input_layout = {};
         }
-        if (m_exposure_ubo.valid())
+        if (m_rcp_frame_ubo.valid())
         {
-            gpu.destroy(m_exposure_ubo);
-            m_exposure_ubo = {};
+            gpu.destroy(m_rcp_frame_ubo);
+            m_rcp_frame_ubo = {};
         }
         if (m_vertex_buffer.valid())
         {
@@ -207,17 +253,12 @@ namespace rendering_engine
         }
     }
 
-    void tonemap_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
+    void fxaa_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
     {
         gpu::render_pass_descriptor descriptor{};
-        // Resolve into the off-screen LDR target rather than straight to
-        // the swapchain: the final post effect (FXAA) needs to sample
-        // this tonemapped result as a shader input, which the swapchain
-        // cannot provide.
-        descriptor.target = ctx.ldr_color_target;
-        // The fullscreen triangle covers every pixel; clearing is
-        // strictly redundant but cheap and keeps the target in a
-        // known state if a future post pass narrows its viewport.
+        descriptor.target = ctx.swapchain_target;
+        // The fullscreen triangle covers every pixel; clearing is strictly
+        // redundant but cheap and keeps the swapchain in a known state.
         descriptor.color.load = gpu::load_op::clear;
         descriptor.color.clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
         descriptor.use_depth = false;

--- a/rendering_engine/passes/post/fxaa_pass.hpp
+++ b/rendering_engine/passes/post/fxaa_pass.hpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/passes/pass.hpp>
+
+namespace rendering_engine
+{
+    /**
+     * @brief Fast approximate anti-aliasing on the tonemapped LDR image,
+     *        the analogue of @c THREE.FXAAShader.
+     *
+     * The cheapest post-process AA: a single fullscreen pass that finds
+     * luminance edges in the already-shaded LDR image and blends along
+     * them, smoothing the jaggies the scene pass leaves behind without
+     * any MSAA sample storage. It is the last link in the post chain,
+     * running after @ref tonemap_pass on the LDR intermediate target and
+     * writing the result straight to the swapchain the @ref ui_pass then
+     * composites on top of.
+     *
+     * FXAA wants a perceptual (non-linear) image and computes its edge
+     * luma from the colour directly, so it slots in *after* tonemap's
+     * ACES + gamma encode rather than on the linear HDR target — sampling
+     * the gamma-encoded LDR is exactly the input Timothy Lottes' original
+     * shader assumes. The implementation is the canonical compact FXAA:
+     * a 3x3 luma neighbourhood picks the edge direction, then two pairs
+     * of bilinear taps along that direction produce the blended colour,
+     * falling back to the tighter blend when the wider one drifts outside
+     * the local luma range.
+     *
+     * Pipeline state mirrors every other fullscreen-triangle post pass
+     * (depth off, blend off, no culling, single vec2 vertex attribute);
+     * the shared @ref fullscreen_triangle_vertex_shader emits the
+     * geometry. The reciprocal frame size (1/width, 1/height) the edge
+     * search steps by is baked into the input bind group at construction
+     * from the backbuffer dimensions, mirroring the way
+     * @ref tonemap_pass captures its exposure; live resolution changes
+     * are out of scope. A degenerate backbuffer bakes a zero step, which
+     * collapses every tap onto the centre texel so the pass becomes a
+     * straight copy.
+     */
+    struct fxaa_pass : pass
+    {
+        // @p input_color is the LDR texture @ref tonemap_pass renders
+        // into; @p width / @p height are the backbuffer dimensions the
+        // per-texel edge step is baked from.
+        fxaa_pass(gpu::texture input_color, uint32_t width, uint32_t height);
+        ~fxaa_pass() override;
+
+        fxaa_pass(const fxaa_pass&) = delete;
+        fxaa_pass& operator=(const fxaa_pass&) = delete;
+
+        void record(gpu::command_encoder& encoder, const frame_context& ctx) override;
+
+    private:
+        gpu::shader_module m_vertex_shader{};
+        gpu::shader_module m_fragment_shader{};
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_rcp_frame_ubo{};
+        gpu::bind_group_layout m_input_layout{};
+        gpu::bind_group m_input_bind_group{};
+        gpu::pipeline m_pipeline{};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/passes/post/tonemap_pass.hpp
+++ b/rendering_engine/passes/post/tonemap_pass.hpp
@@ -35,11 +35,15 @@ namespace rendering_engine
      * applies @c exposure as a pre-curve scale, runs Krzysztof
      * Narkowicz's 5-line ACES filmic approximation per channel,
      * and gamma-2.2 encodes the result before writing to the
-     * swapchain. Without this pass HDR luminance > 1.0 saturates
-     * to white as soon as it hits the 8-bit backbuffer.
+     * off-screen LDR target. Without this pass HDR luminance > 1.0
+     * saturates to white as soon as it hits the 8-bit backbuffer.
      *
-     * Slots into the post chain between @ref scene_pass and
-     * @ref ui_pass. Pipeline state mirrors any other fullscreen-
+     * It resolves into @ref frame_context::ldr_color_target rather
+     * than straight to the swapchain so the trailing @ref fxaa_pass
+     * can sample the tonemapped result as a shader input (the
+     * swapchain is not sampleable). Slots into the post chain between
+     * @ref scene_pass and @ref fxaa_pass. Pipeline state mirrors any
+     * other fullscreen-
      * triangle post pass (depth off, blend off, no culling, no
      * vertex buffers); the shared
      * @ref fullscreen_triangle_vertex_shader emits the geometry

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -35,6 +35,7 @@
 #include <rendering_engine/passes/debug_pass.hpp>
 #include <rendering_engine/passes/pass.hpp>
 #include <rendering_engine/passes/post/bloom_pass.hpp>
+#include <rendering_engine/passes/post/fxaa_pass.hpp>
 #include <rendering_engine/passes/post/tonemap_pass.hpp>
 #include <rendering_engine/passes/scene_pass.hpp>
 #include <rendering_engine/passes/shadow_pass.hpp>
@@ -80,6 +81,19 @@ void rendering_engine::context::init()
     m_scene_color_target = eng.gpu->create_render_target(scene_color_descriptor);
     m_scene_color_texture = eng.gpu->render_target_color_texture(m_scene_color_target);
 
+    // Allocate the off-screen LDR target the tonemap pass resolves into
+    // and the FXAA pass samples. The swapchain cannot be bound as a
+    // shader input, so the final anti-aliasing pass reads its tonemapped
+    // source from this rgba8 intermediate and writes to the swapchain.
+    // No depth: the post chain runs depth-disabled.
+    gpu::render_target_descriptor ldr_color_descriptor{};
+    ldr_color_descriptor.color_format = gpu::texture_format::rgba8_unorm;
+    ldr_color_descriptor.width = width;
+    ldr_color_descriptor.height = height;
+    ldr_color_descriptor.with_depth = false;
+    m_ldr_color_target = eng.gpu->create_render_target(ldr_color_descriptor);
+    m_ldr_color_texture = eng.gpu->render_target_color_texture(m_ldr_color_target);
+
     // Construct the built-in passes first — each pass owns the
     // per-frame bind-group layout its matching material reads at
     // pipeline-create time. The shadow pass is built before the scene
@@ -94,6 +108,9 @@ void rendering_engine::context::init()
     // glow back into the same target, so tonemap maps the bloomed result.
     auto bloom = std::make_unique<bloom_pass>(m_scene_color_texture, width, height);
     auto post = std::make_unique<tonemap_pass>(m_scene_color_texture);
+    // FXAA closes the post chain: it samples the LDR target tonemap
+    // resolved into and writes the anti-aliased result to the swapchain.
+    auto fxaa = std::make_unique<fxaa_pass>(m_ldr_color_texture, width, height);
     auto ui = std::make_unique<ui_pass>(&m_ui_renderables);
 #if _DEBUG
     auto debug = std::make_unique<debug_pass>(&m_debug_renderables);
@@ -111,9 +128,10 @@ void rendering_engine::context::init()
 
     // Register the built-in passes in render order: scene writes into
     // the HDR target, the bloom post pass blurs its bright pixels back
-    // into that target, the tonemap post pass maps the result to LDR on
-    // the swapchain, and the UI pass composites on top. The debug pass is
-    // appended in debug builds only so debug visuals always read on
+    // into that target, the tonemap post pass maps the result to LDR in
+    // the off-screen LDR target, the FXAA post pass anti-aliases that LDR
+    // image onto the swapchain, and the UI pass composites on top. The
+    // debug pass is appended in debug builds only so debug visuals read on
     // top of the game UI; release builds drop it entirely so the
     // overlay registry has no consumer and the stage costs nothing.
     // Further post effects insert between scene and ui by pushing into
@@ -126,6 +144,7 @@ void rendering_engine::context::init()
     m_passes.push_back(std::move(scene));
     m_passes.push_back(std::move(bloom));
     m_passes.push_back(std::move(post));
+    m_passes.push_back(std::move(fxaa));
     m_passes.push_back(std::move(ui));
 #if _DEBUG
     m_passes.push_back(std::move(debug));
@@ -151,6 +170,12 @@ void rendering_engine::context::quit()
     // Release the off-screen HDR target before the device tears its
     // pools down. The colour and depth attachments are owned by the
     // target so destroy() releases all three.
+    if (m_ldr_color_target.valid())
+    {
+        eng.gpu->destroy(m_ldr_color_target);
+        m_ldr_color_target = {};
+        m_ldr_color_texture = {};
+    }
     if (m_scene_color_target.valid())
     {
         eng.gpu->destroy(m_scene_color_target);
@@ -172,8 +197,12 @@ void rendering_engine::context::render()
     // Capture per-frame state once so passes cannot disagree about
     // which camera or backbuffer is active mid-frame, and so they
     // do not have to re-query the camera singleton on every entry.
-    frame_context ctx{
-        gpu.swapchain_target(), camera::get_current_camera(), m_scene_color_target, m_scene_color_texture};
+    frame_context ctx{gpu.swapchain_target(),
+                      camera::get_current_camera(),
+                      m_scene_color_target,
+                      m_scene_color_texture,
+                      m_ldr_color_target,
+                      m_ldr_color_texture};
 
     auto encoder = gpu.create_command_encoder();
     for (auto& p : m_passes)

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -153,5 +153,12 @@ namespace rendering_engine
         // so the post chain can sample it as input.
         gpu::render_target m_scene_color_target{};
         gpu::texture m_scene_color_texture{};
+
+        // Off-screen LDR target the tonemap pass resolves into and the
+        // FXAA pass samples. rgba8, no depth; created alongside the HDR
+        // target in @ref init and released in @ref quit. Surfaced via
+        // @ref frame_context::ldr_color_target / @c ldr_color_texture.
+        gpu::render_target m_ldr_color_target{};
+        gpu::texture m_ldr_color_texture{};
     };
 } // namespace rendering_engine


### PR DESCRIPTION
Closes #115.

## Why

There was no anti-aliasing in the engine. FXAA is a cheap, single-pass post-process AA that drops straight into the existing post chain (the `tonemap_pass` even noted "future FXAA").

## What

Adds FXAA as the final stage of the post chain, following the existing fullscreen-triangle post-pass conventions.

**New pass** — `rendering_engine/passes/post/fxaa_pass.{hpp,cpp}`:
- The canonical compact FXAA (Timothy Lottes): a 3×3 luma neighbourhood picks the edge direction, then bilinear taps along it produce a narrow/wide blend, keeping the wider blend only while its luma stays inside the local min/max so high-contrast detail is not over-smeared.
- The reciprocal frame size `(1/w, 1/h)` is baked into the input bind group at construction (a degenerate backbuffer bakes a zero step → straight copy), mirroring how `tonemap_pass` captures its exposure. Live resolution changes are out of scope.

**Plumbing** — FXAA needs a *sampleable* tonemapped input, which the swapchain can't provide:
- Added an off-screen **rgba8 LDR target** to `context`, surfaced via `frame_context::ldr_color_target` / `ldr_color_texture`.
- `tonemap_pass` now resolves into that LDR target instead of straight to the swapchain.
- `fxaa_pass` samples the LDR target and writes the anti-aliased result to the swapchain; the UI pass composites on top as before.
- Registered the pass between tonemap and UI in `context::init`; updated `passes/post/CMakeLists.txt`.

FXAA runs *after* the ACES + gamma encode on purpose — it expects a perceptual (gamma-encoded) image and computes edge luma directly from the colour, exactly the input Lottes' original shader assumes.

## Verification

- `clang-format` (LLVM 18) and `clang-tidy` naming check: pass on all changed files.
- Full `cmake --build` (Ninja, Debug): configures, compiles and links `AlphaEngine` cleanly.

Rebased on top of current `master` (which includes the `<algorithm>` polyhedron fix), so it builds standalone.

Tier: T2 · Area: passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJpBCTaehkAVxpL9Lf6YHA)_