### PR TITLE
feat: selectable tonemap operator + runtime exposure

### DIFF
--- a/rendering_engine/passes/post/tonemap_pass.cpp
+++ b/rendering_engine/passes/post/tonemap_pass.cpp
@@ -22,6 +22,10 @@
 
 #include <rendering_engine/passes/post/tonemap_pass.hpp>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <string>
 
 #include <control/engine.hpp>
@@ -36,13 +40,17 @@
 
 namespace
 {
-    // Krzysztof Narkowicz's ACES filmic approximation with an
-    // explicit gamma-2.2 encode. The swapchain is regular
-    // GL_RGBA8 (no SDL sRGB attribute, no GL_FRAMEBUFFER_SRGB),
-    // so the framebuffer is treated as linear and the encode has
-    // to happen here. Gamma 2.2 is visually indistinguishable
-    // from the piecewise sRGB curve at these magnitudes and is
-    // the standard chain partner for ACES.
+    // A selectable tonemap curve followed by an explicit gamma-2.2
+    // encode. The swapchain is regular GL_RGBA8 (no SDL sRGB
+    // attribute, no GL_FRAMEBUFFER_SRGB), so the framebuffer is
+    // treated as linear and the encode has to happen here. Gamma 2.2
+    // is visually indistinguishable from the piecewise sRGB curve at
+    // these magnitudes and is the standard chain partner for these
+    // operators.
+    //
+    // u_tonemap.op selects the curve and matches the
+    // rendering_engine::tonemap_operator enumerator values exactly:
+    // 0 = none (clamp only), 1 = Reinhard, 2 = ACES filmic.
     const std::string fragment_shader = R"fs(
         #version 450
 
@@ -54,8 +62,10 @@ namespace
         layout(set = 0, binding = 1, std140) uniform Tonemap
         {
             float exposure;
+            int op;
         } u_tonemap;
 
+        // Krzysztof Narkowicz's ACES filmic approximation.
         vec3 aces_filmic(vec3 x)
         {
             const float a = 2.51;
@@ -66,14 +76,46 @@ namespace
             return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
         }
 
+        // Reinhard's x / (1 + x) shoulder.
+        vec3 reinhard(vec3 x)
+        {
+            return x / (1.0 + x);
+        }
+
         void main()
         {
             vec3 hdr = texture(sceneColor, texCoord).rgb * u_tonemap.exposure;
-            vec3 ldr = aces_filmic(hdr);
+            vec3 mapped;
+            if (u_tonemap.op == 2)
+            {
+                mapped = aces_filmic(hdr);
+            }
+            else if (u_tonemap.op == 1)
+            {
+                mapped = reinhard(hdr);
+            }
+            else
+            {
+                mapped = hdr;
+            }
+            vec3 ldr = clamp(mapped, 0.0, 1.0);
             vec3 srgb = pow(ldr, vec3(1.0 / 2.2));
             fragColor = vec4(srgb, 1.0);
         }
 )fs";
+
+    // std140 rounds the { float, int } block up to the 16-byte
+    // minimum; the float sits at offset 0 and the int at offset 4.
+    constexpr std::size_t tonemap_ubo_size = 16;
+
+    std::array<std::byte, tonemap_ubo_size> pack_uniforms(float exposure, rendering_engine::tonemap_operator op)
+    {
+        std::array<std::byte, tonemap_ubo_size> bytes{};
+        const std::int32_t op_value = static_cast<std::int32_t>(op);
+        std::memcpy(bytes.data(), &exposure, sizeof(float));
+        std::memcpy(bytes.data() + sizeof(float), &op_value, sizeof(std::int32_t));
+        return bytes;
+    }
 } // namespace
 
 namespace rendering_engine
@@ -100,17 +142,19 @@ namespace rendering_engine
         vb_descriptor.initial_data = fullscreen_triangle_vertices.data();
         m_vertex_buffer = gpu.create_buffer(vb_descriptor);
 
-        // Captured once at construction; live tuning is out of
-        // scope per the issue. A future auto-exposure pass will
-        // update this UBO per-frame via write_buffer. std140 rounds
-        // a single float UBO up to a 16-byte allocation.
-        const float exposure = 1.0f;
+        // The Tonemap UBO holds the exposure scale and the operator
+        // selector. Both are live-tunable through set_exposure /
+        // set_operator, which rewrite this buffer via write_buffer;
+        // a future auto-exposure pass will drive the exposure the same
+        // way. std140 lays the float and the int contiguously and
+        // rounds the block up to the 16-byte minimum.
+        const std::array<std::byte, tonemap_ubo_size> initial = pack_uniforms(m_exposure, m_operator);
         gpu::buffer_descriptor ubo_descriptor{};
-        ubo_descriptor.size = 16;
+        ubo_descriptor.size = initial.size();
         ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
         ubo_descriptor.hint = gpu::buffer_usage_hint::static_data;
-        ubo_descriptor.initial_data = &exposure;
-        m_exposure_ubo = gpu.create_buffer(ubo_descriptor);
+        ubo_descriptor.initial_data = initial.data();
+        m_tonemap_ubo = gpu.create_buffer(ubo_descriptor);
 
         gpu::bind_group_layout_descriptor input_layout{};
         input_layout.entries.push_back({0, gpu::binding_kind::texture});
@@ -126,11 +170,11 @@ namespace rendering_engine
         scene_color_slot.texture_value = input_color;
         input_bind_group_descriptor.entries.push_back(scene_color_slot);
 
-        gpu::binding_value exposure_slot{};
-        exposure_slot.binding = 1;
-        exposure_slot.kind = gpu::binding_kind::uniform_buffer;
-        exposure_slot.buffer_value = m_exposure_ubo;
-        input_bind_group_descriptor.entries.push_back(exposure_slot);
+        gpu::binding_value tonemap_slot{};
+        tonemap_slot.binding = 1;
+        tonemap_slot.kind = gpu::binding_kind::uniform_buffer;
+        tonemap_slot.buffer_value = m_tonemap_ubo;
+        input_bind_group_descriptor.entries.push_back(tonemap_slot);
 
         m_input_bind_group = gpu.create_bind_group(input_bind_group_descriptor);
 
@@ -185,10 +229,10 @@ namespace rendering_engine
             gpu.destroy(m_input_layout);
             m_input_layout = {};
         }
-        if (m_exposure_ubo.valid())
+        if (m_tonemap_ubo.valid())
         {
-            gpu.destroy(m_exposure_ubo);
-            m_exposure_ubo = {};
+            gpu.destroy(m_tonemap_ubo);
+            m_tonemap_ubo = {};
         }
         if (m_vertex_buffer.valid())
         {
@@ -228,5 +272,32 @@ namespace rendering_engine
         pass_encoder->set_vertex_buffer(0, m_vertex_buffer, 0, 0);
         pass_encoder->draw(3, 0);
         pass_encoder->end();
+    }
+
+    void tonemap_pass::set_exposure(float exposure)
+    {
+        if (exposure == m_exposure)
+        {
+            return;
+        }
+        m_exposure = exposure;
+        upload_uniforms();
+    }
+
+    void tonemap_pass::set_operator(tonemap_operator op)
+    {
+        if (op == m_operator)
+        {
+            return;
+        }
+        m_operator = op;
+        upload_uniforms();
+    }
+
+    void tonemap_pass::upload_uniforms()
+    {
+        auto& gpu = *control::current_engine().gpu;
+        const std::array<std::byte, tonemap_ubo_size> bytes = pack_uniforms(m_exposure, m_operator);
+        gpu.write_buffer(m_tonemap_ubo, bytes.data(), bytes.size(), 0);
     }
 } // namespace rendering_engine

--- a/rendering_engine/passes/post/tonemap_pass.hpp
+++ b/rendering_engine/passes/post/tonemap_pass.hpp
@@ -28,15 +28,36 @@
 namespace rendering_engine
 {
     /**
+     * @brief Tonemap operator the @ref tonemap_pass applies to the
+     *        HDR scene colour, the analogue of @c THREE.ToneMapping.
+     *
+     * The enumerator values are the contract with the fragment
+     * shader's @c Tonemap UBO — they are uploaded verbatim and
+     * branched on at draw time, so they must not be reordered.
+     */
+    enum class tonemap_operator : int
+    {
+        /// No curve: the exposed colour is only clamped and gamma
+        /// encoded (THREE.NoToneMapping / LinearToneMapping).
+        none = 0,
+        /// Reinhard's x / (1 + x) shoulder (THREE.ReinhardToneMapping).
+        reinhard = 1,
+        /// Krzysztof Narkowicz's ACES filmic approximation
+        /// (THREE.ACESFilmicToneMapping). The default.
+        aces = 2,
+    };
+
+    /**
      * @brief Maps the HDR scene-colour target into LDR for the
-     *        swapchain via an ACES filmic curve and gamma encode.
+     *        swapchain via a selectable tonemap curve and gamma encode.
      *
      * Reads the rgba16f scene target produced by @ref scene_pass,
-     * applies @c exposure as a pre-curve scale, runs Krzysztof
-     * Narkowicz's 5-line ACES filmic approximation per channel,
-     * and gamma-2.2 encodes the result before writing to the
-     * off-screen LDR target. Without this pass HDR luminance > 1.0
-     * saturates to white as soon as it hits the 8-bit backbuffer.
+     * applies @c exposure as a pre-curve scale, runs the operator
+     * selected via @ref set_operator (ACES filmic by default,
+     * Reinhard, or a clamp-only linear path), and gamma-2.2 encodes
+     * the result before writing to the off-screen LDR target. Without
+     * this pass HDR luminance > 1.0 saturates to white as soon as it
+     * hits the 8-bit backbuffer.
      *
      * It resolves into @ref frame_context::ldr_color_target rather
      * than straight to the swapchain so the trailing @ref fxaa_pass
@@ -49,9 +70,12 @@ namespace rendering_engine
      * @ref fullscreen_triangle_vertex_shader emits the geometry
      * from @c gl_VertexID.
      *
-     * @c exposure defaults to 1.0 and is captured into the input
-     * bind group at construction. It exists today as scaffold for
-     * a future auto-exposure stage; live tuning is out of scope.
+     * @c exposure and the operator default to 1.0 / @ref
+     * tonemap_operator::aces and are baked into the @c Tonemap UBO at
+     * construction. Both are live-tunable: @ref set_exposure and
+     * @ref set_operator rewrite the UBO immediately (the change lands
+     * on the next recorded frame), the entry point a future
+     * auto-exposure stage will drive the exposure through.
      */
     struct tonemap_pass : pass
     {
@@ -63,11 +87,36 @@ namespace rendering_engine
 
         void record(gpu::command_encoder& encoder, const frame_context& ctx) override;
 
+        /// @brief Sets the pre-curve exposure scale; rewrites the UBO.
+        void set_exposure(float exposure);
+        /// @brief The current pre-curve exposure scale.
+        float exposure() const
+        {
+            return m_exposure;
+        }
+
+        /// @brief Selects the tonemap curve; rewrites the UBO.
+        void set_operator(tonemap_operator op);
+        /// @brief The currently selected tonemap curve.
+        tonemap_operator operator_kind() const
+        {
+            return m_operator;
+        }
+
     private:
+        // Repacks the { exposure, operator } pair and writes it to the
+        // Tonemap UBO; called by the setters whenever a value changes.
+        void upload_uniforms();
+
+        // CPU-side mirror of the std140 @c Tonemap UBO: the float
+        // exposure scale and the int operator selector.
+        float m_exposure{1.0f};
+        tonemap_operator m_operator{tonemap_operator::aces};
+
         gpu::shader_module m_vertex_shader{};
         gpu::shader_module m_fragment_shader{};
         gpu::buffer m_vertex_buffer{};
-        gpu::buffer m_exposure_ubo{};
+        gpu::buffer m_tonemap_ubo{};
         gpu::bind_group_layout m_input_layout{};
         gpu::bind_group m_input_bind_group{};
         gpu::pipeline m_pipeline{};


### PR DESCRIPTION
## Why

The tonemap pass hardcoded the ACES filmic curve and captured a fixed exposure (1.0) into its UBO at construction. three.js exposes both the curve and the exposure (`renderer.toneMapping` + `toneMappingExposure`). This makes the existing pass configurable rather than adding new machinery.

Closes #116.

## What changed

Both edits are confined to the existing `tonemap_pass` — no new pass type.

**`tonemap_pass.hpp`**
- Added a scoped `enum class tonemap_operator : int { none = 0, reinhard = 1, aces = 2 }`, mapping to three.js's `NoToneMapping`/`ReinhardToneMapping`/`ACESFilmicToneMapping`. The enumerator values are the wire contract with the shader, so they must not be reordered.
- Added `set_exposure(float)` / `exposure()` and `set_operator(tonemap_operator)` / `operator_kind()`. Both setters rewrite the UBO in place via `write_buffer`, so changes land on the next recorded frame — the same entry point a future auto-exposure stage will drive exposure through.
- Defaults stay ACES + exposure 1.0, preserving current behaviour.

**`tonemap_pass.cpp`**
- The `Tonemap` UBO gained an `int op`; the fragment shader branches across ACES filmic, Reinhard, and a clamp-only linear path, then applies the shared gamma-2.2 encode.
- A `pack_uniforms` helper lays out the std140 16-byte `{ float, int }` block; the constructor seeds it and the new `upload_uniforms()` rewrites it on each setter call.

## Verification

- **Build:** full `cmake --build` (Ninja, Debug) links `Binaries/AlphaEngine` cleanly.
- **Format gate:** `clang-format-18` clean on both files.
- **Naming gate:** `clang-tidy-18` with the repo's `readability-identifier-naming` config reports no violations in the changed file.

https://claude.ai/code/session_013LhCqFQakavmo5ow69eYtN

---
_Generated by [Claude Code](https://claude.ai/code/session_013LhCqFQakavmo5ow69eYtN)_