### PR TITLE
feat: line material + line renderable

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,17 +3,17 @@ target_sources(AlphaEngine PRIVATE
     exit_module.cpp
     fps_overlay_module.cpp
     frame_module.cpp
-    points_demo_module.cpp
+    line_demo_module.cpp
 )
 
 # Only one scene-owning demo module is compiled at a time because each
-# places its showcase geometry at the origin. points_demo_module.cpp is
-# the active one: it showcases points_material + the points renderable as
-# a coloured Fibonacci-sphere point cloud.
+# places its showcase geometry at the origin. line_demo_module.cpp is
+# the active one: it showcases line_material + the line renderable as a
+# coloured helix line strip.
 #
-# skybox_demo_module.cpp (procedural sky + IBL sphere grid),
-# phong_demo_module.cpp (Blinn-Phong lit sphere) and line_demo_module.cpp
-# (a coloured helix line strip) are the other showcases; swap any one
-# filename in for points_demo_module.cpp to bring it back.
+# points_demo_module.cpp (coloured Fibonacci-sphere point cloud),
+# skybox_demo_module.cpp (procedural sky + IBL sphere grid) and
+# phong_demo_module.cpp (Blinn-Phong lit sphere) are the other showcases;
+# swap any one filename in for line_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -11,8 +11,9 @@ target_sources(AlphaEngine PRIVATE
 # the active one: it showcases points_material + the points renderable as
 # a coloured Fibonacci-sphere point cloud.
 #
-# skybox_demo_module.cpp (procedural sky + IBL sphere grid) and
-# phong_demo_module.cpp (Blinn-Phong lit sphere) are the other showcases;
-# swap either filename in for points_demo_module.cpp to bring it back.
+# skybox_demo_module.cpp (procedural sky + IBL sphere grid),
+# phong_demo_module.cpp (Blinn-Phong lit sphere) and line_demo_module.cpp
+# (a coloured helix line strip) are the other showcases; swap any one
+# filename in for points_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/line_demo_module.cpp
+++ b/external/line_demo_module.cpp
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "api/game_module.hpp"
+#include "api/log.hpp"
+#include "api/time.hpp"
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <control/engine.hpp>
+#include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/materials/line_material.hpp>
+#include <rendering_engine/renderables/line.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace
+{
+    namespace math = infrastructure::math;
+
+    // Number of samples along the helix strip.
+    constexpr int sample_count = 400;
+
+    std::unique_ptr<rendering_engine::line> g_helix;
+    float g_rotation = 0.0f;
+    const float g_rotation_speed = 3.14f / 6;
+} // namespace
+
+static void on_engine_start(const event_engine::engine_start& event)
+{
+    auto& material = control::current_engine().renderer->get_line_material();
+    material.set_color(rendering_engine::util::color{255, 255, 255, 255});
+
+    // Sample a vertical helix and colour each vertex along the way so the
+    // strip reads as a continuous rainbow ribbon.
+    std::vector<math::vec3> positions;
+    std::vector<math::vec3> colors;
+    positions.reserve(sample_count);
+    colors.reserve(sample_count);
+
+    const float turns = 4.0f;
+    for (int i = 0; i < sample_count; ++i)
+    {
+        const float t = static_cast<float>(i) / static_cast<float>(sample_count - 1);
+        const float angle = turns * 2.0f * 3.14159265f * t;
+        const math::vec3 position{std::cos(angle), 2.0f * t - 1.0f, std::sin(angle)};
+        positions.push_back(position);
+        colors.push_back(math::vec3{0.5f + 0.5f * std::cos(angle), t, 0.5f + 0.5f * std::sin(angle)});
+    }
+
+    g_helix = std::make_unique<rendering_engine::line>(&material);
+    g_helix->set_mode(rendering_engine::line_mode::strip);
+    g_helix->set_positions(positions, colors);
+    g_helix->upload();
+    control::current_engine().renderer->register_scene_renderable(g_helix.get());
+}
+
+static void on_engine_stop(const event_engine::engine_stop& event)
+{
+    control::current_engine().renderer->unregister_scene_renderable(g_helix.get());
+    g_helix.reset();
+}
+
+static void on_frame(const event_engine::frame& event)
+{
+    g_rotation += g_rotation_speed * (static_cast<float>(get_delta_time()) / 1000);
+    g_helix->transform.set_rotation(math::vec3{0.0f, g_rotation, 0.0f});
+}
+
+GAME_MODULE()
+{
+    LOG_INF("Registering external module: line_demo_module");
+    struct game_module_info info = {};
+    info.on_engine_start = on_engine_start;
+    info.on_engine_stop = on_engine_stop;
+    info.on_frame = on_frame;
+    register_game_module(info);
+    return true;
+}

--- a/rendering_engine/materials/CMakeLists.txt
+++ b/rendering_engine/materials/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(AlphaEngine PRIVATE
     basic_material.cpp
     basic_material.hpp
+    line_material.cpp
+    line_material.hpp
     material.cpp
     material.hpp
     phong_material.cpp

--- a/rendering_engine/materials/line_material.cpp
+++ b/rendering_engine/materials/line_material.cpp
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/materials/line_material.hpp>
+
+#include <array>
+#include <string>
+
+#include <control/engine.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+
+namespace
+{
+    // Binding numbers. UBOs share a single namespace across every
+    // descriptor set on the OpenGL backend (ARB_gl_spirv), so they must
+    // stay globally unique: the scene_pass owns camera = 0 and lights = 2
+    // in the per-frame set, the per-draw model matrix takes 1, leaving 3
+    // for the per-material params block. This mirrors basic_material so
+    // the unlit materials share the same slot shape.
+    constexpr uint32_t draw_model_binding = 1;
+    constexpr uint32_t material_params_binding = 3;
+
+    // std140 layout for the per-material params UBO: a single vec4 color
+    // at offset 0. The block is 16 bytes.
+    constexpr size_t material_ubo_size = 16;
+
+    const std::string vertex_shader = R"vs(
+        #version 450
+
+        layout(location = 0) in vec3 position;
+        layout(location = 1) in vec3 color;
+
+        layout(location = 0) out vec3 lineColor;
+
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+        } u_frame;
+
+        layout(set = 1, binding = 1, std140) uniform PerDraw
+        {
+            mat4 modelMatrix;
+        } u_draw;
+
+        void main()
+        {
+            lineColor = color;
+            mat4 MVP = u_frame.projectionMatrix * u_frame.viewMatrix * u_draw.modelMatrix;
+            gl_Position = MVP * vec4(position, 1.0);
+        }
+)vs";
+
+    const std::string fragment_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec3 lineColor;
+        layout(location = 0) out vec4 fragColor;
+
+        layout(set = 2, binding = 3, std140) uniform Material
+        {
+            vec4 color;
+        } u_material;
+
+        void main()
+        {
+            fragColor = u_material.color * vec4(lineColor, 1.0);
+        }
+)fs";
+} // namespace
+
+namespace rendering_engine
+{
+    line_material::line_material(gpu::bind_group_layout frame_layout)
+    {
+        gpu::vertex_buffer_layout vertex_layout{};
+        // Stride = 0 — the per-vertex stride is supplied at
+        // set_vertex_buffer time by the renderable. Position sits at
+        // offset 0 and the per-vertex colour at offset 12.
+        vertex_layout.stride = 0;
+        vertex_layout.attributes.push_back({0, 3, gpu::scalar_type::float32, 0});
+        vertex_layout.attributes.push_back({1, 3, gpu::scalar_type::float32, sizeof(float) * 3});
+
+        // Per-draw layout (slot 1): the model matrix UBO at binding 1,
+        // matching the line renderable's bind group.
+        gpu::bind_group_layout_descriptor draw_layout{};
+        draw_layout.entries.push_back({draw_model_binding, gpu::binding_kind::uniform_buffer});
+
+        // Per-material layout (slot 2): the tint params UBO owned by this
+        // material.
+        gpu::bind_group_layout_descriptor material_layout{};
+        material_layout.entries.push_back({material_params_binding, gpu::binding_kind::uniform_buffer});
+
+        // Opaque unlit lines: depth tested and written, no blending.
+        material_params params{};
+        params.transparent = false;
+        params.depth_test = true;
+        params.depth_write = true;
+
+        construct_pipeline(vertex_shader,
+                           fragment_shader,
+                           vertex_layout,
+                           draw_layout,
+                           frame_layout,
+                           params,
+                           material_layout,
+                           gpu::primitive_topology::lines);
+
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = material_ubo_size;
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        auto& gpu = *control::current_engine().gpu;
+        m_material_ubo = gpu.create_buffer(ubo_descriptor);
+
+        // The per-material bind group never changes shape (one UBO, no
+        // textures), so build it once here rather than rebuilding on
+        // every parameter change.
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_per_material_layout;
+        gpu::binding_value ubo_slot{};
+        ubo_slot.binding = material_params_binding;
+        ubo_slot.kind = gpu::binding_kind::uniform_buffer;
+        ubo_slot.buffer_value = m_material_ubo;
+        bg_descriptor.entries.push_back(ubo_slot);
+        m_per_material_bind_group = gpu.create_bind_group(bg_descriptor);
+
+        upload_params();
+    }
+
+    line_material::~line_material()
+    {
+        // Drop the bind group before the buffer it references, then null
+        // it so the base destructor's destruct_pipeline does not
+        // double-free.
+        auto& gpu = *control::current_engine().gpu;
+        if (m_per_material_bind_group.valid())
+        {
+            gpu.destroy(m_per_material_bind_group);
+            m_per_material_bind_group = {};
+        }
+        if (m_material_ubo.valid())
+        {
+            gpu.destroy(m_material_ubo);
+            m_material_ubo = {};
+        }
+    }
+
+    uint32_t line_material::per_material_slot() const
+    {
+        return per_draw_slot() + 1u;
+    }
+
+    void line_material::set_color(const util::color& color)
+    {
+        m_color = color;
+        upload_params();
+    }
+
+    void line_material::upload_params()
+    {
+        std::array<float, 4> payload{};
+        payload[0] = static_cast<float>(m_color.r) / 255.0f;
+        payload[1] = static_cast<float>(m_color.g) / 255.0f;
+        payload[2] = static_cast<float>(m_color.b) / 255.0f;
+        payload[3] = static_cast<float>(m_color.a) / 255.0f;
+
+        auto& gpu = *control::current_engine().gpu;
+        gpu.write_buffer(m_material_ubo, payload.data(), material_ubo_size, 0);
+    }
+} // namespace rendering_engine

--- a/rendering_engine/materials/line_material.hpp
+++ b/rendering_engine/materials/line_material.hpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine
+{
+    // Built-in unlit line material — the analogue of
+    // @c THREE.LineBasicMaterial. Its pipeline bakes
+    // @c primitive_topology::lines, so a @ref line renderable that
+    // fronts it rasterizes one line segment per index/vertex pair (a
+    // connected strip or independent segments depending on the
+    // renderable's mode).
+    //
+    // Vertex stream: position (vec3) + per-vertex colour (vec3). The
+    // fragment colour is the per-vertex colour modulated by the shared
+    // tint, matching @c THREE.LineBasicMaterial with @c vertexColors.
+    //
+    // Slot layout mirrors @ref basic_material: the per-frame group at
+    // slot 0 (camera, owned by the @ref scene_pass), the per-draw group
+    // at slot 1 (@c modelMatrix, built by the renderable), and the tint
+    // in the per-material group at slot 2 owned by this material.
+    //
+    // Line width is fixed at one pixel: the Vulkan backend pins
+    // @c lineWidth to 1.0 and wide lines are not portable on either
+    // backend, so — like @c THREE.LineBasicMaterial in WebGL — the
+    // @c linewidth knob is intentionally omitted.
+    struct line_material : public material
+    {
+        // @p frame_layout is the per-frame bind-group layout owned by
+        // the @ref scene_pass; it must match the layout the pass binds
+        // at slot 0 every frame so the pipeline and the runtime bind
+        // group agree on slot shape.
+        explicit line_material(gpu::bind_group_layout frame_layout);
+        ~line_material() override;
+
+        // Tint multiplied into every vertex's colour (white leaves the
+        // per-vertex colour unchanged). Alpha participates when the
+        // material is constructed transparent.
+        void set_color(const util::color& color);
+
+        // The per-material group trails the per-frame and per-draw
+        // groups, so it occupies slot 2 (per-frame at 0, per-draw at 1).
+        uint32_t per_material_slot() const override;
+
+    private:
+        // Push the tint colour into the per-material UBO.
+        void upload_params();
+
+        util::color m_color{255, 255, 255, 255};
+        gpu::buffer m_material_ubo{};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/CMakeLists.txt
+++ b/rendering_engine/renderables/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(AlphaEngine PRIVATE
     draw_item.hpp
+    line.cpp
+    line.hpp
     model.cpp
     model.hpp
     points.cpp

--- a/rendering_engine/renderables/line.cpp
+++ b/rendering_engine/renderables/line.cpp
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/line.hpp>
+
+#include <cstdint>
+#include <vector>
+
+#include <control/engine.hpp>
+#include <infrastructure/log.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/materials/material.hpp>
+
+rendering_engine::line::line(material* mat) : m_material{mat} {}
+
+rendering_engine::line::~line()
+{
+    auto& gpu = *control::current_engine().gpu;
+    if (m_draw_bind_group.valid())
+    {
+        gpu.destroy(m_draw_bind_group);
+        m_draw_bind_group = {};
+    }
+    if (m_draw_ubo.valid())
+    {
+        gpu.destroy(m_draw_ubo);
+        m_draw_ubo = {};
+    }
+    if (m_index_buffer.valid())
+    {
+        gpu.destroy(m_index_buffer);
+        m_index_buffer = {};
+    }
+    if (m_vertex_buffer.valid())
+    {
+        gpu.destroy(m_vertex_buffer);
+        m_vertex_buffer = {};
+    }
+}
+
+void rendering_engine::line::set_mode(line_mode mode)
+{
+    m_mode = mode;
+}
+
+void rendering_engine::line::set_positions(const std::vector<infrastructure::math::vec3>& positions)
+{
+    m_vertices.clear();
+    m_vertices.reserve(positions.size());
+    for (const auto& position : positions)
+    {
+        m_vertices.push_back({position, infrastructure::math::vec3{1.0f, 1.0f, 1.0f}});
+    }
+}
+
+void rendering_engine::line::set_positions(const std::vector<infrastructure::math::vec3>& positions,
+                                           const std::vector<infrastructure::math::vec3>& colors)
+{
+    if (positions.size() != colors.size())
+    {
+        LOG_WRN("line::set_positions: positions (%zu) and colors (%zu) size mismatch; ignoring",
+                positions.size(),
+                colors.size());
+        return;
+    }
+
+    m_vertices.clear();
+    m_vertices.reserve(positions.size());
+    for (size_t i = 0; i < positions.size(); ++i)
+    {
+        m_vertices.push_back({positions[i], colors[i]});
+    }
+}
+
+void rendering_engine::line::upload()
+{
+    m_vertex_count = m_vertices.size();
+    m_vertex_stride = sizeof(vertex_position_color);
+    m_index_count = 0;
+
+    auto& gpu = *control::current_engine().gpu;
+
+    // Re-uploading replaces the previous buffers, so drop them first.
+    if (m_vertex_buffer.valid())
+    {
+        gpu.destroy(m_vertex_buffer);
+        m_vertex_buffer = {};
+    }
+    if (m_index_buffer.valid())
+    {
+        gpu.destroy(m_index_buffer);
+        m_index_buffer = {};
+    }
+
+    if (m_vertices.empty())
+    {
+        return;
+    }
+
+    gpu::buffer_descriptor vertex_descriptor{};
+    vertex_descriptor.size = m_vertices.size() * sizeof(vertex_position_color);
+    vertex_descriptor.usage = gpu::buffer_usage_vertex;
+    vertex_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    vertex_descriptor.initial_data = m_vertices.data();
+    m_vertex_buffer = gpu.create_buffer(vertex_descriptor);
+
+    if (m_mode != line_mode::strip)
+    {
+        // Segments draw the vertices directly, two per segment; nothing
+        // to index. An odd trailing vertex has no partner, so it is
+        // dropped from the draw (the buffer still holds it).
+        return;
+    }
+
+    // A strip joins consecutive vertices, but the backend bakes line-list
+    // topology, so expand the polyline into segment pairs: vertex i pairs
+    // with i + 1 for every i in [0, count - 1). Fewer than two vertices
+    // span no segment.
+    if (m_vertices.size() < 2)
+    {
+        return;
+    }
+
+    std::vector<uint32_t> indices;
+    indices.reserve((m_vertices.size() - 1) * 2);
+    for (uint32_t i = 0; i + 1 < static_cast<uint32_t>(m_vertices.size()); ++i)
+    {
+        indices.push_back(i);
+        indices.push_back(i + 1);
+    }
+    m_index_count = indices.size();
+
+    gpu::buffer_descriptor index_descriptor{};
+    index_descriptor.size = indices.size() * sizeof(uint32_t);
+    index_descriptor.usage = gpu::buffer_usage_index;
+    index_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    index_descriptor.initial_data = indices.data();
+    m_index_buffer = gpu.create_buffer(index_descriptor);
+}
+
+void rendering_engine::line::collect_draw_items(std::vector<draw_item>& out)
+{
+    if (m_material == nullptr)
+    {
+        LOG_WRN("line::collect_draw_items: no material");
+        return;
+    }
+    if (!m_vertex_buffer.valid())
+    {
+        return;
+    }
+
+    auto& gpu = *control::current_engine().gpu;
+
+    if (!m_draw_ubo.valid())
+    {
+        // Per-draw UBO matches the @c PerDraw block in the line_material
+        // vertex shader: a single mat4 modelMatrix packed std140
+        // (64 bytes, no padding).
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = sizeof(infrastructure::math::mat4);
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_draw_ubo = gpu.create_buffer(ubo_descriptor);
+    }
+
+    if (!m_draw_bind_group.valid())
+    {
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_material->per_draw_layout();
+        gpu::binding_value model_slot{};
+        model_slot.binding = 1;
+        model_slot.kind = gpu::binding_kind::uniform_buffer;
+        model_slot.buffer_value = m_draw_ubo;
+        bg_descriptor.entries.push_back(model_slot);
+        m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
+    }
+
+    const auto model_matrix = transform.get_transform_matrix();
+    gpu.write_buffer(m_draw_ubo, model_matrix.data(), sizeof(infrastructure::math::mat4), 0);
+
+    // The line topology is baked into the material's pipeline. A strip
+    // carries an index buffer expanding the polyline into segment pairs;
+    // segments draw the vertices directly, two per segment (an odd
+    // trailing vertex is dropped).
+    draw_item item{};
+    item.mat = m_material;
+    item.vertex_buffer = m_vertex_buffer;
+    item.per_draw_bind_group = m_draw_bind_group;
+    item.vertex_stride = m_vertex_stride;
+
+    if (m_index_buffer.valid())
+    {
+        item.index_buffer = m_index_buffer;
+        item.index_count = static_cast<uint32_t>(m_index_count);
+        item.index_format = gpu::index_format::uint32;
+    }
+    else
+    {
+        item.vertex_count = static_cast<uint32_t>(m_vertex_count & ~static_cast<size_t>(1));
+    }
+
+    out.push_back(item);
+}

--- a/rendering_engine/renderables/line.hpp
+++ b/rendering_engine/renderables/line.hpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+#include <rendering_engine/renderables/renderable.hpp>
+#include <rendering_engine/util/transform.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // How successive vertices are joined into segments. @c strip joins
+    // every vertex to the next (the @c THREE.Line analogue — a connected
+    // polyline); @c segments treats vertices as independent pairs (the
+    // @c THREE.LineSegments analogue), so vertices 0-1 form one segment,
+    // 2-3 the next, and so on.
+    enum class line_mode
+    {
+        strip,
+        segments,
+    };
+
+    // A line — the analogue of @c THREE.Line / @c THREE.LineSegments. It
+    // owns a list of vertex positions (with optional per-vertex colours)
+    // and submits a single @ref draw_item against a line-topology
+    // material (@ref line_material), so the scene pass rasterizes the
+    // vertices as connected or independent line segments. The line width
+    // is fixed at one pixel; tint lives on the material, geometry and the
+    // model transform live here.
+    //
+    // The backend bakes line-list topology into the pipeline, so a
+    // @c strip line is expanded into an index buffer of segment pairs at
+    // @ref upload time; a @c segments line draws its vertices directly,
+    // two per segment.
+    struct line : public renderable
+    {
+        // The material is non-owning; it is typically a
+        // @ref line_material (its pipeline must bake line topology)
+        // created by @ref rendering_engine::context and shared by every
+        // line that draws under it.
+        explicit line(material* mat);
+        ~line() override;
+
+        rendering_engine::util::transform transform;
+
+        // Select how vertices are joined. Takes effect on the next
+        // @ref upload; defaults to @c line_mode::strip.
+        void set_mode(line_mode mode);
+
+        // Set the line vertices; every vertex defaults to white and is
+        // tinted by the material colour. Replaces any previous data.
+        // Call @ref upload afterwards to push it to the GPU.
+        void set_positions(const std::vector<infrastructure::math::vec3>& positions);
+
+        // Set positions with a matching per-vertex colour list. The two
+        // vectors must be the same length; a size mismatch logs and the
+        // call is ignored. Call @ref upload afterwards.
+        void set_positions(const std::vector<infrastructure::math::vec3>& positions,
+                           const std::vector<infrastructure::math::vec3>& colors);
+
+        // Upload the staged line data into a GPU vertex buffer (and, in
+        // @c strip mode, the matching segment index buffer). Safe to
+        // call again after a @ref set_positions to re-upload; the
+        // previous buffers are released first.
+        void upload() final;
+
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+    private:
+        material* m_material{nullptr};
+        line_mode m_mode{line_mode::strip};
+        std::vector<vertex_position_color> m_vertices;
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_index_buffer{};
+        gpu::buffer m_draw_ubo{};
+        gpu::bind_group m_draw_bind_group{};
+
+        size_t m_vertex_count{0};
+        size_t m_index_count{0};
+        uint32_t m_vertex_stride{0};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -30,6 +30,7 @@
 #include <rendering_engine/gpu/device.hpp>
 #include <rendering_engine/ibl/environment.hpp>
 #include <rendering_engine/materials/basic_material.hpp>
+#include <rendering_engine/materials/line_material.hpp>
 #include <rendering_engine/materials/phong_material.hpp>
 #include <rendering_engine/materials/points_material.hpp>
 #include <rendering_engine/materials/standard_material.hpp>
@@ -135,9 +136,10 @@ void rendering_engine::context::init()
     m_phong_material = std::make_unique<phong_material>(scene_frame_layout);
     m_standard_material = std::make_unique<standard_material>(scene_frame_layout);
     m_points_material = std::make_unique<points_material>(scene_frame_layout);
+    m_line_material = std::make_unique<line_material>(scene_frame_layout);
     m_ui_material = std::make_unique<ui_material>();
-    LOG_INF("Rendering Engine: basic_material, phong_material, standard_material, points_material and ui_material "
-            "constructed");
+    LOG_INF("Rendering Engine: basic_material, phong_material, standard_material, points_material, line_material and "
+            "ui_material constructed");
 
     // Register the built-in passes in render order: scene writes into
     // the HDR target, the skybox pass fills the untouched background of
@@ -180,6 +182,7 @@ void rendering_engine::context::quit()
     // Then materials, which own pipelines that reference the device.
     // Release them before the device tears its pools down.
     m_ui_material.reset();
+    m_line_material.reset();
     m_points_material.reset();
     m_standard_material.reset();
     m_phong_material.reset();
@@ -289,6 +292,11 @@ rendering_engine::standard_material& rendering_engine::context::get_standard_mat
 rendering_engine::points_material& rendering_engine::context::get_points_material()
 {
     return *m_points_material;
+}
+
+rendering_engine::line_material& rendering_engine::context::get_line_material()
+{
+    return *m_line_material;
 }
 
 rendering_engine::ui_material& rendering_engine::context::get_ui_material()

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -42,6 +42,7 @@ namespace rendering_engine
     struct phong_material;
     struct standard_material;
     struct points_material;
+    struct line_material;
     struct ui_material;
 
     /**
@@ -143,6 +144,9 @@ namespace rendering_engine
         /** @brief Built-in unlit point-cloud material (point topology). Constructed in @ref init. */
         points_material& get_points_material();
 
+        /** @brief Built-in unlit line material (line topology). Constructed in @ref init. */
+        line_material& get_line_material();
+
         /** @brief Built-in 2D overlay material. Constructed in @ref init. */
         ui_material& get_ui_material();
 
@@ -192,6 +196,7 @@ namespace rendering_engine
         std::unique_ptr<phong_material> m_phong_material;
         std::unique_ptr<standard_material> m_standard_material;
         std::unique_ptr<points_material> m_points_material;
+        std::unique_ptr<line_material> m_line_material;
         std::unique_ptr<ui_material> m_ui_material;
 
         // Off-screen HDR target the scene pass renders into.


### PR DESCRIPTION
Add line_material (THREE.LineBasicMaterial analogue) baking line-list
topology with a per-vertex colour stream and a shared tint, plus a line
renderable (THREE.Line / LineSegments analogue) that submits a line
draw_item. The renderable supports strip mode (a connected polyline,
expanded into segment pairs via a generated index buffer) and segments
mode (independent vertex pairs).

Wire the material into the rendering context (getter + lifecycle) and
add line_demo_module.cpp as an available showcase.