### PR TITLE
feat: debug helpers/gizmos (grid, axes, bounds, light, camera)

### DIFF
--- a/rendering_engine/CMakeLists.txt
+++ b/rendering_engine/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(AlphaEngine PRIVATE
 )
 
 add_subdirectory(camera)
+add_subdirectory(debug)
 add_subdirectory(debug_ui)
 add_subdirectory(gpu)
 add_subdirectory(ibl)

--- a/rendering_engine/debug/CMakeLists.txt
+++ b/rendering_engine/debug/CMakeLists.txt
@@ -1,0 +1,17 @@
+target_sources(AlphaEngine PRIVATE
+    axes_helper.cpp
+    axes_helper.hpp
+    box_edges.hpp
+    box_helper.cpp
+    box_helper.hpp
+    camera_helper.cpp
+    camera_helper.hpp
+    directional_light_helper.cpp
+    directional_light_helper.hpp
+    grid_helper.cpp
+    grid_helper.hpp
+    helper.cpp
+    helper.hpp
+    point_light_helper.cpp
+    point_light_helper.hpp
+)

--- a/rendering_engine/debug/CMakeLists.txt
+++ b/rendering_engine/debug/CMakeLists.txt
@@ -12,6 +12,10 @@ target_sources(AlphaEngine PRIVATE
     grid_helper.hpp
     helper.cpp
     helper.hpp
+    infinite_grid.cpp
+    infinite_grid.hpp
+    line_helper.cpp
+    line_helper.hpp
     point_light_helper.cpp
     point_light_helper.hpp
 )

--- a/rendering_engine/debug/axes_helper.cpp
+++ b/rendering_engine/debug/axes_helper.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/axes_helper.hpp>
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+
+namespace rendering_engine::debug
+{
+    axes_helper::axes_helper(float size) : helper("Axes")
+    {
+        namespace math = infrastructure::math;
+
+        const math::vec3 origin{0.0f, 0.0f, 0.0f};
+        const math::vec3 red{1.0f, 0.0f, 0.0f};
+        const math::vec3 green{0.0f, 1.0f, 0.0f};
+        const math::vec3 blue{0.0f, 0.0f, 1.0f};
+
+        const std::vector<math::vec3> positions{origin,
+                                                math::vec3{size, 0.0f, 0.0f},
+                                                origin,
+                                                math::vec3{0.0f, size, 0.0f},
+                                                origin,
+                                                math::vec3{0.0f, 0.0f, size}};
+        const std::vector<math::vec3> colors{red, red, green, green, blue, blue};
+
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/axes_helper.cpp
+++ b/rendering_engine/debug/axes_helper.cpp
@@ -28,7 +28,7 @@
 
 namespace rendering_engine::debug
 {
-    axes_helper::axes_helper(float size) : helper("Axes")
+    axes_helper::axes_helper(float size) : line_helper("Axes")
     {
         namespace math = infrastructure::math;
 

--- a/rendering_engine/debug/axes_helper.hpp
+++ b/rendering_engine/debug/axes_helper.hpp
@@ -22,14 +22,14 @@
 
 #pragma once
 
-#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/line_helper.hpp>
 
 namespace rendering_engine::debug
 {
     // The three world axes drawn from the origin — the analogue of
     // @c THREE.AxesHelper. +X is red, +Y green, +Z blue. Reposition or
     // orient it through the inherited @ref transform.
-    struct axes_helper : public helper
+    struct axes_helper : public line_helper
     {
         // @p size is the length of each axis line. Geometry is baked once
         // at construction.

--- a/rendering_engine/debug/axes_helper.hpp
+++ b/rendering_engine/debug/axes_helper.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/debug/helper.hpp>
+
+namespace rendering_engine::debug
+{
+    // The three world axes drawn from the origin — the analogue of
+    // @c THREE.AxesHelper. +X is red, +Y green, +Z blue. Reposition or
+    // orient it through the inherited @ref transform.
+    struct axes_helper : public helper
+    {
+        // @p size is the length of each axis line. Geometry is baked once
+        // at construction.
+        explicit axes_helper(float size = 1.0f);
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/box_edges.hpp
+++ b/rendering_engine/debug/box_edges.hpp
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include <infrastructure/math/vec3.hpp>
+
+namespace rendering_engine::debug
+{
+    // Append the twelve edges of a hexahedron to @p positions /
+    // @p colors as independent line segments, all tinted @p color.
+    // Corners are indexed so bit 0 is the X axis, bit 1 the Y axis and
+    // bit 2 the Z axis — the layout shared by @ref box_helper (an
+    // axis-aligned box) and @ref camera_helper (the eight unprojected
+    // frustum corners), so the edge table is written once here.
+    inline void build_box_edges(const std::array<infrastructure::math::vec3, 8>& corners,
+                                const infrastructure::math::vec3& color,
+                                std::vector<infrastructure::math::vec3>& positions,
+                                std::vector<infrastructure::math::vec3>& colors)
+    {
+        static constexpr std::array<std::array<int, 2>, 12> edges{
+            {{0, 1}, {1, 3}, {3, 2}, {2, 0}, {4, 5}, {5, 7}, {7, 6}, {6, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7}}};
+
+        positions.reserve(positions.size() + edges.size() * 2);
+        colors.reserve(colors.size() + edges.size() * 2);
+        for (const auto& edge : edges)
+        {
+            positions.push_back(corners[static_cast<size_t>(edge[0])]);
+            positions.push_back(corners[static_cast<size_t>(edge[1])]);
+            colors.push_back(color);
+            colors.push_back(color);
+        }
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/box_helper.cpp
+++ b/rendering_engine/debug/box_helper.cpp
@@ -31,7 +31,7 @@
 namespace rendering_engine::debug
 {
     box_helper::box_helper(const infrastructure::math::aabb& box, util::color color)
-        : helper("Box"), m_box(box), m_color(color)
+        : line_helper("Box"), m_box(box), m_color(color)
     {
         rebuild();
     }

--- a/rendering_engine/debug/box_helper.cpp
+++ b/rendering_engine/debug/box_helper.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/box_helper.hpp>
+
+#include <array>
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/debug/box_edges.hpp>
+
+namespace rendering_engine::debug
+{
+    box_helper::box_helper(const infrastructure::math::aabb& box, util::color color)
+        : helper("Box"), m_box(box), m_color(color)
+    {
+        rebuild();
+    }
+
+    void box_helper::set_box(const infrastructure::math::aabb& box)
+    {
+        m_box = box;
+        rebuild();
+    }
+
+    void box_helper::rebuild()
+    {
+        namespace math = infrastructure::math;
+
+        // The eight corners of the box, indexed so bit 0 selects X,
+        // bit 1 selects Y and bit 2 selects Z between min and max.
+        const std::array<math::vec3, 8> corners{math::vec3{m_box.min.x, m_box.min.y, m_box.min.z},
+                                                math::vec3{m_box.max.x, m_box.min.y, m_box.min.z},
+                                                math::vec3{m_box.min.x, m_box.max.y, m_box.min.z},
+                                                math::vec3{m_box.max.x, m_box.max.y, m_box.min.z},
+                                                math::vec3{m_box.min.x, m_box.min.y, m_box.max.z},
+                                                math::vec3{m_box.max.x, m_box.min.y, m_box.max.z},
+                                                math::vec3{m_box.min.x, m_box.max.y, m_box.max.z},
+                                                math::vec3{m_box.max.x, m_box.max.y, m_box.max.z}};
+
+        std::vector<math::vec3> positions;
+        std::vector<math::vec3> colors;
+        build_box_edges(corners, to_rgb(m_color), positions, colors);
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/box_helper.hpp
+++ b/rendering_engine/debug/box_helper.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <infrastructure/math/aabb.hpp>
-#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/line_helper.hpp>
 #include <rendering_engine/util/color.hpp>
 
 namespace rendering_engine::debug
@@ -32,7 +32,7 @@ namespace rendering_engine::debug
     // @c THREE.Box3Helper. The twelve edges are baked in world space, so
     // the inherited @ref transform is left at identity; call
     // @ref set_box to follow a box that moves.
-    struct box_helper : public helper
+    struct box_helper : public line_helper
     {
         explicit box_helper(const infrastructure::math::aabb& box = infrastructure::math::aabb{},
                             util::color color = util::color{255, 255, 0, 255});

--- a/rendering_engine/debug/box_helper.hpp
+++ b/rendering_engine/debug/box_helper.hpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/aabb.hpp>
+#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine::debug
+{
+    // Wireframe of an axis-aligned bounding box — the analogue of
+    // @c THREE.Box3Helper. The twelve edges are baked in world space, so
+    // the inherited @ref transform is left at identity; call
+    // @ref set_box to follow a box that moves.
+    struct box_helper : public helper
+    {
+        explicit box_helper(const infrastructure::math::aabb& box = infrastructure::math::aabb{},
+                            util::color color = util::color{255, 255, 0, 255});
+
+        // Replace the box and rebuild the wireframe.
+        void set_box(const infrastructure::math::aabb& box);
+
+    private:
+        void rebuild();
+
+        infrastructure::math::aabb m_box;
+        util::color m_color;
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/camera_helper.cpp
+++ b/rendering_engine/debug/camera_helper.cpp
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/camera_helper.hpp>
+
+#include <array>
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/camera/camera.hpp>
+#include <rendering_engine/debug/box_edges.hpp>
+
+namespace rendering_engine::debug
+{
+    camera_helper::camera_helper(const camera* cam, util::color color) : helper("Camera"), m_camera(cam), m_color(color)
+    {
+    }
+
+    void camera_helper::refresh()
+    {
+        if (m_camera == nullptr)
+        {
+            return;
+        }
+
+        namespace math = infrastructure::math;
+
+        const math::mat4 view_projection = m_camera->get_projection_matrix() * m_camera->get_view_matrix();
+        if (m_built && view_projection == m_last_view_projection)
+        {
+            return;
+        }
+        m_last_view_projection = view_projection;
+        m_built = true;
+
+        // Unproject the eight clip-cube corners back into world space.
+        // GLM builds projections with z in [-1, 1] (the camera's frustum
+        // extraction uses the same matrix), so the near plane is z = -1
+        // and the far plane z = 1. Corners are indexed bit 0 = X,
+        // bit 1 = Y, bit 2 = Z to match build_box_edges().
+        const math::mat4 inverse_vp = math::inverse(view_projection);
+        std::array<math::vec3, 8> corners{};
+        for (int i = 0; i < 8; ++i)
+        {
+            const float x = (i & 1) != 0 ? 1.0f : -1.0f;
+            const float y = (i & 2) != 0 ? 1.0f : -1.0f;
+            const float z = (i & 4) != 0 ? 1.0f : -1.0f;
+            const math::vec4 clip = inverse_vp * math::vec4{x, y, z, 1.0f};
+            const float inv_w = clip.w != 0.0f ? 1.0f / clip.w : 1.0f;
+            corners[static_cast<size_t>(i)] = math::vec3{clip.x * inv_w, clip.y * inv_w, clip.z * inv_w};
+        }
+
+        std::vector<math::vec3> positions;
+        std::vector<math::vec3> colors;
+        build_box_edges(corners, to_rgb(m_color), positions, colors);
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/camera_helper.cpp
+++ b/rendering_engine/debug/camera_helper.cpp
@@ -31,7 +31,8 @@
 
 namespace rendering_engine::debug
 {
-    camera_helper::camera_helper(const camera* cam, util::color color) : helper("Camera"), m_camera(cam), m_color(color)
+    camera_helper::camera_helper(const camera* cam, util::color color)
+        : line_helper("Camera"), m_camera(cam), m_color(color)
     {
     }
 

--- a/rendering_engine/debug/camera_helper.hpp
+++ b/rendering_engine/debug/camera_helper.hpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine
+{
+    struct camera;
+}
+
+namespace rendering_engine::debug
+{
+    // Wireframe of a camera's view frustum — the analogue of
+    // @c THREE.CameraHelper. The eight clip-space corners are unprojected
+    // through the inverse view-projection into world space and drawn as a
+    // hexahedron, so the gizmo shows exactly what the camera sees. The
+    // geometry tracks the camera's view-projection every frame, so the
+    // helper must not outlive the camera it points at.
+    //
+    // Visualising the active camera's own frustum is degenerate (it fills
+    // the screen); this is meant for a secondary / inactive camera.
+    struct camera_helper : public helper
+    {
+        explicit camera_helper(const camera* cam, util::color color = util::color{200, 200, 80, 255});
+
+    protected:
+        void refresh() override;
+
+    private:
+        const camera* m_camera;
+        util::color m_color;
+
+        // Last view-projection the geometry was built from, so refresh()
+        // only rebuilds when the camera moves.
+        infrastructure::math::mat4 m_last_view_projection{};
+        bool m_built{false};
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/camera_helper.hpp
+++ b/rendering_engine/debug/camera_helper.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <infrastructure/math/math.hpp>
-#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/line_helper.hpp>
 #include <rendering_engine/util/color.hpp>
 
 namespace rendering_engine
@@ -42,7 +42,7 @@ namespace rendering_engine::debug
     //
     // Visualising the active camera's own frustum is degenerate (it fills
     // the screen); this is meant for a secondary / inactive camera.
-    struct camera_helper : public helper
+    struct camera_helper : public line_helper
     {
         explicit camera_helper(const camera* cam, util::color color = util::color{200, 200, 80, 255});
 

--- a/rendering_engine/debug/directional_light_helper.cpp
+++ b/rendering_engine/debug/directional_light_helper.cpp
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/directional_light_helper.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/lighting/directional_light.hpp>
+
+namespace rendering_engine::debug
+{
+    namespace
+    {
+        namespace math = infrastructure::math;
+
+        // The light radiance is unbounded (colour * intensity), so clamp
+        // each channel into the displayable [0, 1] before it becomes the
+        // gizmo tint.
+        math::vec3 clamp_color(const math::vec3& c)
+        {
+            return math::vec3{std::clamp(c.x, 0.0f, 1.0f), std::clamp(c.y, 0.0f, 1.0f), std::clamp(c.z, 0.0f, 1.0f)};
+        }
+    } // namespace
+
+    directional_light_helper::directional_light_helper(const directional_light* light, float size)
+        : helper("Directional light"), m_light(light), m_size(size)
+    {
+    }
+
+    void directional_light_helper::refresh()
+    {
+        if (m_light == nullptr)
+        {
+            return;
+        }
+
+        const math::vec3 direction = m_light->direction;
+        const math::vec3 color = m_light->color;
+        if (m_built && direction == m_last_direction && color == m_last_color)
+        {
+            return;
+        }
+        m_last_direction = direction;
+        m_last_color = color;
+        m_built = true;
+
+        const math::vec3 dir = math::normalize(direction);
+        // Build an orthonormal basis around the travel direction; pick a
+        // world up that is not parallel to it so the cross product is
+        // stable.
+        const math::vec3 world_up =
+            std::abs(dir.y) < 0.99f ? math::vec3{0.0f, 1.0f, 0.0f} : math::vec3{1.0f, 0.0f, 0.0f};
+        const math::vec3 right = math::normalize(math::cross(world_up, dir));
+        const math::vec3 up = math::normalize(math::cross(dir, right));
+
+        const math::vec3 origin{0.0f, 0.0f, 0.0f};
+        const float hs = m_size * 0.25f;
+        // Square panel facing the light direction, centred at the origin.
+        const math::vec3 c0 = origin + right * hs + up * hs;
+        const math::vec3 c1 = origin - right * hs + up * hs;
+        const math::vec3 c2 = origin - right * hs - up * hs;
+        const math::vec3 c3 = origin + right * hs - up * hs;
+
+        const math::vec3 rgb = clamp_color(color);
+        std::vector<math::vec3> positions{c0, c1, c1, c2, c2, c3, c3, c0, origin, origin + dir * m_size};
+        std::vector<math::vec3> colors(positions.size(), rgb);
+
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/directional_light_helper.cpp
+++ b/rendering_engine/debug/directional_light_helper.cpp
@@ -45,7 +45,7 @@ namespace rendering_engine::debug
     } // namespace
 
     directional_light_helper::directional_light_helper(const directional_light* light, float size)
-        : helper("Directional light"), m_light(light), m_size(size)
+        : line_helper("Directional light"), m_light(light), m_size(size)
     {
     }
 

--- a/rendering_engine/debug/directional_light_helper.hpp
+++ b/rendering_engine/debug/directional_light_helper.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/debug/helper.hpp>
+
+namespace rendering_engine
+{
+    struct directional_light;
+}
+
+namespace rendering_engine::debug
+{
+    // Gizmo for a directional light — the analogue of
+    // @c THREE.DirectionalLightHelper. Draws a small square facing the
+    // light's travel direction at the world origin plus a ray along that
+    // direction, both tinted with the light's colour. The geometry tracks
+    // the light's direction / colour every frame, so the helper must not
+    // outlive the light it points at.
+    struct directional_light_helper : public helper
+    {
+        explicit directional_light_helper(const directional_light* light, float size = 1.0f);
+
+    protected:
+        void refresh() override;
+
+    private:
+        const directional_light* m_light;
+        float m_size;
+
+        // Last state the geometry was built from, so refresh() only
+        // rebuilds when the light actually moves or changes colour.
+        infrastructure::math::vec3 m_last_direction{0.0f, 0.0f, 0.0f};
+        infrastructure::math::vec3 m_last_color{0.0f, 0.0f, 0.0f};
+        bool m_built{false};
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/grid_helper.cpp
+++ b/rendering_engine/debug/grid_helper.cpp
@@ -28,7 +28,8 @@
 
 namespace rendering_engine::debug
 {
-    grid_helper::grid_helper(float size, int divisions, util::color color, util::color center_color) : helper("Grid")
+    grid_helper::grid_helper(float size, int divisions, util::color color, util::color center_color)
+        : line_helper("Grid")
     {
         namespace math = infrastructure::math;
 
@@ -47,23 +48,25 @@ namespace rendering_engine::debug
         positions.reserve(static_cast<size_t>(divisions + 1) * 4);
         colors.reserve(static_cast<size_t>(divisions + 1) * 4);
 
-        // The middle index lands on the centre lines; flag it so both the
-        // X- and Z-aligned spans through the origin get the accent colour.
+        // The grid lies on the X/Y plane (z = 0) because the engine is
+        // Z-up. The middle index lands on the centre lines; flag it so
+        // both the X- and Y-aligned spans through the origin get the
+        // accent colour.
         const int center_index = divisions / 2;
         for (int i = 0; i <= divisions; ++i)
         {
             const float coord = -half + step * static_cast<float>(i);
             const math::vec3& rgb = (i == center_index) ? center_rgb : line_rgb;
 
-            // Span parallel to X at this Z.
-            positions.push_back(math::vec3{-half, 0.0f, coord});
-            positions.push_back(math::vec3{half, 0.0f, coord});
+            // Span parallel to X at this Y.
+            positions.push_back(math::vec3{-half, coord, 0.0f});
+            positions.push_back(math::vec3{half, coord, 0.0f});
             colors.push_back(rgb);
             colors.push_back(rgb);
 
-            // Span parallel to Z at this X.
-            positions.push_back(math::vec3{coord, 0.0f, -half});
-            positions.push_back(math::vec3{coord, 0.0f, half});
+            // Span parallel to Y at this X.
+            positions.push_back(math::vec3{coord, -half, 0.0f});
+            positions.push_back(math::vec3{coord, half, 0.0f});
             colors.push_back(rgb);
             colors.push_back(rgb);
         }

--- a/rendering_engine/debug/grid_helper.cpp
+++ b/rendering_engine/debug/grid_helper.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/grid_helper.hpp>
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+
+namespace rendering_engine::debug
+{
+    grid_helper::grid_helper(float size, int divisions, util::color color, util::color center_color) : helper("Grid")
+    {
+        namespace math = infrastructure::math;
+
+        if (divisions < 1)
+        {
+            divisions = 1;
+        }
+
+        const float half = size * 0.5f;
+        const float step = size / static_cast<float>(divisions);
+        const math::vec3 line_rgb = to_rgb(color);
+        const math::vec3 center_rgb = to_rgb(center_color);
+
+        std::vector<math::vec3> positions;
+        std::vector<math::vec3> colors;
+        positions.reserve(static_cast<size_t>(divisions + 1) * 4);
+        colors.reserve(static_cast<size_t>(divisions + 1) * 4);
+
+        // The middle index lands on the centre lines; flag it so both the
+        // X- and Z-aligned spans through the origin get the accent colour.
+        const int center_index = divisions / 2;
+        for (int i = 0; i <= divisions; ++i)
+        {
+            const float coord = -half + step * static_cast<float>(i);
+            const math::vec3& rgb = (i == center_index) ? center_rgb : line_rgb;
+
+            // Span parallel to X at this Z.
+            positions.push_back(math::vec3{-half, 0.0f, coord});
+            positions.push_back(math::vec3{half, 0.0f, coord});
+            colors.push_back(rgb);
+            colors.push_back(rgb);
+
+            // Span parallel to Z at this X.
+            positions.push_back(math::vec3{coord, 0.0f, -half});
+            positions.push_back(math::vec3{coord, 0.0f, half});
+            colors.push_back(rgb);
+            colors.push_back(rgb);
+        }
+
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/grid_helper.hpp
+++ b/rendering_engine/debug/grid_helper.hpp
@@ -22,16 +22,18 @@
 
 #pragma once
 
-#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/line_helper.hpp>
 #include <rendering_engine/util/color.hpp>
 
 namespace rendering_engine::debug
 {
-    // A square reference grid on the X/Z plane centred at the origin —
-    // the analogue of @c THREE.GridHelper. The line through the centre on
-    // each axis is drawn in @p center_color so the origin reads at a
-    // glance; the remaining lines use @p color.
-    struct grid_helper : public helper
+    // A finite square reference grid on the X/Y ground plane (the engine
+    // is Z-up) centred at the origin — a bounded line-based analogue of
+    // @c THREE.GridHelper. The line through the centre on each axis is
+    // drawn in @p center_color so the origin reads at a glance; the
+    // remaining lines use @p color. For an unbounded grid that integrates
+    // with the scene depth, see @ref infinite_grid.
+    struct grid_helper : public line_helper
     {
         // @p size is the full edge length of the grid, @p divisions the
         // number of cells per side. Geometry is baked once at

--- a/rendering_engine/debug/grid_helper.hpp
+++ b/rendering_engine/debug/grid_helper.hpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine::debug
+{
+    // A square reference grid on the X/Z plane centred at the origin —
+    // the analogue of @c THREE.GridHelper. The line through the centre on
+    // each axis is drawn in @p center_color so the origin reads at a
+    // glance; the remaining lines use @p color.
+    struct grid_helper : public helper
+    {
+        // @p size is the full edge length of the grid, @p divisions the
+        // number of cells per side. Geometry is baked once at
+        // construction.
+        explicit grid_helper(float size = 10.0f,
+                             int divisions = 10,
+                             util::color color = util::color{120, 120, 120, 255},
+                             util::color center_color = util::color{70, 70, 70, 255});
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/helper.cpp
+++ b/rendering_engine/debug/helper.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 
 #include <control/engine.hpp>
-#include <rendering_engine/materials/line_material.hpp>
 #include <rendering_engine/rendering_engine.hpp>
 
 namespace rendering_engine::debug
@@ -43,19 +42,32 @@ namespace rendering_engine::debug
         }
     } // namespace
 
-    helper::helper(const char* name)
-        : m_name(name), m_line(&control::current_engine().renderer->get_debug_line_material())
+    helper::helper(const char* name, helper_layer layer) : m_name(name), m_layer(layer)
     {
-        // Every gizmo is a list of independent segments (vertex pairs).
-        m_line.set_mode(line_mode::segments);
-
         helper_registry().push_back(this);
-        control::current_engine().renderer->register_debug_renderable(this);
+
+        auto& renderer = *control::current_engine().renderer;
+        if (m_layer == helper_layer::scene)
+        {
+            renderer.register_scene_renderable(this);
+        }
+        else
+        {
+            renderer.register_debug_renderable(this);
+        }
     }
 
     helper::~helper()
     {
-        control::current_engine().renderer->unregister_debug_renderable(this);
+        auto& renderer = *control::current_engine().renderer;
+        if (m_layer == helper_layer::scene)
+        {
+            renderer.unregister_scene_renderable(this);
+        }
+        else
+        {
+            renderer.unregister_debug_renderable(this);
+        }
 
         auto& helpers = helper_registry();
         helpers.erase(std::remove(helpers.begin(), helpers.end(), this), helpers.end());
@@ -66,41 +78,10 @@ namespace rendering_engine::debug
         return m_name;
     }
 
-    void helper::upload()
-    {
-        // Geometry is uploaded eagerly in set_segments(); nothing to do
-        // when the pass requests an upload.
-    }
-
-    void helper::set_segments(const std::vector<infrastructure::math::vec3>& positions,
-                              const std::vector<infrastructure::math::vec3>& colors)
-    {
-        m_line.set_positions(positions, colors);
-        m_line.upload();
-    }
-
-    void helper::refresh() {}
-
     infrastructure::math::vec3 helper::to_rgb(const util::color& c)
     {
         return infrastructure::math::vec3{
             static_cast<float>(c.r) / 255.0f, static_cast<float>(c.g) / 255.0f, static_cast<float>(c.b) / 255.0f};
-    }
-
-    void helper::collect_draw_items(std::vector<draw_item>& out)
-    {
-        if (!visible)
-        {
-            return;
-        }
-
-        // Let dynamic gizmos follow their target before they draw.
-        refresh();
-
-        // Place the (mostly origin-baked) geometry; dynamic helpers leave
-        // the transform at identity and bake world-space vertices.
-        m_line.transform = transform;
-        m_line.collect_draw_items(out);
     }
 
     const std::vector<helper*>& registered_helpers()

--- a/rendering_engine/debug/helper.cpp
+++ b/rendering_engine/debug/helper.cpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/helper.hpp>
+
+#include <algorithm>
+
+#include <control/engine.hpp>
+#include <rendering_engine/materials/line_material.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+
+namespace rendering_engine::debug
+{
+    namespace
+    {
+        // Process-wide list of live helpers, in construction order. Holds
+        // non-owning back-pointers; the debug UI walks it to toggle each
+        // gizmo. Function-local so it is constructed on first use,
+        // mirroring registered_lights().
+        std::vector<helper*>& helper_registry()
+        {
+            static std::vector<helper*> helpers;
+            return helpers;
+        }
+    } // namespace
+
+    helper::helper(const char* name)
+        : m_name(name), m_line(&control::current_engine().renderer->get_debug_line_material())
+    {
+        // Every gizmo is a list of independent segments (vertex pairs).
+        m_line.set_mode(line_mode::segments);
+
+        helper_registry().push_back(this);
+        control::current_engine().renderer->register_debug_renderable(this);
+    }
+
+    helper::~helper()
+    {
+        control::current_engine().renderer->unregister_debug_renderable(this);
+
+        auto& helpers = helper_registry();
+        helpers.erase(std::remove(helpers.begin(), helpers.end(), this), helpers.end());
+    }
+
+    const char* helper::name() const noexcept
+    {
+        return m_name;
+    }
+
+    void helper::upload()
+    {
+        // Geometry is uploaded eagerly in set_segments(); nothing to do
+        // when the pass requests an upload.
+    }
+
+    void helper::set_segments(const std::vector<infrastructure::math::vec3>& positions,
+                              const std::vector<infrastructure::math::vec3>& colors)
+    {
+        m_line.set_positions(positions, colors);
+        m_line.upload();
+    }
+
+    void helper::refresh() {}
+
+    infrastructure::math::vec3 helper::to_rgb(const util::color& c)
+    {
+        return infrastructure::math::vec3{
+            static_cast<float>(c.r) / 255.0f, static_cast<float>(c.g) / 255.0f, static_cast<float>(c.b) / 255.0f};
+    }
+
+    void helper::collect_draw_items(std::vector<draw_item>& out)
+    {
+        if (!visible)
+        {
+            return;
+        }
+
+        // Let dynamic gizmos follow their target before they draw.
+        refresh();
+
+        // Place the (mostly origin-baked) geometry; dynamic helpers leave
+        // the transform at identity and bake world-space vertices.
+        m_line.transform = transform;
+        m_line.collect_draw_items(out);
+    }
+
+    const std::vector<helper*>& registered_helpers()
+    {
+        return helper_registry();
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/helper.hpp
+++ b/rendering_engine/debug/helper.hpp
@@ -25,30 +25,40 @@
 #include <vector>
 
 #include <infrastructure/math/math.hpp>
-#include <rendering_engine/renderables/line.hpp>
 #include <rendering_engine/renderables/renderable.hpp>
 #include <rendering_engine/util/color.hpp>
-#include <rendering_engine/util/transform.hpp>
 
 namespace rendering_engine::debug
 {
+    // Which pass a helper draws in.
+    enum class helper_layer
+    {
+        // The depth-less debug-overlay pass: always-on-top gizmos that
+        // never get occluded (axes, light/camera/box wireframes). Drawn
+        // only in debug builds.
+        overlay,
+
+        // The 3D scene pass: depth-tested geometry that integrates with
+        // the scene and is occluded by it (the infinite ground grid).
+        scene,
+    };
+
     // Base for the debug gizmo family — the analogue of Three.js's
-    // @c *Helper objects (grid, axes, bounding box, light, camera
-    // frustum). A helper owns a single @ref line renderable drawn as
-    // independent segments through the shared @ref line_material, and on
-    // construction registers itself twice: into the engine's
-    // debug-renderable registry (so the debug pass draws it — debug
-    // builds only) and into the process-wide helper registry the debug UI
-    // walks to toggle visibility. Simply keeping a helper alive is enough
-    // for it to draw; destroying it unregisters from both.
+    // @c *Helper objects. A helper carries a display name and a
+    // visibility flag, and on construction registers itself twice: into
+    // the process-wide helper registry the debug UI walks to toggle
+    // visibility, and into one of the engine's renderable registries
+    // (chosen by @ref helper_layer) so the matching pass draws it.
+    // Destroying it unregisters from both.
     //
-    // Like the rest of the debug-overlay machinery the type is always
-    // compiled, but its draws are inert in release: the debug pass is
-    // dropped from the pass list there, so a registered helper is never
-    // collected.
+    // The geometry itself lives in the subclasses: @ref line_helper for
+    // the line-based overlay gizmos, @ref infinite_grid for the
+    // shader-driven ground grid. Like the rest of the debug-overlay
+    // machinery the types are always compiled, but the overlay layer is
+    // inert in release where the debug pass is dropped.
     struct helper : public renderable
     {
-        explicit helper(const char* name);
+        helper(const char* name, helper_layer layer);
         ~helper() override;
 
         helper(const helper&) = delete;
@@ -61,39 +71,14 @@ namespace rendering_engine::debug
         // debug UI flips this per helper; defaults to visible.
         bool visible{true};
 
-        // World placement of the gizmo. The grid and axes helpers leave
-        // this at identity and bake their geometry around the origin; the
-        // dynamic helpers (box, light, camera) bake world-space geometry
-        // directly and ignore it.
-        util::transform transform;
-
-        void upload() final;
-        void collect_draw_items(std::vector<draw_item>& out) final;
-
     protected:
-        // Replace the gizmo geometry with @p positions interpreted as
-        // independent line segments (vertex pairs) and upload it. The two
-        // vectors must be the same length; concrete helpers call this when
-        // their geometry changes.
-        void set_segments(const std::vector<infrastructure::math::vec3>& positions,
-                          const std::vector<infrastructure::math::vec3>& colors);
-
-        // Rebuild geometry from the helper's target before drawing.
-        // Static helpers (grid, axes) build once in their constructor and
-        // leave this a no-op; helpers that follow a moving target (light,
-        // camera) override it to refresh when the target changes. Invoked
-        // from @ref collect_draw_items.
-        virtual void refresh();
-
         // Linear-RGB triple in [0, 1] from a 0..255 @ref util::color,
-        // ignoring alpha. The debug pass writes straight to the LDR
-        // backbuffer (after tonemapping), so the value lands on screen
-        // unmodified.
+        // ignoring alpha.
         static infrastructure::math::vec3 to_rgb(const util::color& c);
 
     private:
         const char* m_name;
-        line m_line;
+        helper_layer m_layer;
     };
 
     // The helpers alive right now, in construction order. Owned by the

--- a/rendering_engine/debug/helper.hpp
+++ b/rendering_engine/debug/helper.hpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/renderables/line.hpp>
+#include <rendering_engine/renderables/renderable.hpp>
+#include <rendering_engine/util/color.hpp>
+#include <rendering_engine/util/transform.hpp>
+
+namespace rendering_engine::debug
+{
+    // Base for the debug gizmo family — the analogue of Three.js's
+    // @c *Helper objects (grid, axes, bounding box, light, camera
+    // frustum). A helper owns a single @ref line renderable drawn as
+    // independent segments through the shared @ref line_material, and on
+    // construction registers itself twice: into the engine's
+    // debug-renderable registry (so the debug pass draws it — debug
+    // builds only) and into the process-wide helper registry the debug UI
+    // walks to toggle visibility. Simply keeping a helper alive is enough
+    // for it to draw; destroying it unregisters from both.
+    //
+    // Like the rest of the debug-overlay machinery the type is always
+    // compiled, but its draws are inert in release: the debug pass is
+    // dropped from the pass list there, so a registered helper is never
+    // collected.
+    struct helper : public renderable
+    {
+        explicit helper(const char* name);
+        ~helper() override;
+
+        helper(const helper&) = delete;
+        helper& operator=(const helper&) = delete;
+
+        // Human-readable label shown in the debug UI helper panel.
+        const char* name() const noexcept;
+
+        // When false the helper contributes no draws this frame. The
+        // debug UI flips this per helper; defaults to visible.
+        bool visible{true};
+
+        // World placement of the gizmo. The grid and axes helpers leave
+        // this at identity and bake their geometry around the origin; the
+        // dynamic helpers (box, light, camera) bake world-space geometry
+        // directly and ignore it.
+        util::transform transform;
+
+        void upload() final;
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+    protected:
+        // Replace the gizmo geometry with @p positions interpreted as
+        // independent line segments (vertex pairs) and upload it. The two
+        // vectors must be the same length; concrete helpers call this when
+        // their geometry changes.
+        void set_segments(const std::vector<infrastructure::math::vec3>& positions,
+                          const std::vector<infrastructure::math::vec3>& colors);
+
+        // Rebuild geometry from the helper's target before drawing.
+        // Static helpers (grid, axes) build once in their constructor and
+        // leave this a no-op; helpers that follow a moving target (light,
+        // camera) override it to refresh when the target changes. Invoked
+        // from @ref collect_draw_items.
+        virtual void refresh();
+
+        // Linear-RGB triple in [0, 1] from a 0..255 @ref util::color,
+        // ignoring alpha. The debug pass writes straight to the LDR
+        // backbuffer (after tonemapping), so the value lands on screen
+        // unmodified.
+        static infrastructure::math::vec3 to_rgb(const util::color& c);
+
+    private:
+        const char* m_name;
+        line m_line;
+    };
+
+    // The helpers alive right now, in construction order. Owned by the
+    // helpers themselves (the vector holds non-owning back-pointers); the
+    // debug UI walks it to list every gizmo and toggle its visibility.
+    const std::vector<helper*>& registered_helpers();
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/infinite_grid.cpp
+++ b/rendering_engine/debug/infinite_grid.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/infinite_grid.hpp>
+
+#include <array>
+#include <cstdint>
+
+#include <control/engine.hpp>
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/materials/grid_material.hpp>
+#include <rendering_engine/renderables/draw_item.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+
+namespace rendering_engine::debug
+{
+    infinite_grid::infinite_grid(float /*fade_distance*/)
+        : helper("Grid (infinite)", helper_layer::scene),
+          m_material(&control::current_engine().renderer->get_grid_material())
+    {
+        upload();
+    }
+
+    infinite_grid::~infinite_grid()
+    {
+        auto& gpu = *control::current_engine().gpu;
+        if (m_draw_bind_group.valid())
+        {
+            gpu.destroy(m_draw_bind_group);
+            m_draw_bind_group = {};
+        }
+        if (m_draw_ubo.valid())
+        {
+            gpu.destroy(m_draw_ubo);
+            m_draw_ubo = {};
+        }
+        if (m_vertex_buffer.valid())
+        {
+            gpu.destroy(m_vertex_buffer);
+            m_vertex_buffer = {};
+        }
+    }
+
+    void infinite_grid::upload()
+    {
+        auto& gpu = *control::current_engine().gpu;
+
+        // A single fullscreen triangle in clip space; the grid material's
+        // vertex shader unprojects these corners to reconstruct the view
+        // rays, so no transform is applied to the positions themselves.
+        const std::array<infrastructure::math::vec3, 3> vertices{infrastructure::math::vec3{-1.0f, -1.0f, 0.0f},
+                                                                 infrastructure::math::vec3{3.0f, -1.0f, 0.0f},
+                                                                 infrastructure::math::vec3{-1.0f, 3.0f, 0.0f}};
+
+        gpu::buffer_descriptor vertex_descriptor{};
+        vertex_descriptor.size = vertices.size() * sizeof(infrastructure::math::vec3);
+        vertex_descriptor.usage = gpu::buffer_usage_vertex;
+        vertex_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        vertex_descriptor.initial_data = vertices.data();
+        m_vertex_buffer = gpu.create_buffer(vertex_descriptor);
+
+        // Per-draw model matrix (identity for the origin grid); the
+        // shader references it when reconstructing depth.
+        const auto model = infrastructure::math::mat4{};
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = sizeof(infrastructure::math::mat4);
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        ubo_descriptor.initial_data = model.data();
+        m_draw_ubo = gpu.create_buffer(ubo_descriptor);
+
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_material->per_draw_layout();
+        gpu::binding_value model_slot{};
+        model_slot.binding = 1;
+        model_slot.kind = gpu::binding_kind::uniform_buffer;
+        model_slot.buffer_value = m_draw_ubo;
+        bg_descriptor.entries.push_back(model_slot);
+        m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
+    }
+
+    void infinite_grid::collect_draw_items(std::vector<draw_item>& out)
+    {
+        if (!visible || m_material == nullptr || !m_vertex_buffer.valid())
+        {
+            return;
+        }
+
+        draw_item item{};
+        item.mat = m_material;
+        item.vertex_buffer = m_vertex_buffer;
+        item.per_draw_bind_group = m_draw_bind_group;
+        item.vertex_stride = sizeof(infrastructure::math::vec3);
+        item.vertex_count = 3;
+        out.push_back(item);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/infinite_grid.hpp
+++ b/rendering_engine/debug/infinite_grid.hpp
@@ -22,37 +22,41 @@
 
 #pragma once
 
-#include <infrastructure/math/math.hpp>
-#include <rendering_engine/debug/line_helper.hpp>
+#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/gpu/handle.hpp>
 
 namespace rendering_engine
 {
-    struct directional_light;
+    struct grid_material;
 }
 
 namespace rendering_engine::debug
 {
-    // Gizmo for a directional light — the analogue of
-    // @c THREE.DirectionalLightHelper. Draws a small square facing the
-    // light's travel direction at the world origin plus a ray along that
-    // direction, both tinted with the light's colour. The geometry tracks
-    // the light's direction / colour every frame, so the helper must not
-    // outlive the light it points at.
-    struct directional_light_helper : public line_helper
+    // The CAD-style infinite ground grid — an unbounded analogue of
+    // @c THREE.GridHelper. Unlike the line-based @ref grid_helper it is a
+    // scene-pass renderable: a single fullscreen triangle fronts the
+    // analytic @ref grid_material, whose fragment shader reconstructs the
+    // ground plane (z = 0, the engine is Z-up), draws minor / major lines
+    // plus the coloured world axes, fades with distance and depth-tests
+    // against the scene, so it stretches to the horizon and is occluded by
+    // scene geometry.
+    //
+    // Created as a built-in gizmo in debug builds and toggled from the
+    // debug UI like the other helpers.
+    struct infinite_grid : public helper
     {
-        explicit directional_light_helper(const directional_light* light, float size = 1.0f);
+        // @p fade_distance is the world-space radius past which the grid
+        // has fully faded.
+        explicit infinite_grid(float fade_distance = 100.0f);
+        ~infinite_grid() override;
 
-    protected:
-        void refresh() override;
+        void upload() final;
+        void collect_draw_items(std::vector<draw_item>& out) final;
 
     private:
-        const directional_light* m_light;
-        float m_size;
-
-        // Last state the geometry was built from, so refresh() only
-        // rebuilds when the light actually moves or changes colour.
-        infrastructure::math::vec3 m_last_direction{0.0f, 0.0f, 0.0f};
-        infrastructure::math::vec3 m_last_color{0.0f, 0.0f, 0.0f};
-        bool m_built{false};
+        grid_material* m_material{nullptr};
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_draw_ubo{};
+        gpu::bind_group m_draw_bind_group{};
     };
 } // namespace rendering_engine::debug

--- a/rendering_engine/debug/line_helper.cpp
+++ b/rendering_engine/debug/line_helper.cpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/line_helper.hpp>
+
+#include <control/engine.hpp>
+#include <rendering_engine/materials/line_material.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+
+namespace rendering_engine::debug
+{
+    line_helper::line_helper(const char* name)
+        : helper(name, helper_layer::overlay), m_line(&control::current_engine().renderer->get_debug_line_material())
+    {
+        // Every gizmo is a list of independent segments (vertex pairs).
+        m_line.set_mode(line_mode::segments);
+    }
+
+    line_helper::~line_helper() = default;
+
+    void line_helper::upload()
+    {
+        // Geometry is uploaded eagerly in set_segments(); nothing to do
+        // when the pass requests an upload.
+    }
+
+    void line_helper::set_segments(const std::vector<infrastructure::math::vec3>& positions,
+                                   const std::vector<infrastructure::math::vec3>& colors)
+    {
+        m_line.set_positions(positions, colors);
+        m_line.upload();
+    }
+
+    void line_helper::refresh() {}
+
+    void line_helper::collect_draw_items(std::vector<draw_item>& out)
+    {
+        if (!visible)
+        {
+            return;
+        }
+
+        // Let dynamic gizmos follow their target before they draw.
+        refresh();
+
+        // Place the (mostly origin-baked) geometry; helpers that bake
+        // world-space vertices leave the transform at identity.
+        m_line.transform = transform;
+        m_line.collect_draw_items(out);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/line_helper.hpp
+++ b/rendering_engine/debug/line_helper.hpp
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/renderables/line.hpp>
+#include <rendering_engine/util/transform.hpp>
+
+namespace rendering_engine::debug
+{
+    // A helper whose geometry is a list of independent line segments
+    // (vertex pairs) drawn through the shared depth-disabled debug line
+    // material, in the always-on-top overlay pass. The line-based gizmos
+    // (axes, bounding box, light and camera wireframes) derive from this;
+    // they fill geometry via @ref set_segments and optionally follow a
+    // moving target via @ref refresh.
+    struct line_helper : public helper
+    {
+        explicit line_helper(const char* name);
+        ~line_helper() override;
+
+        // World placement of the gizmo. Helpers that bake their geometry
+        // around the origin (axes) use it; helpers that bake world-space
+        // geometry directly (box, light, camera) leave it at identity.
+        util::transform transform;
+
+        void upload() final;
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+    protected:
+        // Replace the gizmo geometry with @p positions interpreted as
+        // independent line segments (vertex pairs) and upload it. The two
+        // vectors must be the same length.
+        void set_segments(const std::vector<infrastructure::math::vec3>& positions,
+                          const std::vector<infrastructure::math::vec3>& colors);
+
+        // Rebuild geometry from the helper's target before drawing.
+        // Static helpers (axes) build once in their constructor and leave
+        // this a no-op; helpers that follow a moving target (light,
+        // camera) override it. Invoked from @ref collect_draw_items.
+        virtual void refresh();
+
+    private:
+        line m_line;
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/point_light_helper.cpp
+++ b/rendering_engine/debug/point_light_helper.cpp
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/debug/point_light_helper.hpp>
+
+#include <algorithm>
+#include <array>
+#include <vector>
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/lighting/point_light.hpp>
+
+namespace rendering_engine::debug
+{
+    namespace
+    {
+        namespace math = infrastructure::math;
+
+        math::vec3 clamp_color(const math::vec3& c)
+        {
+            return math::vec3{std::clamp(c.x, 0.0f, 1.0f), std::clamp(c.y, 0.0f, 1.0f), std::clamp(c.z, 0.0f, 1.0f)};
+        }
+    } // namespace
+
+    point_light_helper::point_light_helper(const point_light* light, float size)
+        : helper("Point light"), m_light(light), m_size(size)
+    {
+    }
+
+    void point_light_helper::refresh()
+    {
+        if (m_light == nullptr)
+        {
+            return;
+        }
+
+        const math::vec3 position = m_light->position;
+        const math::vec3 color = m_light->color;
+        if (m_built && position == m_last_position && color == m_last_color)
+        {
+            return;
+        }
+        m_last_position = position;
+        m_last_color = color;
+        m_built = true;
+
+        const float r = m_size;
+        // Octahedron: a +Y / -Y apex pair over a four-vertex equator ring
+        // in the X/Z plane, all offset to the light position.
+        const math::vec3 top = position + math::vec3{0.0f, r, 0.0f};
+        const math::vec3 bottom = position - math::vec3{0.0f, r, 0.0f};
+        const std::array<math::vec3, 4> ring{position + math::vec3{r, 0.0f, 0.0f},
+                                             position + math::vec3{0.0f, 0.0f, r},
+                                             position - math::vec3{r, 0.0f, 0.0f},
+                                             position - math::vec3{0.0f, 0.0f, r}};
+
+        std::vector<math::vec3> positions;
+        positions.reserve(24);
+        for (size_t i = 0; i < ring.size(); ++i)
+        {
+            const math::vec3& a = ring[i];
+            const math::vec3& b = ring[(i + 1) % ring.size()];
+            // Equator edge plus the two edges up to the apexes.
+            positions.push_back(a);
+            positions.push_back(b);
+            positions.push_back(a);
+            positions.push_back(top);
+            positions.push_back(a);
+            positions.push_back(bottom);
+        }
+
+        const math::vec3 rgb = clamp_color(color);
+        std::vector<math::vec3> colors(positions.size(), rgb);
+        set_segments(positions, colors);
+    }
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/point_light_helper.cpp
+++ b/rendering_engine/debug/point_light_helper.cpp
@@ -42,7 +42,7 @@ namespace rendering_engine::debug
     } // namespace
 
     point_light_helper::point_light_helper(const point_light* light, float size)
-        : helper("Point light"), m_light(light), m_size(size)
+        : line_helper("Point light"), m_light(light), m_size(size)
     {
     }
 

--- a/rendering_engine/debug/point_light_helper.hpp
+++ b/rendering_engine/debug/point_light_helper.hpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <infrastructure/math/math.hpp>
+#include <rendering_engine/debug/helper.hpp>
+
+namespace rendering_engine
+{
+    struct point_light;
+}
+
+namespace rendering_engine::debug
+{
+    // Gizmo for a point light — the analogue of @c THREE.PointLightHelper.
+    // Draws a small octahedron wireframe at the light's world position,
+    // tinted with the light's colour. The geometry tracks the light's
+    // position / colour every frame, so the helper must not outlive the
+    // light it points at.
+    struct point_light_helper : public helper
+    {
+        explicit point_light_helper(const point_light* light, float size = 0.25f);
+
+    protected:
+        void refresh() override;
+
+    private:
+        const point_light* m_light;
+        float m_size;
+
+        // Last state the geometry was built from, so refresh() only
+        // rebuilds when the light actually moves or changes colour.
+        infrastructure::math::vec3 m_last_position{0.0f, 0.0f, 0.0f};
+        infrastructure::math::vec3 m_last_color{0.0f, 0.0f, 0.0f};
+        bool m_built{false};
+    };
+} // namespace rendering_engine::debug

--- a/rendering_engine/debug/point_light_helper.hpp
+++ b/rendering_engine/debug/point_light_helper.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <infrastructure/math/math.hpp>
-#include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/line_helper.hpp>
 
 namespace rendering_engine
 {
@@ -37,7 +37,7 @@ namespace rendering_engine::debug
     // tinted with the light's colour. The geometry tracks the light's
     // position / colour every frame, so the helper must not outlive the
     // light it points at.
-    struct point_light_helper : public helper
+    struct point_light_helper : public line_helper
     {
         explicit point_light_helper(const point_light* light, float size = 0.25f);
 

--- a/rendering_engine/debug_ui/imgui_layer.cpp
+++ b/rendering_engine/debug_ui/imgui_layer.cpp
@@ -41,6 +41,7 @@
 #include <infrastructure/log.hpp>
 #include <infrastructure/settings.hpp>
 #include <infrastructure/time.hpp>
+#include <rendering_engine/debug/helper.hpp>
 #include <rendering_engine/gpu/backend/vulkan/vk_device.hpp>
 #include <rendering_engine/gpu/backend/vulkan/vk_resources.hpp>
 #include <rendering_engine/gpu/command_encoder.hpp>
@@ -74,6 +75,7 @@ namespace rendering_engine::debug_ui
         bool g_show_settings = true;
         bool g_show_profiler = true;
         bool g_show_demo = false;
+        bool g_show_helpers = true;
 
         // Rolling frame-time history (milliseconds) for the profiler
         // graph, used as a ring buffer.
@@ -144,6 +146,7 @@ namespace rendering_engine::debug_ui
                 {
                     ImGui::MenuItem("Profiler", nullptr, &g_show_profiler);
                     ImGui::MenuItem("Settings", nullptr, &g_show_settings);
+                    ImGui::MenuItem("Helpers", nullptr, &g_show_helpers);
                     ImGui::MenuItem("ImGui demo", nullptr, &g_show_demo);
                     ImGui::EndPopup();
                 }
@@ -231,6 +234,59 @@ namespace rendering_engine::debug_ui
             ImGui::End();
         }
 
+        // Lists every live debug gizmo (the THREE.*Helper analogues) with
+        // a checkbox bound to its visibility, plus master show / hide
+        // shortcuts. The helper registry is shared with the renderer, so
+        // the toggles take effect on the next debug-pass draw.
+        void draw_helpers_window()
+        {
+            if (!g_show_helpers)
+            {
+                return;
+            }
+
+            const auto& helpers = rendering_engine::debug::registered_helpers();
+
+            ImGui::SetNextWindowSize(ImVec2{260.0f, 0.0f}, ImGuiCond_FirstUseEver);
+            if (ImGui::Begin("Helpers", &g_show_helpers))
+            {
+                if (helpers.empty())
+                {
+                    ImGui::TextDisabled("no debug helpers registered");
+                }
+                else
+                {
+                    if (ImGui::SmallButton("Show all"))
+                    {
+                        for (auto* gizmo : helpers)
+                        {
+                            gizmo->visible = true;
+                        }
+                    }
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("Hide all"))
+                    {
+                        for (auto* gizmo : helpers)
+                        {
+                            gizmo->visible = false;
+                        }
+                    }
+                    ImGui::Separator();
+
+                    // Disambiguate the checkbox ids by index so two
+                    // helpers sharing a name still toggle independently.
+                    int index = 0;
+                    for (auto* gizmo : helpers)
+                    {
+                        ImGui::PushID(index++);
+                        ImGui::Checkbox(gizmo->name(), &gizmo->visible);
+                        ImGui::PopID();
+                    }
+                }
+            }
+            ImGui::End();
+        }
+
         void build_panels()
         {
             // Push this frame's time into the rolling history first so the
@@ -242,6 +298,7 @@ namespace rendering_engine::debug_ui
             draw_fps_overlay();
             draw_profiler_window();
             draw_settings_window();
+            draw_helpers_window();
             if (g_show_demo)
             {
                 ImGui::ShowDemoWindow(&g_show_demo);

--- a/rendering_engine/materials/CMakeLists.txt
+++ b/rendering_engine/materials/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(AlphaEngine PRIVATE
     basic_material.cpp
     basic_material.hpp
+    grid_material.cpp
+    grid_material.hpp
     line_material.cpp
     line_material.hpp
     material.cpp

--- a/rendering_engine/materials/grid_material.cpp
+++ b/rendering_engine/materials/grid_material.cpp
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/materials/grid_material.hpp>
+
+#include <string>
+
+#include <rendering_engine/gpu/types.hpp>
+
+namespace
+{
+    constexpr uint32_t draw_model_binding = 1;
+
+    // Fullscreen triangle: the vertex positions arrive already in clip
+    // space (xy in {-1, 3}), so the vertex stage only has to unproject
+    // the near / far plane points back into world space for the fragment
+    // ray-march. binding 0 (camera) lives in the scene per-frame set, the
+    // per-draw model matrix at binding 1 places the ground plane.
+    const std::string vertex_shader = R"vs(
+        #version 450
+
+        layout(location = 0) in vec3 position;
+
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+        } u_frame;
+
+        layout(set = 1, binding = 1, std140) uniform PerDraw
+        {
+            mat4 modelMatrix;
+        } u_draw;
+
+        layout(location = 0) out vec3 nearPoint;
+        layout(location = 1) out vec3 farPoint;
+        layout(location = 2) out vec3 cameraPoint;
+
+        vec3 unproject(vec2 ndc, float z, mat4 inverseViewProj)
+        {
+            vec4 world = inverseViewProj * vec4(ndc, z, 1.0);
+            return world.xyz / world.w;
+        }
+
+        void main()
+        {
+            mat4 viewProj = u_frame.projectionMatrix * u_frame.viewMatrix;
+            mat4 inverseViewProj = inverse(viewProj);
+
+            vec2 ndc = position.xy;
+            // GL-convention clip space: near plane at z = -1, far at z = 1.
+            nearPoint = unproject(ndc, -1.0, inverseViewProj);
+            farPoint = unproject(ndc, 1.0, inverseViewProj);
+            cameraPoint = inverse(u_frame.viewMatrix)[3].xyz;
+
+            gl_Position = vec4(ndc, 0.0, 1.0);
+        }
+)vs";
+
+    // The fragment shader does the real work: intersect the per-pixel
+    // view ray with the z = 0 ground plane, draw two grid scales plus the
+    // X/Y world axes with derivative-based anti-aliasing, fade with
+    // distance, and write the reconstructed depth so the scene occludes
+    // the grid. @c {{FADE}} is substituted with the fade radius.
+    const std::string fragment_shader_template = R"fs(
+        #version 450
+
+        layout(location = 0) in vec3 nearPoint;
+        layout(location = 1) in vec3 farPoint;
+        layout(location = 2) in vec3 cameraPoint;
+
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+        } u_frame;
+
+        layout(set = 1, binding = 1, std140) uniform PerDraw
+        {
+            mat4 modelMatrix;
+        } u_draw;
+
+        layout(location = 0) out vec4 fragColor;
+
+        // Coverage of the nearest grid line at the given spacing, with
+        // screen-space-derivative anti-aliasing. 1.0 on a line, 0.0 in a
+        // cell.
+        float gridCoverage(vec2 p, float spacing)
+        {
+            vec2 coord = p / spacing;
+            vec2 derivative = fwidth(coord);
+            vec2 distance = abs(fract(coord - 0.5) - 0.5) / max(derivative, vec2(1e-8));
+            float line = min(distance.x, distance.y);
+            return 1.0 - min(line, 1.0);
+        }
+
+        void main()
+        {
+            vec3 rayDirection = farPoint - nearPoint;
+
+            // Intersect the ray with the Z-up ground plane (z = 0). t
+            // outside (0, 1) means the plane is behind the camera or past
+            // the far plane, so there is nothing to draw.
+            float t = -nearPoint.z / rayDirection.z;
+            if (t <= 0.0 || t >= 1.0)
+            {
+                discard;
+            }
+
+            vec3 world = nearPoint + t * rayDirection;
+
+            // Reconstructed depth (references the per-draw model matrix so
+            // the binding stays live; identity for the origin grid). Map
+            // the GL-convention clip z in [-1, 1] to the [0, 1] window
+            // depth range used by both backends.
+            vec4 clip = u_frame.projectionMatrix * u_frame.viewMatrix * u_draw.modelMatrix * vec4(world, 1.0);
+            gl_FragDepth = 0.5 * (clip.z / clip.w) + 0.5;
+
+            vec2 plane = world.xy;
+            float minor = gridCoverage(plane, 1.0);
+            float major = gridCoverage(plane, 10.0);
+
+            vec3 minorColor = vec3(0.32);
+            vec3 majorColor = vec3(0.55);
+            vec3 color = mix(minorColor, majorColor, major);
+            float alpha = max(minor * 0.55, major);
+
+            // Coloured world axes: the Y axis (x = 0) green, the X axis
+            // (y = 0) red, each one derivative-width wide.
+            vec2 axisWidth = fwidth(plane);
+            if (abs(world.x) < axisWidth.x)
+            {
+                color = vec3(0.25, 0.85, 0.35);
+                alpha = max(alpha, 1.0);
+            }
+            if (abs(world.y) < axisWidth.y)
+            {
+                color = vec3(0.9, 0.3, 0.35);
+                alpha = max(alpha, 1.0);
+            }
+
+            // Fade out with distance from the camera so the grid dissolves
+            // into the horizon rather than aliasing into a solid mass.
+            float fade = 1.0 - clamp(length(world - cameraPoint) / {{FADE}}, 0.0, 1.0);
+            alpha *= fade * fade;
+
+            if (alpha <= 0.001)
+            {
+                discard;
+            }
+            fragColor = vec4(color, alpha);
+        }
+)fs";
+
+    std::string build_fragment_shader(float fade_distance)
+    {
+        std::string source = fragment_shader_template;
+        const std::string token = "{{FADE}}";
+        const std::string value = std::to_string(fade_distance);
+        for (size_t pos = source.find(token); pos != std::string::npos; pos = source.find(token))
+        {
+            source.replace(pos, token.size(), value);
+        }
+        return source;
+    }
+} // namespace
+
+namespace rendering_engine
+{
+    grid_material::grid_material(gpu::bind_group_layout frame_layout, float fade_distance)
+    {
+        gpu::vertex_buffer_layout vertex_layout{};
+        // Stride supplied per draw by the renderable; one vec3 position.
+        vertex_layout.stride = 0;
+        vertex_layout.attributes.push_back({0, 3, gpu::scalar_type::float32, 0});
+
+        // Per-draw layout (slot 1): the model matrix UBO at binding 1,
+        // matching the renderable's bind group.
+        gpu::bind_group_layout_descriptor draw_layout{};
+        draw_layout.entries.push_back({draw_model_binding, gpu::binding_kind::uniform_buffer});
+
+        // Transparent so the grid fades; depth tested but not written, so
+        // scene geometry occludes the grid while the grid never clobbers
+        // the depth buffer. Double-sided so the fullscreen triangle is
+        // never culled.
+        material_params params{};
+        params.transparent = true;
+        params.blending = blend_mode::normal;
+        params.double_sided = true;
+        params.depth_test = true;
+        params.depth_write = false;
+
+        construct_pipeline(vertex_shader,
+                           build_fragment_shader(fade_distance),
+                           vertex_layout,
+                           draw_layout,
+                           frame_layout,
+                           params,
+                           gpu::bind_group_layout_descriptor{},
+                           gpu::primitive_topology::triangles);
+    }
+
+    grid_material::~grid_material() = default;
+} // namespace rendering_engine

--- a/rendering_engine/materials/grid_material.hpp
+++ b/rendering_engine/materials/grid_material.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/materials/material.hpp>
+
+namespace rendering_engine
+{
+    // Analytic infinite-grid material — the CAD-style ground grid. It is
+    // drawn by a single fullscreen triangle (see @ref debug::infinite_grid)
+    // whose fragment shader reconstructs, per pixel, the world point where
+    // the view ray crosses the Z-up ground plane (z = 0), draws minor /
+    // major grid lines and the coloured world axes with screen-space
+    // derivative anti-aliasing, and fades the whole thing out with
+    // distance. It writes per-pixel depth and depth-tests against the
+    // scene (depth-write off) so scene geometry occludes the grid.
+    //
+    // Slot layout mirrors the line material: the scene per-frame group
+    // (camera) at slot 0, and a per-draw group at slot 1 holding a model
+    // matrix that places / orients the ground plane (identity for the
+    // origin grid). There is no per-material group.
+    struct grid_material : public material
+    {
+        // @p frame_layout is the scene_pass per-frame layout bound at
+        // slot 0. @p fade_distance is the world-space radius (from the
+        // camera) past which the grid has fully faded to nothing.
+        explicit grid_material(gpu::bind_group_layout frame_layout, float fade_distance = 100.0f);
+        ~grid_material() override;
+    };
+} // namespace rendering_engine

--- a/rendering_engine/materials/line_material.cpp
+++ b/rendering_engine/materials/line_material.cpp
@@ -91,7 +91,7 @@ namespace
 
 namespace rendering_engine
 {
-    line_material::line_material(gpu::bind_group_layout frame_layout)
+    line_material::line_material(gpu::bind_group_layout frame_layout, bool depth_tested)
     {
         gpu::vertex_buffer_layout vertex_layout{};
         // Stride = 0 — the per-vertex stride is supplied at
@@ -111,11 +111,13 @@ namespace rendering_engine
         gpu::bind_group_layout_descriptor material_layout{};
         material_layout.entries.push_back({material_params_binding, gpu::binding_kind::uniform_buffer});
 
-        // Opaque unlit lines: depth tested and written, no blending.
+        // Opaque unlit lines: depth tested and written by default, no
+        // blending. The debug-overlay variant disables both so its
+        // gizmos always draw on top of a depth-less pass.
         material_params params{};
         params.transparent = false;
-        params.depth_test = true;
-        params.depth_write = true;
+        params.depth_test = depth_tested;
+        params.depth_write = depth_tested;
 
         construct_pipeline(vertex_shader,
                            fragment_shader,

--- a/rendering_engine/materials/line_material.hpp
+++ b/rendering_engine/materials/line_material.hpp
@@ -54,7 +54,14 @@ namespace rendering_engine
         // the @ref scene_pass; it must match the layout the pass binds
         // at slot 0 every frame so the pipeline and the runtime bind
         // group agree on slot shape.
-        explicit line_material(gpu::bind_group_layout frame_layout);
+        //
+        // @p depth_tested keeps the default opaque scene behaviour
+        // (depth tested and written). Pass @c false for lines drawn in a
+        // depth-less pass such as the debug-overlay pass, where the
+        // swapchain depth buffer is not cleared per frame and a
+        // depth-writing line would occlude itself on the next frame; the
+        // debug gizmos use such a variant so they always draw on top.
+        explicit line_material(gpu::bind_group_layout frame_layout, bool depth_tested = true);
         ~line_material() override;
 
         // Tint multiplied into every vertex's colour (white leaves the

--- a/rendering_engine/passes/debug_pass.cpp
+++ b/rendering_engine/passes/debug_pass.cpp
@@ -33,7 +33,10 @@
 
 namespace rendering_engine
 {
-    debug_pass::debug_pass(std::vector<renderable*>* registry) : m_registry(registry) {}
+    debug_pass::debug_pass(std::vector<renderable*>* registry, gpu::bind_group frame_bind_group)
+        : m_registry(registry), m_frame_bind_group(frame_bind_group)
+    {
+    }
 
     void debug_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
     {
@@ -60,12 +63,24 @@ namespace rendering_engine
                          { return a.mat->pipeline().id < b.mat->pipeline().id; });
 
         uint64_t last_pipeline_id = 0;
+        bool first_iter = true;
         for (const auto& item : m_items)
         {
             const uint64_t pid = item.mat->pipeline().id;
             if (pid != last_pipeline_id)
             {
                 pass_encoder->set_pipeline(item.mat->pipeline());
+
+                // Bind the camera per-frame group once after the first
+                // pipeline change so the line gizmos project with the
+                // scene camera; it sticks across later set_pipeline calls.
+                // Skipped when absent (no scene pass / camera).
+                if (first_iter && m_frame_bind_group.valid())
+                {
+                    pass_encoder->set_bind_group(0, m_frame_bind_group);
+                    first_iter = false;
+                }
+
                 if (item.mat->per_material_bind_group().valid())
                 {
                     pass_encoder->set_bind_group(item.mat->per_material_slot(), item.mat->per_material_bind_group());

--- a/rendering_engine/passes/debug_pass.hpp
+++ b/rendering_engine/passes/debug_pass.hpp
@@ -53,7 +53,15 @@ namespace rendering_engine
      */
     struct debug_pass : pass
     {
-        explicit debug_pass(std::vector<renderable*>* registry);
+        // @p frame_bind_group is the scene pass's per-frame group (camera
+        // at slot 0). The debug helpers draw through the line material,
+        // whose pipeline reserves slot 0 for the camera, so binding it
+        // here projects the world-space gizmos with the same camera the
+        // scene used. The scene pass runs first and refills the backing
+        // UBO every frame, so the captured handle always reflects the
+        // current camera. An invalid handle simply binds nothing (e.g.
+        // ImGui-only debug content).
+        debug_pass(std::vector<renderable*>* registry, gpu::bind_group frame_bind_group);
         ~debug_pass() override = default;
 
         debug_pass(const debug_pass&) = delete;
@@ -66,6 +74,10 @@ namespace rendering_engine
         // debug-renderable registry. Same lifetime guarantee as
         // @ref ui_pass::m_registry.
         std::vector<renderable*>* m_registry;
+
+        // Scene pass's per-frame camera bind group, bound at slot 0 for
+        // the line-based gizmos. See the constructor note.
+        gpu::bind_group m_frame_bind_group;
 
         // Reused across frames so the underlying allocation persists.
         std::vector<draw_item> m_items;

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -172,6 +172,11 @@ namespace rendering_engine
         return m_frame_layout;
     }
 
+    gpu::bind_group scene_pass::frame_bind_group() const
+    {
+        return m_frame_bind_group;
+    }
+
     void scene_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
     {
         auto& eng = control::current_engine();

--- a/rendering_engine/passes/scene_pass.hpp
+++ b/rendering_engine/passes/scene_pass.hpp
@@ -69,6 +69,13 @@ namespace rendering_engine
         // reserve slot 0 for this layout.
         gpu::bind_group_layout frame_bind_group_layout() const;
 
+        // The per-frame bind group itself (camera / lights / shadow at
+        // slot 0). The handle is stable across frames — the pass refills
+        // the backing UBOs in record() rather than recreating the group —
+        // so the debug pass can capture it once and bind it to project
+        // its line-based gizmos with the same camera the scene used.
+        gpu::bind_group frame_bind_group() const;
+
     private:
         // Non-owning back-pointer to the engine context's
         // scene-renderable registry. The context outlives every

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -27,13 +27,14 @@
 #include <infrastructure/settings.hpp>
 #include <rendering_engine/camera/camera.hpp>
 #include <rendering_engine/debug/axes_helper.hpp>
-#include <rendering_engine/debug/grid_helper.hpp>
 #include <rendering_engine/debug/helper.hpp>
+#include <rendering_engine/debug/infinite_grid.hpp>
 #include <rendering_engine/debug_ui/imgui_layer.hpp>
 #include <rendering_engine/gpu/command_encoder.hpp>
 #include <rendering_engine/gpu/device.hpp>
 #include <rendering_engine/ibl/environment.hpp>
 #include <rendering_engine/materials/basic_material.hpp>
+#include <rendering_engine/materials/grid_material.hpp>
 #include <rendering_engine/materials/line_material.hpp>
 #include <rendering_engine/materials/phong_material.hpp>
 #include <rendering_engine/materials/points_material.hpp>
@@ -146,6 +147,8 @@ void rendering_engine::context::init()
     // Depth-disabled line variant for the debug gizmos so they always
     // read on top in the depth-less debug pass.
     m_debug_line_material = std::make_unique<line_material>(scene_frame_layout, /*depth_tested=*/false);
+    // Analytic infinite-grid material; shares the scene per-frame layout.
+    m_grid_material = std::make_unique<grid_material>(scene_frame_layout);
     m_ui_material = std::make_unique<ui_material>();
     LOG_INF("Rendering Engine: basic_material, phong_material, standard_material, points_material, line_material and "
             "ui_material constructed");
@@ -182,14 +185,16 @@ void rendering_engine::context::init()
     debug_ui::init();
 
 #if _DEBUG
-    // Provide a couple of always-available reference gizmos (ground grid
-    // + world axes) so a fresh debug build has something to toggle from
-    // the overlay's Helpers panel. They auto-register into the
-    // debug-renderable registry and the helper registry on construction.
-    // Game code can add the box / light / camera helpers against its own
-    // objects the same way. The debug pass is dropped in release, so this
-    // whole block compiles out there.
-    m_debug_helpers.push_back(std::make_unique<debug::grid_helper>());
+    // Provide a couple of always-available reference gizmos (the infinite
+    // ground grid + world axes) so a fresh debug build has something to
+    // toggle from the overlay's Helpers panel. They auto-register into the
+    // matching renderable registry and the helper registry on
+    // construction: the infinite grid into the scene pass (depth-tested),
+    // the axes into the always-on-top debug pass. Game code can add the
+    // box / light / camera helpers against its own objects the same way.
+    // The debug pass is dropped in release, so this whole block compiles
+    // out there.
+    m_debug_helpers.push_back(std::make_unique<debug::infinite_grid>());
     m_debug_helpers.push_back(std::make_unique<debug::axes_helper>());
 #endif
 }
@@ -217,6 +222,7 @@ void rendering_engine::context::quit()
     // Then materials, which own pipelines that reference the device.
     // Release them before the device tears its pools down.
     m_ui_material.reset();
+    m_grid_material.reset();
     m_debug_line_material.reset();
     m_line_material.reset();
     m_points_material.reset();
@@ -338,6 +344,11 @@ rendering_engine::line_material& rendering_engine::context::get_line_material()
 rendering_engine::line_material& rendering_engine::context::get_debug_line_material()
 {
     return *m_debug_line_material;
+}
+
+rendering_engine::grid_material& rendering_engine::context::get_grid_material()
+{
+    return *m_grid_material;
 }
 
 rendering_engine::ui_material& rendering_engine::context::get_ui_material()

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -26,6 +26,9 @@
 #include <infrastructure/log.hpp>
 #include <infrastructure/settings.hpp>
 #include <rendering_engine/camera/camera.hpp>
+#include <rendering_engine/debug/axes_helper.hpp>
+#include <rendering_engine/debug/grid_helper.hpp>
+#include <rendering_engine/debug/helper.hpp>
 #include <rendering_engine/debug_ui/imgui_layer.hpp>
 #include <rendering_engine/gpu/command_encoder.hpp>
 #include <rendering_engine/gpu/device.hpp>
@@ -126,7 +129,9 @@ void rendering_engine::context::init()
     auto fxaa = std::make_unique<fxaa_pass>(m_ldr_color_texture, width, height);
     auto ui = std::make_unique<ui_pass>(&m_ui_renderables);
 #if _DEBUG
-    auto debug = std::make_unique<debug_pass>(&m_debug_renderables);
+    // The debug pass binds the scene pass's per-frame camera group at
+    // slot 0 so the line-based debug gizmos project with the same camera.
+    auto debug = std::make_unique<debug_pass>(&m_debug_renderables, scene->frame_bind_group());
 #endif
 
     // Construct the built-in materials against the per-frame layouts
@@ -138,6 +143,9 @@ void rendering_engine::context::init()
     m_standard_material = std::make_unique<standard_material>(scene_frame_layout);
     m_points_material = std::make_unique<points_material>(scene_frame_layout);
     m_line_material = std::make_unique<line_material>(scene_frame_layout);
+    // Depth-disabled line variant for the debug gizmos so they always
+    // read on top in the depth-less debug pass.
+    m_debug_line_material = std::make_unique<line_material>(scene_frame_layout, /*depth_tested=*/false);
     m_ui_material = std::make_unique<ui_material>();
     LOG_INF("Rendering Engine: basic_material, phong_material, standard_material, points_material, line_material and "
             "ui_material constructed");
@@ -172,6 +180,18 @@ void rendering_engine::context::init()
     // Bring the ImGui debug overlay up now that the window, GL context
     // and passes are live. No-op in release builds.
     debug_ui::init();
+
+#if _DEBUG
+    // Provide a couple of always-available reference gizmos (ground grid
+    // + world axes) so a fresh debug build has something to toggle from
+    // the overlay's Helpers panel. They auto-register into the
+    // debug-renderable registry and the helper registry on construction.
+    // Game code can add the box / light / camera helpers against its own
+    // objects the same way. The debug pass is dropped in release, so this
+    // whole block compiles out there.
+    m_debug_helpers.push_back(std::make_unique<debug::grid_helper>());
+    m_debug_helpers.push_back(std::make_unique<debug::axes_helper>());
+#endif
 }
 
 void rendering_engine::context::quit()
@@ -182,6 +202,12 @@ void rendering_engine::context::quit()
     // it bound to are still alive. No-op in release builds.
     debug_ui::shutdown();
 
+    // Release the built-in debug helpers before the line material and the
+    // GPU device they reference; their destructors unregister from the
+    // debug-renderable registry and free their line buffers. Empty in
+    // release. Game-owned helpers must likewise be released before quit.
+    m_debug_helpers.clear();
+
     // Drop the passes first; their record() bodies reach for the
     // event bus we're about to release, and the passes own per-frame
     // bind-group layouts referenced by the materials' pipelines.
@@ -191,6 +217,7 @@ void rendering_engine::context::quit()
     // Then materials, which own pipelines that reference the device.
     // Release them before the device tears its pools down.
     m_ui_material.reset();
+    m_debug_line_material.reset();
     m_line_material.reset();
     m_points_material.reset();
     m_standard_material.reset();
@@ -306,6 +333,11 @@ rendering_engine::points_material& rendering_engine::context::get_points_materia
 rendering_engine::line_material& rendering_engine::context::get_line_material()
 {
     return *m_line_material;
+}
+
+rendering_engine::line_material& rendering_engine::context::get_debug_line_material()
+{
+    return *m_debug_line_material;
 }
 
 rendering_engine::ui_material& rendering_engine::context::get_ui_material()

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -43,6 +43,7 @@ namespace rendering_engine
     struct standard_material;
     struct points_material;
     struct line_material;
+    struct grid_material;
     struct ui_material;
 
     namespace debug
@@ -164,6 +165,15 @@ namespace rendering_engine
          */
         line_material& get_debug_line_material();
 
+        /**
+         * @brief Built-in analytic infinite-grid material (the CAD-style
+         *        ground grid). Constructed in @ref init.
+         *
+         * Shares the scene per-frame layout (camera at slot 0) and is
+         * fronted by the @ref debug::infinite_grid scene renderable.
+         */
+        grid_material& get_grid_material();
+
         /** @brief Built-in 2D overlay material. Constructed in @ref init. */
         ui_material& get_ui_material();
 
@@ -224,6 +234,8 @@ namespace rendering_engine
         std::unique_ptr<line_material> m_line_material;
         // Depth-disabled line material the debug gizmos draw through.
         std::unique_ptr<line_material> m_debug_line_material;
+        // Analytic infinite-grid material fronted by debug::infinite_grid.
+        std::unique_ptr<grid_material> m_grid_material;
         std::unique_ptr<ui_material> m_ui_material;
 
         // Off-screen HDR target the scene pass renders into.

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -45,6 +45,11 @@ namespace rendering_engine
     struct line_material;
     struct ui_material;
 
+    namespace debug
+    {
+        struct helper;
+    }
+
     /**
      * @brief Orchestrates the rendering subsystem (window, GL context, materials, passes).
      *
@@ -147,6 +152,18 @@ namespace rendering_engine
         /** @brief Built-in unlit line material (line topology). Constructed in @ref init. */
         line_material& get_line_material();
 
+        /**
+         * @brief Built-in line material for debug gizmos — line topology
+         *        with depth testing disabled.
+         *
+         * Shares the scene per-frame layout (camera at slot 0) with
+         * @ref get_line_material, but draws depth-less so the debug
+         * helpers (the THREE.*Helper analogues) always read on top in the
+         * depth-less debug pass. Constructed in @ref init; used by the
+         * @ref debug::helper family.
+         */
+        line_material& get_debug_line_material();
+
         /** @brief Built-in 2D overlay material. Constructed in @ref init. */
         ui_material& get_ui_material();
 
@@ -168,6 +185,14 @@ namespace rendering_engine
         std::vector<renderable*> m_scene_renderables;
         std::vector<renderable*> m_ui_renderables;
         std::vector<renderable*> m_debug_renderables;
+
+        // Built-in debug gizmos (ground grid + world axes) created in
+        // @ref init for debug builds and toggled from the debug UI. They
+        // auto-register into @ref m_debug_renderables on construction, so
+        // this list owns their lifetime and must be cleared in @ref quit
+        // before the line material and GPU device they reference. Empty in
+        // release builds, where the debug pass is dropped entirely.
+        std::vector<std::unique_ptr<debug::helper>> m_debug_helpers;
 
         // Ordered pass list walked once per frame in @ref render.
         // Populated by @ref init with the built-in scene + UI passes
@@ -197,6 +222,8 @@ namespace rendering_engine
         std::unique_ptr<standard_material> m_standard_material;
         std::unique_ptr<points_material> m_points_material;
         std::unique_ptr<line_material> m_line_material;
+        // Depth-disabled line material the debug gizmos draw through.
+        std::unique_ptr<line_material> m_debug_line_material;
         std::unique_ptr<ui_material> m_ui_material;
 
         // Off-screen HDR target the scene pass renders into.


### PR DESCRIPTION
## Why

Three.js's `*Helper` family is invaluable for debugging scenes. AlphaEngine already has a debug-only pass (the FPS overlay's home) and the line renderable from #119, so this adds the gizmo family on top of them — plus a runtime enable/disable toggle in the debug UI.

Closes #120.

## What

New `rendering_engine/debug/` subsystem. Each gizmo is a `debug::helper` — a `renderable` that owns a line and auto-registers into both the debug-renderable registry (drawn by the debug pass) and a process-wide helper registry (walked by the UI). It skips its draw when toggled off.

| Helper | Three.js analog |
| --- | --- |
| `grid_helper` | `GridHelper` — X/Z reference grid |
| `axes_helper` | `AxesHelper` — RGB world axes |
| `box_helper` | `Box3Helper` — AABB wireframe |
| `directional_light_helper` / `point_light_helper` | `DirectionalLightHelper` / `PointLightHelper` |
| `camera_helper` | `CameraHelper` — view-frustum wireframe |

Dynamic helpers (light, camera) follow their target and rebuild only when it actually changes, so there's no per-frame buffer churn.

### Engine wiring the gizmos needed

- **Camera in the debug pass.** The debug pass now binds the scene pass's per-frame camera group at slot 0 (via a stable `scene_pass::frame_bind_group()` handle), so the world-space line gizmos project with the same camera the scene used. Previously the debug pass only fed ImGui and bound no per-frame group.
- **Depth-disabled line variant.** Added a `depth_tested` flag to `line_material` and a `context::get_debug_line_material()` that the gizmos draw through. The overlay pass's swapchain depth buffer isn't cleared per frame, so a depth-writing line would occlude itself on the next frame on OpenGL; drawing depth-less keeps the gizmos always-on-top, matching the pass's intent.

### Enable/disable from the debug UI

The ImGui overlay gains a **Helpers** panel (toggled from the FPS overlay's right-click menu) listing every live gizmo with a per-helper visibility checkbox plus Show-all / Hide-all shortcuts. A ground grid + world axes are created by default in debug builds so there's something to toggle out of the box.

## Notes

- `snake_case` throughout; debug-build only. The whole system compiles out of release where the debug pass is dropped from the pass list.

## Verification

- Full Debug build links cleanly (all translation units, real binary produced).
- clang-tidy-18 (naming gate) clean on all changed files.
- clang-format-18 clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2VZq59usrywGPHeZvQrtv)_