### PR TITLE
feat: core::jobs worker pool and parallel world-matrix prepass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,12 @@ add_subdirectory(core)
 add_subdirectory(rendering_engine)
 add_subdirectory(external)
 
+# Threads — the core worker pool (core/jobs) uses std::thread. MSVC links its
+# threading support implicitly; on Linux this pulls in pthread.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(AlphaEngine Threads::Threads)
+
 # Use C++ standard library
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_compile_options(AlphaEngine PRIVATE -stdlib=libc++)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(AlphaEngine PRIVATE
     event.hpp
     event_engine.cpp
     event_engine.hpp
+    jobs.cpp
+    jobs.hpp
     log.cpp
     log.hpp
     pool.hpp

--- a/core/jobs.cpp
+++ b/core/jobs.cpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <core/jobs.hpp>
+
+#include <utility>
+
+#include <core/log.hpp>
+
+core::jobs::jobs()
+{
+    // Leave one hardware thread for the main thread, which participates in
+    // every wait. hardware_concurrency() can report 0 (unknown); treat that —
+    // and a genuine single core — as "no workers, run everything inline".
+    const unsigned int hardware = std::thread::hardware_concurrency();
+    const unsigned int count = hardware > 1 ? hardware - 1 : 0;
+
+    m_workers.reserve(count);
+    for (unsigned int i = 0; i < count; ++i)
+    {
+        m_workers.emplace_back([this] { worker_main(); });
+    }
+
+    LOG_INF("jobs: worker pool started with %u worker thread(s)", count);
+}
+
+core::jobs::~jobs()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_stop = true;
+    }
+    m_wake.notify_all();
+    for (std::thread& worker : m_workers)
+    {
+        if (worker.joinable())
+        {
+            worker.join();
+        }
+    }
+}
+
+unsigned int core::jobs::worker_count() const noexcept
+{
+    return static_cast<unsigned int>(m_workers.size());
+}
+
+void core::jobs::enqueue(job_fn body)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.push_back(std::move(body));
+        m_in_flight.fetch_add(1, std::memory_order_relaxed);
+    }
+    m_wake.notify_one();
+}
+
+void core::jobs::execute(job_fn& body)
+{
+    body();
+    // The decrement carries the release so wait_idle's acquire load sees every
+    // write the job made. The last one to reach zero wakes any idle waiter.
+    if (m_in_flight.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_drained.notify_all();
+    }
+}
+
+bool core::jobs::run_one_pending()
+{
+    job_fn body;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_queue.empty())
+        {
+            return false;
+        }
+        body = std::move(m_queue.front());
+        m_queue.pop_front();
+    }
+    execute(body);
+    return true;
+}
+
+void core::jobs::worker_main()
+{
+    for (;;)
+    {
+        job_fn body;
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            m_wake.wait(lock, [this] { return m_stop || !m_queue.empty(); });
+            if (m_stop && m_queue.empty())
+            {
+                return;
+            }
+            body = std::move(m_queue.front());
+            m_queue.pop_front();
+        }
+        execute(body);
+    }
+}
+
+void core::jobs::parallel_for(std::size_t count, const std::function<void(std::size_t)>& body, std::size_t grain)
+{
+    if (count == 0)
+    {
+        return;
+    }
+
+    const std::size_t chunk = grain > 0 ? grain : 1;
+
+    // Inline fast path: nothing to gain from a hand-off when there are no
+    // workers, or the whole range fits in a single chunk.
+    if (m_workers.empty() || count <= chunk)
+    {
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            body(i);
+        }
+        return;
+    }
+
+    const std::size_t chunks = (count + chunk - 1) / chunk;
+
+    // The batch lives entirely within this call: we block below until every
+    // chunk has run, so capturing @p body and @c remaining by reference is safe.
+    std::atomic<std::size_t> remaining{chunks};
+    for (std::size_t c = 0; c < chunks; ++c)
+    {
+        const std::size_t begin = c * chunk;
+        const std::size_t end = begin + chunk < count ? begin + chunk : count;
+        enqueue(
+            [&body, &remaining, begin, end]
+            {
+                for (std::size_t i = begin; i < end; ++i)
+                {
+                    body(i);
+                }
+                remaining.fetch_sub(1, std::memory_order_acq_rel);
+            });
+    }
+
+    // Participate until our own batch is done, helping run whatever is queued.
+    while (remaining.load(std::memory_order_acquire) != 0)
+    {
+        if (!run_one_pending())
+        {
+            std::this_thread::yield();
+        }
+    }
+}
+
+void core::jobs::dispatch(job_fn body)
+{
+    // With no workers the job would never be drained, so run it inline.
+    if (m_workers.empty())
+    {
+        body();
+        return;
+    }
+    enqueue(std::move(body));
+}
+
+void core::jobs::wait_idle()
+{
+    // Pitch in first, then sleep until the workers retire the last job.
+    while (run_one_pending())
+    {
+    }
+    std::unique_lock<std::mutex> lock(m_mutex);
+    m_drained.wait(lock, [this] { return m_in_flight.load(std::memory_order_acquire) == 0; });
+}

--- a/core/jobs.hpp
+++ b/core/jobs.hpp
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * @file jobs.hpp
+ * @brief Fixed-size worker pool and the fork-join primitives built on it.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace core
+{
+    /**
+     * @brief Process-wide worker pool that runs engine work in parallel.
+     *
+     * Owned by @ref runtime::engine and constructed early so any subsystem can
+     * hand it work during init or per frame. The pool starts
+     * @c hardware_concurrency() - 1 worker threads — the main thread is the Nth
+     * participant. On a single-core host it starts none, and every call below
+     * degrades to running inline on the caller, so behaviour is identical minus
+     * the parallelism.
+     *
+     * The model is deliberately fork-join: a caller dispatches a burst of work
+     * and blocks (helping run queued jobs meanwhile) until it finishes. There is
+     * no free-running background mutation, so the rest of the engine keeps its
+     * main-thread-only contract; only the work handed to @ref parallel_for /
+     * @ref dispatch ever runs off the main thread. Whatever a job touches must
+     * therefore be safe to touch concurrently — read-only shared state, or
+     * writes that are disjoint per index.
+     *
+     * Unlike every other subsystem, this type is itself thread-safe: its queue,
+     * dispatch, and completion tracking are synchronised.
+     */
+    struct jobs
+    {
+        /** @brief Callable unit of work handed to @ref dispatch. */
+        using job_fn = std::function<void()>;
+
+        /** @brief Starts the worker threads. */
+        jobs();
+
+        /** @brief Signals the workers to stop, then joins every one. */
+        ~jobs();
+
+        jobs(const jobs&) = delete;
+        jobs& operator=(const jobs&) = delete;
+        jobs(jobs&&) = delete;
+        jobs& operator=(jobs&&) = delete;
+
+        /**
+         * @brief Number of worker threads, excluding the calling/main thread.
+         *
+         * Zero on a single-core host, in which case every call runs inline.
+         */
+        unsigned int worker_count() const noexcept;
+
+        /**
+         * @brief Runs @p body for every index in <tt>[0, count)</tt> and blocks
+         *        until all of them complete.
+         *
+         * Indices are handed out in contiguous chunks of roughly @p grain. The
+         * calling thread participates in execution rather than spinning idle.
+         * When there are no workers, or the batch is no larger than one chunk,
+         * the whole range runs inline on the caller with no threading overhead,
+         * so small workloads cost nothing.
+         *
+         * @param count Number of indices to process.
+         * @param body  Invoked as @c body(i) for each @c i. Must be safe to run
+         *              concurrently across distinct indices, and must not throw.
+         * @param grain Minimum number of indices per chunk. Larger values trade
+         *              load balancing for lower per-chunk overhead.
+         */
+        void parallel_for(std::size_t count, const std::function<void(std::size_t)>& body, std::size_t grain = 1);
+
+        /**
+         * @brief Enqueues one fire-and-forget job.
+         *
+         * Returns as soon as the job is queued — or, with no workers, after
+         * running it inline. Join with @ref wait_idle. The foundation for
+         * background work such as asset streaming.
+         */
+        void dispatch(job_fn body);
+
+        /**
+         * @brief Blocks until every dispatched job has finished, helping run
+         *        queued work meanwhile.
+         */
+        void wait_idle();
+
+    private:
+        // Worker thread entry point: blocks for queued work and runs it.
+        void worker_main();
+        // Pops and runs a single queued job, returning false if none was ready.
+        bool run_one_pending();
+        // Runs @p body then drops the in-flight count, waking @ref wait_idle at zero.
+        void execute(job_fn& body);
+        // Queues @p body and bumps the in-flight count.
+        void enqueue(job_fn body);
+
+        std::vector<std::thread> m_workers;
+        std::deque<job_fn> m_queue;
+        std::mutex m_mutex;
+        std::condition_variable m_wake;    // a job was queued, or we are stopping
+        std::condition_variable m_drained; // the in-flight count reached zero
+        std::atomic<std::size_t> m_in_flight{0};
+        bool m_stop{false};
+    };
+} // namespace core

--- a/runtime/engine.cpp
+++ b/runtime/engine.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 
 #include <core/event_engine.hpp>
+#include <core/jobs.hpp>
 #include <core/log.hpp>
 #include <core/settings.hpp>
 #include <core/time.hpp>
@@ -84,6 +85,10 @@ namespace runtime
         // header and the old subsystem init order in main_loop.cpp.
         settings = std::make_unique<::settings>();
         time = std::make_unique<core::time>();
+        // The worker pool has no dependencies and is brought up early so any
+        // subsystem can hand it work during init or per frame. Its threads
+        // idle until the first job is dispatched.
+        jobs = std::make_unique<core::jobs>();
         events = std::make_unique<core::event_bus>();
         window = std::make_unique<rendering_engine::window>();
         gpu = rendering_engine::gpu::create_device(to_backend_type(settings->graphics.backend));
@@ -104,6 +109,9 @@ namespace runtime
         gpu.reset();
         window.reset();
         events.reset();
+        // Joins the worker threads. Every per-frame job is forked and joined
+        // within tick(), so nothing is in flight by the time we get here.
+        jobs.reset();
         time.reset();
         settings.reset();
         g_current_engine = nullptr;

--- a/runtime/engine.hpp
+++ b/runtime/engine.hpp
@@ -48,6 +48,10 @@ namespace core
 }
 namespace core
 {
+    struct jobs;
+}
+namespace core
+{
     struct time;
 }
 namespace rendering_engine
@@ -114,6 +118,7 @@ namespace runtime
         // engine's own lifetime, in the order they are declared here.
         std::unique_ptr<::settings> settings;
         std::unique_ptr<core::time> time;
+        std::unique_ptr<core::jobs> jobs;
         std::unique_ptr<core::event_bus> events;
         std::unique_ptr<rendering_engine::window> window;
         std::unique_ptr<rendering_engine::gpu::device> gpu;

--- a/runtime/scene_graph.cpp
+++ b/runtime/scene_graph.cpp
@@ -22,9 +22,12 @@
 
 #include <runtime/scene_graph.hpp>
 
-#include <core/log.hpp>
-
 #include <string>
+#include <utility>
+
+#include <core/jobs.hpp>
+#include <core/log.hpp>
+#include <runtime/engine.hpp>
 
 runtime::context::context()
 {
@@ -48,5 +51,45 @@ void runtime::context::quit()
 
 void runtime::context::update()
 {
+    // Phase 1 (parallel): warm every active node's cached world matrix,
+    // breadth-first by depth. Within one depth band every node's parent was
+    // resolved in the previous band, so a node only ever writes its own cache
+    // while reading its parent's already-settled one — the writes are disjoint
+    // and the reads are pure, which makes the band data-race free. This keeps
+    // the matrix multiplies (the costly part of a deep hierarchy) on the worker
+    // pool while everything with side effects below stays on the main thread.
+    //
+    // Inactive subtrees are skipped, matching node::update_subtree: a disabled
+    // node freezes its whole subtree and its components are already hidden.
+    core::jobs& jobs = *current_engine().jobs;
+
+    m_band.clear();
+    if (root.is_active())
+    {
+        m_band.push_back(&root);
+    }
+
+    while (!m_band.empty())
+    {
+        jobs.parallel_for(m_band.size(), [this](std::size_t i) { m_band[i]->transform.get_world_matrix(); });
+
+        m_next_band.clear();
+        for (node* parent : m_band)
+        {
+            for (node* child : parent->children())
+            {
+                if (child->is_active())
+                {
+                    m_next_band.push_back(child);
+                }
+            }
+        }
+        std::swap(m_band, m_next_band);
+    }
+
+    // Phase 2 (serial): dispatch each component's on_update down the tree.
+    // Components bridge to shared subsystems (renderer registries, the light
+    // list, per-draw GPU buffers), none of which are thread-safe, so this walk
+    // stays single-threaded — and the world matrices it reads are already warm.
     root.update_subtree();
 }

--- a/runtime/scene_graph.hpp
+++ b/runtime/scene_graph.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <runtime/component.hpp>
 #include <runtime/node.hpp>
@@ -82,5 +83,13 @@ namespace runtime
          * behaviour beyond being a conventional, always-present parent.
          */
         node root;
+
+    private:
+        // Reusable scratch for the breadth-first world-matrix prepass in
+        // @ref update: the active nodes at the current depth and the next one.
+        // Kept as members so the per-frame walk reuses one allocation that
+        // grows to the scene's high-water mark rather than allocating each tick.
+        std::vector<node*> m_band;
+        std::vector<node*> m_next_band;
     };
 } // namespace runtime


### PR DESCRIPTION
## What

Lays the multithreading foundation for the engine, which was previously single-threaded.

### `core::jobs` — a fork-join worker pool
- `parallel_for`, `dispatch`, and `wait_idle`, backed by `hardware_concurrency() - 1` worker threads (the main thread is the Nth participant).
- **Inline fast path:** with no workers or a batch no larger than one chunk, work runs on the calling thread at zero threading cost — so small / single-core workloads are unaffected.
- Waiting threads help drain the queue (uses the idle core, avoids nested-wait deadlock).
- Owned by `runtime::engine`, brought up early (no dependencies). Thread-safe, unlike the other subsystems.

### First consumer — depth-banded world-matrix prepass
`runtime::context::update()` now warms world matrices breadth-first by depth via `parallel_for`. Because each band's parents are resolved one band earlier, every node writes only its own cache while reading its parent's already-settled one — **race-free by construction**.

## The threading contract (why so little is parallel)
Parallelism is strictly fork-join inside `tick()`; the rest of the engine keeps its main-thread-only invariant. Only pure / per-index-disjoint work goes on the pool. **Component `on_update` and draw collection deliberately stay serial** because they touch non-thread-safe shared state — renderer/light registries, and `model::collect_draw_items` writes per-draw GPU buffers every frame. A dedicated render thread / frame pipelining was deferred (the engine is single-frame-in-flight and not yet CPU-bound).

## Build / CMake
Links `Threads` for the `std::thread` dependency (implicit on MSVC, pulls pthread on Linux).

## Verification
- Debug build: clean (exit 0, no warnings).
- `check-style.ps1`: no style issues.
- `check-naming.ps1`: no naming violations.
- Confirmed at runtime that the pool spins up the expected worker count and that work fans across all hardware threads.
