### PR TITLE
feat: instanced-mesh renderable

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(AlphaEngine PRIVATE
     camera_module.cpp
     exit_module.cpp
     frame_module.cpp
-    scene_graph_demo_module.cpp
+    instanced_demo_module.cpp
 )
 
 # The FPS counter used to live here as a label-rendering game module; it
@@ -10,17 +10,16 @@ target_sources(AlphaEngine PRIVATE
 # so the standalone fps_overlay_module was removed.
 
 # Only one scene-owning demo module is compiled at a time because each
-# places its showcase geometry at the origin. scene_graph_demo_module.cpp
-# is the active one: it builds a parent/child node hierarchy (a spinning
-# pivot with orbiting cube mesh_components, a second-level moon, and a
-# point light via light_component) to showcase the entity/component scene
-# graph and world-matrix propagation.
+# places its showcase geometry at the origin. instanced_demo_module.cpp is
+# the active one: it draws a grid_side^3 lattice of cubes (thousands of
+# objects) from one shared geometry in a single instanced draw call to
+# showcase the instanced_mesh renderable and its per-instance storage buffer.
 #
-# line_demo_module.cpp (coloured helix line strip), points_demo_module.cpp
-# (coloured Fibonacci-sphere point cloud), skybox_demo_module.cpp
-# (procedural sky + IBL sphere grid), phong_demo_module.cpp (Blinn-Phong
-# lit sphere) and instanced_demo_module.cpp (a wall of cubes drawn in one
-# instanced draw call) are the other showcases; swap any one filename in for
-# scene_graph_demo_module.cpp to bring it back.
+# scene_graph_demo_module.cpp (parent/child node hierarchy with orbiting
+# cube mesh_components and a point light), line_demo_module.cpp (coloured
+# helix line strip), points_demo_module.cpp (coloured Fibonacci-sphere point
+# cloud), skybox_demo_module.cpp (procedural sky + IBL sphere grid) and
+# phong_demo_module.cpp (Blinn-Phong lit sphere) are the other showcases;
+# swap any one filename in for instanced_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,8 +18,9 @@ target_sources(AlphaEngine PRIVATE
 #
 # line_demo_module.cpp (coloured helix line strip), points_demo_module.cpp
 # (coloured Fibonacci-sphere point cloud), skybox_demo_module.cpp
-# (procedural sky + IBL sphere grid) and phong_demo_module.cpp (Blinn-Phong
-# lit sphere) are the other showcases; swap any one filename in for
+# (procedural sky + IBL sphere grid), phong_demo_module.cpp (Blinn-Phong
+# lit sphere) and instanced_demo_module.cpp (a wall of cubes drawn in one
+# instanced draw call) are the other showcases; swap any one filename in for
 # scene_graph_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/camera_module.cpp
+++ b/external/camera_module.cpp
@@ -44,6 +44,11 @@ static void on_engine_start(const core::engine_start& event)
     attach_camera(g_camera_id);
 
     set_camera_pos(g_camera_id, -5.0, 0.0, 0.0);
+    // Give the camera a sensible initial forward (+X, toward the origin
+    // where the demos place their geometry). Without it the forward is the
+    // zero vector and the view matrix is degenerate, so nothing is visible
+    // until the first mouse move.
+    set_camera_rot(g_camera_id, 1.0, 0.0, 0.0);
 }
 
 static void on_engine_stop(const core::engine_stop& event)

--- a/external/instanced_demo_module.cpp
+++ b/external/instanced_demo_module.cpp
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "api/game_module.hpp"
+#include "api/log.hpp"
+#include "api/time.hpp"
+
+#include <core/log.hpp>
+#include <core/math/math.hpp>
+#include <rendering_engine/materials/instanced_material.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+#include <rendering_engine/renderables/instanced_mesh.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+#include <rendering_engine/util/color.hpp>
+#include <runtime/engine.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace
+{
+    // A grid_side x grid_side wall of cubes drawn from one shared geometry
+    // in a single instanced draw call, each cube with its own transform and
+    // tint. The camera (camera_module) sits at -X looking toward the origin,
+    // so the wall is laid out in the Y-Z plane at x = 0 to face it.
+    constexpr uint32_t grid_side = 8;
+    constexpr uint32_t instance_count = grid_side * grid_side;
+    constexpr float spacing = 1.6f;
+    constexpr float cube_scale = 0.6f;
+
+    std::unique_ptr<rendering_engine::instanced_mesh> g_cubes;
+    std::vector<core::math::vec3> g_base_positions;
+    float g_time = 0.0f;
+
+    // Builds a unit cube (six single-quad faces, CCW-from-outside winding)
+    // in the position+uv+normal vertex format the instanced material draws.
+    void build_unit_cube(std::vector<rendering_engine::vertex_position_uv_normal>& vertices,
+                         std::vector<uint32_t>& indices)
+    {
+        using core::math::vec2;
+        using core::math::vec3;
+
+        const auto build_face = [&](const vec3& u_axis, const vec3& v_axis, const vec3& w_dir)
+        {
+            const auto base = static_cast<uint32_t>(vertices.size());
+            for (int iy = 0; iy <= 1; ++iy)
+            {
+                for (int ix = 0; ix <= 1; ++ix)
+                {
+                    rendering_engine::vertex_position_uv_normal vertex;
+                    vertex.pos = u_axis * (static_cast<float>(ix) - 0.5f) + v_axis * (static_cast<float>(iy) - 0.5f) +
+                                 w_dir * 0.5f;
+                    vertex.normal = w_dir;
+                    vertex.uv = vec2{static_cast<float>(ix), static_cast<float>(iy)};
+                    vertices.push_back(vertex);
+                }
+            }
+            const uint32_t a = base;
+            const uint32_t b = base + 1;
+            const uint32_t c = base + 2;
+            const uint32_t d = base + 3;
+            indices.push_back(a);
+            indices.push_back(c);
+            indices.push_back(d);
+            indices.push_back(a);
+            indices.push_back(d);
+            indices.push_back(b);
+        };
+
+        const vec3 ax{1.0f, 0.0f, 0.0f};
+        const vec3 ay{0.0f, 1.0f, 0.0f};
+        const vec3 az{0.0f, 0.0f, 1.0f};
+        build_face(ax, ay, az);   // +Z
+        build_face(-az, ay, ax);  // +X
+        build_face(-ax, ay, -az); // -Z
+        build_face(az, ay, -ax);  // -X
+        build_face(ax, -az, ay);  // +Y
+        build_face(ax, az, -ay);  // -Y
+    }
+
+    void on_engine_start(const core::engine_start& event)
+    {
+        (void)event;
+
+        auto& material = runtime::current_engine().renderer->get_instanced_material();
+        material.set_color(rendering_engine::util::color{255, 255, 255, 255});
+
+        std::vector<rendering_engine::vertex_position_uv_normal> vertices;
+        std::vector<uint32_t> indices;
+        build_unit_cube(vertices, indices);
+
+        g_cubes = std::make_unique<rendering_engine::instanced_mesh>(&material, instance_count);
+        g_cubes->upload_geometry(vertices, indices);
+
+        g_base_positions.reserve(instance_count);
+        const float centre = static_cast<float>(grid_side - 1) * 0.5f;
+        for (uint32_t i = 0; i < grid_side; ++i)
+        {
+            for (uint32_t j = 0; j < grid_side; ++j)
+            {
+                const uint32_t index = i * grid_side + j;
+                const float y = (static_cast<float>(i) - centre) * spacing;
+                const float z = (static_cast<float>(j) - centre) * spacing;
+                g_base_positions.push_back(core::math::vec3{0.0f, y, z});
+
+                // Tint each cube by its grid position for a colour gradient.
+                const auto r = static_cast<uint8_t>(40 + (215 * i) / (grid_side - 1));
+                const auto b = static_cast<uint8_t>(40 + (215 * j) / (grid_side - 1));
+                g_cubes->set_instance_color(index, rendering_engine::util::color{r, 80, b, 255});
+            }
+        }
+
+        runtime::current_engine().renderer->register_scene_renderable(g_cubes.get());
+    }
+
+    void on_engine_stop(const core::engine_stop& event)
+    {
+        (void)event;
+        runtime::current_engine().renderer->unregister_scene_renderable(g_cubes.get());
+        g_cubes.reset();
+        g_base_positions.clear();
+    }
+
+    void on_frame(const core::frame& event)
+    {
+        (void)event;
+        if (!g_cubes)
+        {
+            return;
+        }
+
+        g_time += static_cast<float>(get_delta_time()) / 1000.0f;
+
+        const core::math::vec3 spin_axis{0.0f, 0.0f, 1.0f};
+        const core::math::vec3 unit_scale{cube_scale, cube_scale, cube_scale};
+        for (uint32_t index = 0; index < instance_count; ++index)
+        {
+            const core::math::vec3& base = g_base_positions[index];
+            // A travelling sine wave along the wall plus a per-cube spin,
+            // recomputed every frame to exercise the dynamic per-instance
+            // storage-buffer upload path.
+            const float phase = base.y + base.z;
+            const float bob = std::sin(g_time * 2.0f + phase) * 0.4f;
+            const core::math::vec3 position{base.x + bob, base.y, base.z};
+            const float angle = g_time + phase;
+
+            const core::math::mat4 model =
+                core::math::translate(position) * core::math::rotate(angle, spin_axis) * core::math::scale(unit_scale);
+            g_cubes->set_instance_transform(index, model);
+        }
+    }
+} // namespace
+
+GAME_MODULE()
+{
+    LOG_INF("Registering external module: instanced_demo_module");
+    struct game_module_info info = {};
+    info.on_engine_start = on_engine_start;
+    info.on_engine_stop = on_engine_stop;
+    info.on_frame = on_frame;
+    register_game_module(info);
+    return true;
+}

--- a/external/instanced_demo_module.cpp
+++ b/external/instanced_demo_module.cpp
@@ -40,14 +40,15 @@
 
 namespace
 {
-    // A grid_side x grid_side wall of cubes drawn from one shared geometry
-    // in a single instanced draw call, each cube with its own transform and
-    // tint. The camera (camera_module) sits at -X looking toward the origin,
-    // so the wall is laid out in the Y-Z plane at x = 0 to face it.
-    constexpr uint32_t grid_side = 8;
-    constexpr uint32_t instance_count = grid_side * grid_side;
-    constexpr float spacing = 1.6f;
-    constexpr float cube_scale = 0.6f;
+    // A grid_side^3 lattice of small cubes drawn from one shared geometry
+    // in a single instanced draw call — thousands of objects, one draw.
+    // The camera (camera_module) starts at -X looking toward the origin, so
+    // the lattice is pushed forward along +X to sit in front of it.
+    constexpr uint32_t grid_side = 16;
+    constexpr uint32_t instance_count = grid_side * grid_side * grid_side; // 4096
+    constexpr float spacing = 0.7f;
+    constexpr float cube_scale = 0.32f;
+    constexpr float forward_offset = 2.0f;
 
     std::unique_ptr<rendering_engine::instanced_mesh> g_cubes;
     std::vector<core::math::vec3> g_base_positions;
@@ -119,19 +120,25 @@ namespace
         {
             for (uint32_t j = 0; j < grid_side; ++j)
             {
-                const uint32_t index = i * grid_side + j;
-                const float y = (static_cast<float>(i) - centre) * spacing;
-                const float z = (static_cast<float>(j) - centre) * spacing;
-                g_base_positions.push_back(core::math::vec3{0.0f, y, z});
+                for (uint32_t k = 0; k < grid_side; ++k)
+                {
+                    const uint32_t index = (i * grid_side + j) * grid_side + k;
+                    const float x = (static_cast<float>(i) - centre) * spacing + forward_offset;
+                    const float y = (static_cast<float>(j) - centre) * spacing;
+                    const float z = (static_cast<float>(k) - centre) * spacing;
+                    g_base_positions.push_back(core::math::vec3{x, y, z});
 
-                // Tint each cube by its grid position for a colour gradient.
-                const auto r = static_cast<uint8_t>(40 + (215 * i) / (grid_side - 1));
-                const auto b = static_cast<uint8_t>(40 + (215 * j) / (grid_side - 1));
-                g_cubes->set_instance_color(index, rendering_engine::util::color{r, 80, b, 255});
+                    // Tint each cube by its lattice cell for an RGB gradient.
+                    const auto r = static_cast<uint8_t>(40 + (215 * i) / (grid_side - 1));
+                    const auto g = static_cast<uint8_t>(40 + (215 * j) / (grid_side - 1));
+                    const auto b = static_cast<uint8_t>(40 + (215 * k) / (grid_side - 1));
+                    g_cubes->set_instance_color(index, rendering_engine::util::color{r, g, b, 255});
+                }
             }
         }
 
         runtime::current_engine().renderer->register_scene_renderable(g_cubes.get());
+        LOG_INF("instanced_demo_module: %u cubes in one instanced draw", instance_count);
     }
 
     void on_engine_stop(const core::engine_stop& event)
@@ -152,17 +159,17 @@ namespace
 
         g_time += static_cast<float>(get_delta_time()) / 1000.0f;
 
-        const core::math::vec3 spin_axis{0.0f, 0.0f, 1.0f};
+        const core::math::vec3 spin_axis{0.0f, 1.0f, 0.0f};
         const core::math::vec3 unit_scale{cube_scale, cube_scale, cube_scale};
         for (uint32_t index = 0; index < instance_count; ++index)
         {
             const core::math::vec3& base = g_base_positions[index];
-            // A travelling sine wave along the wall plus a per-cube spin,
-            // recomputed every frame to exercise the dynamic per-instance
-            // storage-buffer upload path.
-            const float phase = base.y + base.z;
-            const float bob = std::sin(g_time * 2.0f + phase) * 0.4f;
-            const core::math::vec3 position{base.x + bob, base.y, base.z};
+            // A travelling sine wave across the lattice plus a per-cube spin,
+            // recomputed every frame for all instances to exercise the
+            // dynamic per-instance storage-buffer upload path at scale.
+            const float phase = base.x + base.y + base.z;
+            const float bob = std::sin(g_time * 2.0f + phase) * 0.25f;
+            const core::math::vec3 position{base.x, base.y + bob, base.z};
             const float angle = g_time + phase;
 
             const core::math::mat4 model =

--- a/external/instanced_demo_module.cpp
+++ b/external/instanced_demo_module.cpp
@@ -46,9 +46,9 @@ namespace
     // the lattice is pushed forward along +X to sit in front of it.
     constexpr uint32_t grid_side = 16;
     constexpr uint32_t instance_count = grid_side * grid_side * grid_side; // 4096
-    constexpr float spacing = 0.7f;
-    constexpr float cube_scale = 0.32f;
-    constexpr float forward_offset = 2.0f;
+    constexpr float spacing = 0.6f;
+    constexpr float cube_scale = 0.3f;
+    constexpr float forward_offset = 8.0f;
 
     std::unique_ptr<rendering_engine::instanced_mesh> g_cubes;
     std::vector<core::math::vec3> g_base_positions;

--- a/rendering_engine/CMakeLists.txt
+++ b/rendering_engine/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(AlphaEngine PRIVATE
+    render_stats.hpp
     rendering_engine.cpp
     rendering_engine.hpp
     window.cpp

--- a/rendering_engine/debug_ui/imgui_layer.cpp
+++ b/rendering_engine/debug_ui/imgui_layer.cpp
@@ -45,6 +45,9 @@
 #include <rendering_engine/gpu/backend/vulkan/vk_resources.hpp>
 #include <rendering_engine/gpu/command_encoder.hpp>
 #include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/lighting/light.hpp>
+#include <rendering_engine/render_stats.hpp>
+#include <rendering_engine/rendering_engine.hpp>
 #include <rendering_engine/window.hpp>
 #include <runtime/engine.hpp>
 #include <SDL3/SDL.h>
@@ -76,6 +79,7 @@ namespace rendering_engine::debug_ui
         bool g_show_profiler = true;
         bool g_show_demo = false;
         bool g_show_helpers = true;
+        bool g_show_scene = true;
 
         // Rolling frame-time history (milliseconds) for the profiler
         // graph, used as a ring buffer.
@@ -145,6 +149,7 @@ namespace rendering_engine::debug_ui
                 if (ImGui::BeginPopupContextWindow())
                 {
                     ImGui::MenuItem("Profiler", nullptr, &g_show_profiler);
+                    ImGui::MenuItem("Scene", nullptr, &g_show_scene);
                     ImGui::MenuItem("Settings", nullptr, &g_show_settings);
                     ImGui::MenuItem("Helpers", nullptr, &g_show_helpers);
                     ImGui::MenuItem("ImGui demo", nullptr, &g_show_demo);
@@ -198,6 +203,64 @@ namespace rendering_engine::debug_ui
                 ImGui::Text("min %.2f ms", static_cast<double>(min_ms));
                 ImGui::SameLine();
                 ImGui::Text("max %.2f ms", static_cast<double>(max_ms));
+            }
+            ImGui::End();
+        }
+
+        // Scene statistics: how much geometry the scene pass submitted last
+        // frame (models, draw calls, instances, triangles, vertices) plus a
+        // breakdown of the live lights by type. The geometry figures come
+        // from the renderer's per-frame @ref render_stats; the light counts
+        // are read live from the lighting registry.
+        void draw_scene_window()
+        {
+            if (!g_show_scene)
+            {
+                return;
+            }
+
+            const auto& stats = runtime::current_engine().renderer->get_render_stats();
+
+            uint32_t ambient = 0;
+            uint32_t directional = 0;
+            uint32_t point = 0;
+            const auto& lights = registered_lights();
+            for (const auto* source : lights)
+            {
+                switch (source->type())
+                {
+                case light_type::ambient:
+                    ++ambient;
+                    break;
+                case light_type::directional:
+                    ++directional;
+                    break;
+                case light_type::point:
+                    ++point;
+                    break;
+                }
+            }
+
+            ImGui::SetNextWindowSize(ImVec2{300.0f, 0.0f}, ImGuiCond_FirstUseEver);
+            if (ImGui::Begin("Scene", &g_show_scene))
+            {
+                ImGui::SeparatorText("Geometry");
+                ImGui::Text("Models in scene: %u", stats.scene_renderables);
+                ImGui::Text("Models rendered: %u", stats.draw_calls);
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("No frustum culling yet — every registered model is drawn.");
+                }
+                ImGui::Text("Draw calls: %u", stats.draw_calls);
+                ImGui::Text("Instances: %u", stats.instances);
+                ImGui::Text("Triangles: %llu", static_cast<unsigned long long>(stats.triangles));
+                ImGui::Text("Vertices: %llu", static_cast<unsigned long long>(stats.vertices));
+
+                ImGui::SeparatorText("Lights");
+                ImGui::Text("Total: %zu", lights.size());
+                ImGui::Text("Ambient: %u", ambient);
+                ImGui::Text("Directional: %u", directional);
+                ImGui::Text("Point: %u", point);
             }
             ImGui::End();
         }
@@ -297,6 +360,7 @@ namespace rendering_engine::debug_ui
 
             draw_fps_overlay();
             draw_profiler_window();
+            draw_scene_window();
             draw_settings_window();
             draw_helpers_window();
             if (g_show_demo)

--- a/rendering_engine/gpu/backend/opengl/gl_command_encoder.cpp
+++ b/rendering_engine/gpu/backend/opengl/gl_command_encoder.cpp
@@ -271,6 +271,11 @@ namespace rendering_engine::gpu::backend::opengl
 
         const auto& layout = pipe->vertex_buffers[slot];
         const uint32_t stride = stride_override != 0 ? stride_override : layout.stride;
+        // Per-instance slots advance once per instance (divisor 1) instead
+        // of once per vertex, so a single record drives a whole instanced
+        // draw copy. The divisor is VAO state, so it is set alongside the
+        // attribute pointer here.
+        const GLuint divisor = layout.step_mode == vertex_step_mode::instance ? 1u : 0u;
         for (const auto& attribute : layout.attributes)
         {
             const GLsizeiptr final_offset = static_cast<GLsizeiptr>(offset + attribute.offset);
@@ -281,6 +286,7 @@ namespace rendering_engine::gpu::backend::opengl
                                   GL_FALSE,
                                   static_cast<GLsizei>(stride),
                                   reinterpret_cast<const GLvoid*>(final_offset));
+            glVertexAttribDivisor(attribute.location, divisor);
         }
     }
 

--- a/rendering_engine/gpu/backend/vulkan/vk_device_pipeline.cpp
+++ b/rendering_engine/gpu/backend/vulkan/vk_device_pipeline.cpp
@@ -206,7 +206,8 @@ namespace rendering_engine::gpu::backend::vulkan
                 VkVertexInputBindingDescription bd{};
                 bd.binding = slot;
                 bd.stride = vbl.stride;
-                bd.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+                bd.inputRate = vbl.step_mode == vertex_step_mode::instance ? VK_VERTEX_INPUT_RATE_INSTANCE
+                                                                           : VK_VERTEX_INPUT_RATE_VERTEX;
                 vk_bindings.push_back(bd);
                 for (const auto& attr : vbl.attributes)
                 {

--- a/rendering_engine/gpu/shader.hpp
+++ b/rendering_engine/gpu/shader.hpp
@@ -62,12 +62,24 @@ namespace rendering_engine::gpu
         uint32_t offset{0};
     };
 
+    // How a vertex buffer slot advances through its attributes. @c vertex
+    // steps once per vertex (the default); @c instance steps once per
+    // instance, so a single record feeds every vertex of one instanced
+    // draw copy. Maps to @c glVertexAttribDivisor (0 / 1) on the OpenGL
+    // backend and to @c VkVertexInputRate on Vulkan.
+    enum class vertex_step_mode
+    {
+        vertex,
+        instance,
+    };
+
     // Layout of one vertex buffer slot fed into a pipeline. The
     // pipeline references its layouts by index; the runtime
     // @c set_vertex_buffer call binds a buffer to the same slot.
     struct vertex_buffer_layout
     {
         uint32_t stride{0};
+        vertex_step_mode step_mode{vertex_step_mode::vertex};
         std::vector<vertex_attribute> attributes;
     };
 } // namespace rendering_engine::gpu

--- a/rendering_engine/materials/CMakeLists.txt
+++ b/rendering_engine/materials/CMakeLists.txt
@@ -3,6 +3,8 @@ target_sources(AlphaEngine PRIVATE
     basic_material.hpp
     grid_material.cpp
     grid_material.hpp
+    instanced_material.cpp
+    instanced_material.hpp
     line_material.cpp
     line_material.hpp
     material.cpp

--- a/rendering_engine/materials/instanced_material.cpp
+++ b/rendering_engine/materials/instanced_material.cpp
@@ -34,24 +34,32 @@ namespace
     // Binding numbers. UBOs share a single namespace across every
     // descriptor set on the OpenGL backend (ARB_gl_spirv), so they must
     // stay globally unique: the scene_pass owns camera = 0 (and lights = 2)
-    // in the per-frame set, leaving 3 for the per-material tint block. The
-    // per-instance data lives in a storage buffer, whose binding namespace
-    // is disjoint from the UBO one, so it can reuse binding 1.
-    constexpr uint32_t instance_buffer_binding = rendering_engine::instanced_material::instance_buffer_binding;
+    // in the per-frame set, leaving 3 for the per-material tint block.
     constexpr uint32_t material_params_binding = 3;
 
     // std140 layout for the per-material params UBO: a single vec4 tint,
     // 16 bytes.
     constexpr size_t material_ubo_size = 4 * sizeof(float);
 
-    // The vertex shader reads the per-instance model matrix and tint from a
-    // storage buffer indexed by gl_InstanceIndex. The std430 record is a
-    // mat4 (64 bytes) followed by a vec4 (16 bytes); @ref instanced_mesh
-    // uploads a matching POD array.
+    // Per-instance vertex attribute locations. Location 0 is the shared
+    // geometry position; the model matrix occupies four consecutive vec4
+    // slots (one per column) and the tint follows.
+    constexpr uint32_t position_location = 0;
+    constexpr uint32_t model_column0_location = 1;
+    constexpr uint32_t instance_color_location = 5;
+
+    // The model matrix and colour arrive as ordinary vertex attributes from
+    // a per-instance stream (divisor 1), so the path does not depend on
+    // gl_InstanceIndex behaving across the SPIR-V -> GL translation.
     const std::string vertex_shader = R"vs(
         #version 450
 
         layout(location = 0) in vec3 position;
+        layout(location = 1) in vec4 model0;
+        layout(location = 2) in vec4 model1;
+        layout(location = 3) in vec4 model2;
+        layout(location = 4) in vec4 model3;
+        layout(location = 5) in vec4 instanceTint;
 
         layout(location = 0) out vec4 instanceColor;
 
@@ -61,23 +69,11 @@ namespace
             mat4 projectionMatrix;
         } u_frame;
 
-        struct instance_data
-        {
-            mat4 model;
-            vec4 color;
-        };
-
-        layout(set = 1, binding = 1, std430) readonly buffer Instances
-        {
-            instance_data instances[];
-        } u_instances;
-
         void main()
         {
-            instance_data inst = u_instances.instances[gl_InstanceIndex];
-            instanceColor = inst.color;
-            mat4 MVP = u_frame.projectionMatrix * u_frame.viewMatrix * inst.model;
-            gl_Position = MVP * vec4(position, 1.0);
+            mat4 model = mat4(model0, model1, model2, model3);
+            instanceColor = instanceTint;
+            gl_Position = u_frame.projectionMatrix * u_frame.viewMatrix * model * vec4(position, 1.0);
         }
 )vs";
 
@@ -103,17 +99,30 @@ namespace rendering_engine
 {
     instanced_material::instanced_material(gpu::bind_group_layout frame_layout)
     {
-        gpu::vertex_buffer_layout vertex_layout{};
-        // Stride = 0 — the per-instance stride is supplied at
-        // set_vertex_buffer time. Only the position is consumed; any
-        // uv / normal channels in the shared geometry are ignored.
-        vertex_layout.stride = 0;
-        vertex_layout.attributes.push_back({0, 3, gpu::scalar_type::float32, 0});
+        // Slot 0: the shared geometry stream. Stride 0 — the per-renderable
+        // stride is supplied at set_vertex_buffer time. Only the position is
+        // consumed; any uv / normal channels in the geometry are ignored.
+        gpu::vertex_buffer_layout geometry_layout{};
+        geometry_layout.stride = 0;
+        geometry_layout.step_mode = gpu::vertex_step_mode::vertex;
+        geometry_layout.attributes.push_back({position_location, 3, gpu::scalar_type::float32, 0});
 
-        // Per-draw layout (slot 1): the per-instance storage buffer at
-        // binding 1, matching the bind group @ref instanced_mesh builds.
+        // Slot 1: the per-instance stream (divisor 1). A mat4 model as four
+        // vec4 columns followed by a vec4 tint, matching the record
+        // @ref instanced_mesh uploads.
+        gpu::vertex_buffer_layout instance_layout{};
+        instance_layout.stride = instance_buffer_stride;
+        instance_layout.step_mode = gpu::vertex_step_mode::instance;
+        const auto vec4_size = static_cast<uint32_t>(4 * sizeof(float));
+        for (uint32_t column = 0; column < 4; ++column)
+        {
+            instance_layout.attributes.push_back(
+                {model_column0_location + column, 4, gpu::scalar_type::float32, column * vec4_size});
+        }
+        instance_layout.attributes.push_back({instance_color_location, 4, gpu::scalar_type::float32, 4 * vec4_size});
+
+        // No per-draw bind group: the per-instance data is a vertex stream.
         gpu::bind_group_layout_descriptor draw_layout{};
-        draw_layout.entries.push_back({instance_buffer_binding, gpu::binding_kind::storage_buffer});
 
         // Per-material layout (slot 2): the flat-tint UBO owned by this
         // material.
@@ -126,8 +135,13 @@ namespace rendering_engine
         params.depth_test = true;
         params.depth_write = true;
 
-        construct_pipeline(
-            vertex_shader, fragment_shader, vertex_layout, draw_layout, frame_layout, params, material_layout);
+        construct_pipeline(vertex_shader,
+                           fragment_shader,
+                           std::vector<gpu::vertex_buffer_layout>{geometry_layout, instance_layout},
+                           draw_layout,
+                           frame_layout,
+                           params,
+                           material_layout);
 
         gpu::buffer_descriptor ubo_descriptor{};
         ubo_descriptor.size = material_ubo_size;

--- a/rendering_engine/materials/instanced_material.cpp
+++ b/rendering_engine/materials/instanced_material.cpp
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/materials/instanced_material.hpp>
+
+#include <array>
+#include <string>
+
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <runtime/engine.hpp>
+
+namespace
+{
+    // Binding numbers. UBOs share a single namespace across every
+    // descriptor set on the OpenGL backend (ARB_gl_spirv), so they must
+    // stay globally unique: the scene_pass owns camera = 0 (and lights = 2)
+    // in the per-frame set, leaving 3 for the per-material tint block. The
+    // per-instance data lives in a storage buffer, whose binding namespace
+    // is disjoint from the UBO one, so it can reuse binding 1.
+    constexpr uint32_t instance_buffer_binding = rendering_engine::instanced_material::instance_buffer_binding;
+    constexpr uint32_t material_params_binding = 3;
+
+    // std140 layout for the per-material params UBO: a single vec4 tint,
+    // 16 bytes.
+    constexpr size_t material_ubo_size = 4 * sizeof(float);
+
+    // The vertex shader reads the per-instance model matrix and tint from a
+    // storage buffer indexed by gl_InstanceIndex. The std430 record is a
+    // mat4 (64 bytes) followed by a vec4 (16 bytes); @ref instanced_mesh
+    // uploads a matching POD array.
+    const std::string vertex_shader = R"vs(
+        #version 450
+
+        layout(location = 0) in vec3 position;
+
+        layout(location = 0) out vec4 instanceColor;
+
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+        } u_frame;
+
+        struct instance_data
+        {
+            mat4 model;
+            vec4 color;
+        };
+
+        layout(set = 1, binding = 1, std430) readonly buffer Instances
+        {
+            instance_data instances[];
+        } u_instances;
+
+        void main()
+        {
+            instance_data inst = u_instances.instances[gl_InstanceIndex];
+            instanceColor = inst.color;
+            mat4 MVP = u_frame.projectionMatrix * u_frame.viewMatrix * inst.model;
+            gl_Position = MVP * vec4(position, 1.0);
+        }
+)vs";
+
+    const std::string fragment_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec4 instanceColor;
+        layout(location = 0) out vec4 fragColor;
+
+        layout(set = 2, binding = 3, std140) uniform Material
+        {
+            vec4 color;
+        } u_material;
+
+        void main()
+        {
+            fragColor = u_material.color * instanceColor;
+        }
+)fs";
+} // namespace
+
+namespace rendering_engine
+{
+    instanced_material::instanced_material(gpu::bind_group_layout frame_layout)
+    {
+        gpu::vertex_buffer_layout vertex_layout{};
+        // Stride = 0 — the per-instance stride is supplied at
+        // set_vertex_buffer time. Only the position is consumed; any
+        // uv / normal channels in the shared geometry are ignored.
+        vertex_layout.stride = 0;
+        vertex_layout.attributes.push_back({0, 3, gpu::scalar_type::float32, 0});
+
+        // Per-draw layout (slot 1): the per-instance storage buffer at
+        // binding 1, matching the bind group @ref instanced_mesh builds.
+        gpu::bind_group_layout_descriptor draw_layout{};
+        draw_layout.entries.push_back({instance_buffer_binding, gpu::binding_kind::storage_buffer});
+
+        // Per-material layout (slot 2): the flat-tint UBO owned by this
+        // material.
+        gpu::bind_group_layout_descriptor material_layout{};
+        material_layout.entries.push_back({material_params_binding, gpu::binding_kind::uniform_buffer});
+
+        // Opaque unlit surface: depth tested and written, no blending.
+        material_params params{};
+        params.transparent = false;
+        params.depth_test = true;
+        params.depth_write = true;
+
+        construct_pipeline(
+            vertex_shader, fragment_shader, vertex_layout, draw_layout, frame_layout, params, material_layout);
+
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = material_ubo_size;
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        auto& gpu = *runtime::current_engine().gpu;
+        m_material_ubo = gpu.create_buffer(ubo_descriptor);
+
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_per_material_layout;
+        gpu::binding_value ubo_slot{};
+        ubo_slot.binding = material_params_binding;
+        ubo_slot.kind = gpu::binding_kind::uniform_buffer;
+        ubo_slot.buffer_value = m_material_ubo;
+        bg_descriptor.entries.push_back(ubo_slot);
+        m_per_material_bind_group = gpu.create_bind_group(bg_descriptor);
+
+        upload_params();
+    }
+
+    instanced_material::~instanced_material()
+    {
+        // Drop the bind group before the buffer it references, then null
+        // it so the base destructor's destruct_pipeline does not double-free.
+        auto& gpu = *runtime::current_engine().gpu;
+        if (m_per_material_bind_group.valid())
+        {
+            gpu.destroy(m_per_material_bind_group);
+            m_per_material_bind_group = {};
+        }
+        if (m_material_ubo.valid())
+        {
+            gpu.destroy(m_material_ubo);
+            m_material_ubo = {};
+        }
+    }
+
+    uint32_t instanced_material::per_material_slot() const
+    {
+        return per_draw_slot() + 1u;
+    }
+
+    void instanced_material::set_color(const util::color& color)
+    {
+        m_color = color;
+        upload_params();
+    }
+
+    void instanced_material::upload_params()
+    {
+        std::array<float, 4> payload{};
+        payload[0] = static_cast<float>(m_color.r) / 255.0f;
+        payload[1] = static_cast<float>(m_color.g) / 255.0f;
+        payload[2] = static_cast<float>(m_color.b) / 255.0f;
+        payload[3] = static_cast<float>(m_color.a) / 255.0f;
+
+        auto& gpu = *runtime::current_engine().gpu;
+        gpu.write_buffer(m_material_ubo, payload.data(), material_ubo_size, 0);
+    }
+} // namespace rendering_engine

--- a/rendering_engine/materials/instanced_material.hpp
+++ b/rendering_engine/materials/instanced_material.hpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine
+{
+    // Built-in unlit material for @ref instanced_mesh. Position+UV vertex
+    // stream like @ref basic_material, but the model matrix and per-instance
+    // tint come from a per-draw storage buffer indexed by @c gl_InstanceIndex
+    // rather than a single per-draw model UBO — so one draw paints every
+    // instance with its own transform and colour.
+    //
+    // Slot layout: the per-frame group at slot 0 (camera, owned by the
+    // @ref scene_pass), the per-draw group at slot 1 (the per-instance
+    // storage buffer, built by @ref instanced_mesh), and the per-material
+    // group at slot 2 (a flat tint multiplied onto every instance, owned
+    // by this material).
+    //
+    // The per-draw bind group must carry a @c storage_buffer of
+    // @ref instanced_mesh records at @ref instance_buffer_binding; only
+    // @ref instanced_mesh produces a matching group, so this material is
+    // meant to be fronted by it.
+    struct instanced_material : public material
+    {
+        // @p frame_layout is the per-frame bind-group layout owned by the
+        // @ref scene_pass; it must match the layout the pass binds at slot
+        // 0 every frame so the pipeline and the runtime bind group agree.
+        explicit instanced_material(gpu::bind_group_layout frame_layout);
+        ~instanced_material() override;
+
+        // Per-draw storage-buffer binding the instance records live at.
+        // Exposed so @ref instanced_mesh builds its bind group against the
+        // same number this material's pipeline expects.
+        static constexpr uint32_t instance_buffer_binding = 1;
+
+        // Flat tint multiplied onto every instance's own colour (white
+        // leaves the per-instance colours unchanged).
+        void set_color(const util::color& color);
+
+        // The per-material group trails the per-frame and per-draw groups,
+        // so it occupies slot 2 (per-frame at 0, per-draw at 1).
+        uint32_t per_material_slot() const override;
+
+    private:
+        // Push the tint into the per-material UBO.
+        void upload_params();
+
+        util::color m_color{255, 255, 255, 255};
+        gpu::buffer m_material_ubo{};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/materials/instanced_material.hpp
+++ b/rendering_engine/materials/instanced_material.hpp
@@ -22,28 +22,32 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <rendering_engine/gpu/handle.hpp>
 #include <rendering_engine/materials/material.hpp>
 #include <rendering_engine/util/color.hpp>
 
 namespace rendering_engine
 {
-    // Built-in unlit material for @ref instanced_mesh. Position+UV vertex
+    // Built-in unlit material for @ref instanced_mesh. Position vertex
     // stream like @ref basic_material, but the model matrix and per-instance
-    // tint come from a per-draw storage buffer indexed by @c gl_InstanceIndex
-    // rather than a single per-draw model UBO — so one draw paints every
-    // instance with its own transform and colour.
+    // tint come from a second, per-instance vertex stream (bound at slot 1)
+    // rather than a per-draw model UBO — so one draw paints every instance
+    // with its own transform and colour.
     //
-    // Slot layout: the per-frame group at slot 0 (camera, owned by the
-    // @ref scene_pass), the per-draw group at slot 1 (the per-instance
-    // storage buffer, built by @ref instanced_mesh), and the per-material
-    // group at slot 2 (a flat tint multiplied onto every instance, owned
-    // by this material).
+    // The per-instance stream is a tightly packed record of a @c mat4 model
+    // (four @c vec4 columns at locations 1..4) followed by a @c vec4 colour
+    // (location 5); see @ref instance_buffer_stride. It is fed through
+    // @c glVertexAttribDivisor / @c VK_VERTEX_INPUT_RATE_INSTANCE instead of
+    // @c gl_InstanceIndex, which keeps the path portable across the OpenGL
+    // (ARB_gl_spirv) and Vulkan backends. @ref instanced_mesh builds a
+    // matching buffer; this material is meant to be fronted by it.
     //
-    // The per-draw bind group must carry a @c storage_buffer of
-    // @ref instanced_mesh records at @ref instance_buffer_binding; only
-    // @ref instanced_mesh produces a matching group, so this material is
-    // meant to be fronted by it.
+    // Slot layout: per-frame group at slot 0 (camera, owned by the
+    // @ref scene_pass) and the per-material group at slot 2 (a flat tint
+    // multiplied onto every instance, owned by this material). The per-draw
+    // group (slot 1) is unused.
     struct instanced_material : public material
     {
         // @p frame_layout is the per-frame bind-group layout owned by the
@@ -52,10 +56,10 @@ namespace rendering_engine
         explicit instanced_material(gpu::bind_group_layout frame_layout);
         ~instanced_material() override;
 
-        // Per-draw storage-buffer binding the instance records live at.
-        // Exposed so @ref instanced_mesh builds its bind group against the
-        // same number this material's pipeline expects.
-        static constexpr uint32_t instance_buffer_binding = 1;
+        // Byte stride of one per-instance record: a mat4 model (64 bytes)
+        // followed by a vec4 colour (16 bytes). @ref instanced_mesh lays out
+        // its instance buffer to match.
+        static constexpr uint32_t instance_buffer_stride = 16u * sizeof(float) + 4u * sizeof(float);
 
         // Flat tint multiplied onto every instance's own colour (white
         // leaves the per-instance colours unchanged).

--- a/rendering_engine/materials/material.cpp
+++ b/rendering_engine/materials/material.cpp
@@ -130,10 +130,29 @@ namespace rendering_engine
                                       const gpu::bind_group_layout_descriptor& material_layout,
                                       gpu::primitive_topology topology)
     {
+        construct_pipeline(vertex_source,
+                           fragment_source,
+                           std::vector<gpu::vertex_buffer_layout>{vertex_layout},
+                           draw_layout,
+                           frame_layout,
+                           params,
+                           material_layout,
+                           topology);
+    }
+
+    void material::construct_pipeline(const std::string& vertex_source,
+                                      const std::string& fragment_source,
+                                      const std::vector<gpu::vertex_buffer_layout>& vertex_layouts,
+                                      const gpu::bind_group_layout_descriptor& draw_layout,
+                                      gpu::bind_group_layout frame_layout,
+                                      const material_params& params,
+                                      const gpu::bind_group_layout_descriptor& material_layout,
+                                      gpu::primitive_topology topology)
+    {
         m_params = params;
         construct_pipeline(vertex_source,
                            fragment_source,
-                           vertex_layout,
+                           vertex_layouts,
                            draw_layout,
                            frame_layout,
                            to_depth_state(params),
@@ -146,6 +165,29 @@ namespace rendering_engine
     void material::construct_pipeline(const std::string& vertex_source,
                                       const std::string& fragment_source,
                                       const gpu::vertex_buffer_layout& vertex_layout,
+                                      const gpu::bind_group_layout_descriptor& draw_layout,
+                                      gpu::bind_group_layout frame_layout,
+                                      const gpu::depth_state& depth,
+                                      const gpu::blend_state& blend,
+                                      const gpu::rasterizer_state& rasterizer,
+                                      const gpu::bind_group_layout_descriptor& material_layout,
+                                      gpu::primitive_topology topology)
+    {
+        construct_pipeline(vertex_source,
+                           fragment_source,
+                           std::vector<gpu::vertex_buffer_layout>{vertex_layout},
+                           draw_layout,
+                           frame_layout,
+                           depth,
+                           blend,
+                           rasterizer,
+                           material_layout,
+                           topology);
+    }
+
+    void material::construct_pipeline(const std::string& vertex_source,
+                                      const std::string& fragment_source,
+                                      const std::vector<gpu::vertex_buffer_layout>& vertex_layouts,
                                       const gpu::bind_group_layout_descriptor& draw_layout,
                                       gpu::bind_group_layout frame_layout,
                                       const gpu::depth_state& depth,
@@ -182,7 +224,7 @@ namespace rendering_engine
         gpu::pipeline_descriptor pipeline_descriptor{};
         pipeline_descriptor.vertex_shader = m_vertex_shader;
         pipeline_descriptor.fragment_shader = m_fragment_shader;
-        pipeline_descriptor.vertex_buffers.push_back(vertex_layout);
+        pipeline_descriptor.vertex_buffers = vertex_layouts;
         pipeline_descriptor.topology = topology;
         pipeline_descriptor.depth = depth;
         pipeline_descriptor.blend = blend;

--- a/rendering_engine/materials/material.hpp
+++ b/rendering_engine/materials/material.hpp
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include <rendering_engine/gpu/bind_group.hpp>
 #include <rendering_engine/gpu/handle.hpp>
@@ -153,6 +154,20 @@ namespace rendering_engine
                                 const gpu::bind_group_layout_descriptor& material_layout = {},
                                 gpu::primitive_topology topology = gpu::primitive_topology::triangles);
 
+        // Multi-stream variant: each entry of @p vertex_layouts becomes a
+        // vertex buffer slot in declaration order, so a material can mix a
+        // per-vertex geometry stream with a per-instance stream (see
+        // @ref instanced_material). Otherwise identical to the single-layout
+        // overload above.
+        void construct_pipeline(const std::string& vertex_source,
+                                const std::string& fragment_source,
+                                const std::vector<gpu::vertex_buffer_layout>& vertex_layouts,
+                                const gpu::bind_group_layout_descriptor& draw_layout,
+                                gpu::bind_group_layout frame_layout,
+                                const material_params& params,
+                                const gpu::bind_group_layout_descriptor& material_layout = {},
+                                gpu::primitive_topology topology = gpu::primitive_topology::triangles);
+
         // Build the pipeline + per-draw layout from source. When
         // @p frame_layout is valid, slot 0 is reserved for a
         // per-frame bind group owned by the corresponding pass and
@@ -164,6 +179,19 @@ namespace rendering_engine
         void construct_pipeline(const std::string& vertex_source,
                                 const std::string& fragment_source,
                                 const gpu::vertex_buffer_layout& vertex_layout,
+                                const gpu::bind_group_layout_descriptor& draw_layout,
+                                gpu::bind_group_layout frame_layout,
+                                const gpu::depth_state& depth,
+                                const gpu::blend_state& blend,
+                                const gpu::rasterizer_state& rasterizer,
+                                const gpu::bind_group_layout_descriptor& material_layout = {},
+                                gpu::primitive_topology topology = gpu::primitive_topology::triangles);
+
+        // Multi-stream variant of the explicit-state overload; see the
+        // multi-stream @ref construct_pipeline above.
+        void construct_pipeline(const std::string& vertex_source,
+                                const std::string& fragment_source,
+                                const std::vector<gpu::vertex_buffer_layout>& vertex_layouts,
                                 const gpu::bind_group_layout_descriptor& draw_layout,
                                 gpu::bind_group_layout frame_layout,
                                 const gpu::depth_state& depth,

--- a/rendering_engine/passes/point_shadow_pass.cpp
+++ b/rendering_engine/passes/point_shadow_pass.cpp
@@ -358,6 +358,14 @@ namespace rendering_engine
 
             for (const auto& item : m_items)
             {
+                // Instanced renderables keep their transforms in a per-draw
+                // storage buffer the depth-only pipeline can't read, so they
+                // don't cast omni shadows yet — skip them rather than emit a
+                // single garbage caster from the unbound model UBO.
+                if (item.indirect_buffer.valid())
+                {
+                    continue;
+                }
                 pass_encoder->set_bind_group(1, item.per_draw_bind_group);
                 pass_encoder->set_vertex_buffer(0, item.vertex_buffer, 0, item.vertex_stride);
                 if (item.index_buffer.valid())

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -356,7 +356,16 @@ namespace rendering_engine
             if (item.index_buffer.valid())
             {
                 pass_encoder->set_index_buffer(item.index_buffer, item.index_format);
-                pass_encoder->draw_indexed(item.index_count, 0);
+                if (item.indirect_buffer.valid())
+                {
+                    // Instanced draw: index and instance counts come from
+                    // the indirect command record (see @ref instanced_mesh).
+                    pass_encoder->draw_indexed_indirect(item.indirect_buffer, 0);
+                }
+                else
+                {
+                    pass_encoder->draw_indexed(item.index_count, 0);
+                }
             }
             else
             {

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -88,8 +88,11 @@ namespace rendering_engine
             point_shadow_face_count * sizeof(core::math::mat4) + 2 * 4 * sizeof(float);
     } // namespace
 
-    scene_pass::scene_pass(std::vector<renderable*>* registry, shadow_pass* shadow, point_shadow_pass* point_shadow)
-        : m_registry(registry), m_shadow(shadow), m_point_shadow(point_shadow)
+    scene_pass::scene_pass(std::vector<renderable*>* registry,
+                           shadow_pass* shadow,
+                           point_shadow_pass* point_shadow,
+                           render_stats* stats)
+        : m_registry(registry), m_shadow(shadow), m_point_shadow(point_shadow), m_stats(stats)
     {
         auto& gpu = *runtime::current_engine().gpu;
 
@@ -232,6 +235,15 @@ namespace rendering_engine
         auto& eng = runtime::current_engine();
         auto& gpu = *eng.gpu;
 
+        // Reset this frame's stats up front. The renderable count is known
+        // regardless of whether a camera is attached; the draw totals stay
+        // zero on no-camera frames (nothing is collected below).
+        if (m_stats != nullptr)
+        {
+            *m_stats = render_stats{};
+            m_stats->scene_renderables = static_cast<uint32_t>(m_registry->size());
+        }
+
         // Render into the HDR scene-colour target so the post chain
         // can sample real luminance. The tonemap post pass maps the
         // result onto the swapchain before the UI composites.
@@ -324,6 +336,23 @@ namespace rendering_engine
                          m_items.end(),
                          [](const draw_item& a, const draw_item& b)
                          { return a.mat->pipeline().id < b.mat->pipeline().id; });
+
+        // Tally this frame's draw statistics for the debug overlay. Each
+        // item is one draw call; triangle / vertex counts scale by the
+        // item's instance count. Indexed draws count index_count vertices
+        // (vertices fetched), non-indexed count vertex_count.
+        if (m_stats != nullptr)
+        {
+            m_stats->draw_calls = static_cast<uint32_t>(m_items.size());
+            for (const auto& item : m_items)
+            {
+                const uint32_t instances = item.instance_count == 0 ? 1u : item.instance_count;
+                const uint32_t verts = item.index_buffer.valid() ? item.index_count : item.vertex_count;
+                m_stats->instances += instances;
+                m_stats->vertices += static_cast<uint64_t>(verts) * instances;
+                m_stats->triangles += static_cast<uint64_t>(verts / 3u) * instances;
+            }
+        }
 
         uint64_t last_pipeline_id = 0;
         bool first_iter = true;

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -351,8 +351,18 @@ namespace rendering_engine
                 last_pipeline_id = pid;
             }
 
-            pass_encoder->set_bind_group(item.mat->per_draw_slot(), item.per_draw_bind_group);
+            // Instanced renderables keep their per-instance data in a
+            // vertex stream (slot 1), not a per-draw bind group, so the
+            // per-draw group is optional.
+            if (item.per_draw_bind_group.valid())
+            {
+                pass_encoder->set_bind_group(item.mat->per_draw_slot(), item.per_draw_bind_group);
+            }
             pass_encoder->set_vertex_buffer(0, item.vertex_buffer, 0, item.vertex_stride);
+            if (item.instance_buffer.valid())
+            {
+                pass_encoder->set_vertex_buffer(1, item.instance_buffer, 0, item.instance_stride);
+            }
             if (item.index_buffer.valid())
             {
                 pass_encoder->set_index_buffer(item.index_buffer, item.index_format);

--- a/rendering_engine/passes/scene_pass.hpp
+++ b/rendering_engine/passes/scene_pass.hpp
@@ -26,6 +26,7 @@
 
 #include <rendering_engine/gpu/handle.hpp>
 #include <rendering_engine/passes/pass.hpp>
+#include <rendering_engine/render_stats.hpp>
 #include <rendering_engine/renderables/draw_item.hpp>
 
 namespace rendering_engine
@@ -60,7 +61,13 @@ namespace rendering_engine
         // @p point_shadow is the omni shadow pass for the first shadow-casting
         // point light; its six depth maps are baked into the per-frame bind
         // group and its matrices uploaded each frame. May be null.
-        scene_pass(std::vector<renderable*>* registry, shadow_pass* shadow, point_shadow_pass* point_shadow);
+        // @p stats is filled with this frame's draw statistics each record();
+        // non-owning, owned by the engine context and surfaced to the debug
+        // overlay. May be null to disable stats collection.
+        scene_pass(std::vector<renderable*>* registry,
+                   shadow_pass* shadow,
+                   point_shadow_pass* point_shadow,
+                   render_stats* stats);
         ~scene_pass() override;
 
         scene_pass(const scene_pass&) = delete;
@@ -105,6 +112,11 @@ namespace rendering_engine
         // Null disables that kind of shadowing.
         shadow_pass* m_shadow{nullptr};
         point_shadow_pass* m_point_shadow{nullptr};
+
+        // Non-owning; filled each record() with this frame's draw stats.
+        // Owned by the engine context, which outlives the pass. Null
+        // disables collection.
+        render_stats* m_stats{nullptr};
 
         // Reused across frames so the underlying allocation persists.
         std::vector<draw_item> m_items;

--- a/rendering_engine/passes/shadow_pass.cpp
+++ b/rendering_engine/passes/shadow_pass.cpp
@@ -357,6 +357,14 @@ namespace rendering_engine
 
         for (const auto& item : m_items)
         {
+            // Instanced renderables carry their transforms in a per-draw
+            // storage buffer the depth-only pipeline can't consume, so
+            // they don't cast shadows yet — skip them rather than emit a
+            // single garbage caster from the unbound model UBO.
+            if (item.indirect_buffer.valid())
+            {
+                continue;
+            }
             pass_encoder->set_bind_group(1, item.per_draw_bind_group);
             pass_encoder->set_vertex_buffer(0, item.vertex_buffer, 0, item.vertex_stride);
             if (item.index_buffer.valid())

--- a/rendering_engine/render_stats.hpp
+++ b/rendering_engine/render_stats.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace rendering_engine
+{
+    // Per-frame scene / draw statistics, refreshed by the @ref scene_pass
+    // each frame and surfaced read-only through
+    // @ref context::get_render_stats (consumed by the debug overlay).
+    //
+    // There is no frustum culling yet, so @ref draw_calls equals one draw
+    // per submitted @ref draw_item — i.e. everything registered is drawn.
+    // The triangle / vertex counts are the geometry actually submitted to
+    // the pipeline this frame, multiplied through instancing.
+    struct render_stats
+    {
+        // Renderables registered with the scene-renderable registry.
+        uint32_t scene_renderables{0};
+
+        // Draw items submitted this frame (one GPU draw call each). A
+        // single renderable may emit more than one.
+        uint32_t draw_calls{0};
+
+        // Total instances drawn across every draw item (a non-instanced
+        // draw counts as one).
+        uint32_t instances{0};
+
+        // Triangles submitted this frame, counting instancing.
+        uint64_t triangles{0};
+
+        // Vertices submitted to the vertex stage this frame, counting
+        // instancing. For indexed draws this is the index count (vertices
+        // fetched), not the unique vertex-buffer size.
+        uint64_t vertices{0};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/CMakeLists.txt
+++ b/rendering_engine/renderables/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(AlphaEngine PRIVATE
     draw_item.hpp
+    instanced_mesh.cpp
+    instanced_mesh.hpp
     line.cpp
     line.hpp
     model.cpp

--- a/rendering_engine/renderables/draw_item.hpp
+++ b/rendering_engine/renderables/draw_item.hpp
@@ -45,16 +45,24 @@ namespace rendering_engine
     // record instead of from @ref index_count. This is how
     // @ref instanced_mesh emits a single instanced draw over shared
     // geometry; only the index path supports it.
+    //
+    // A valid @ref instance_buffer is bound to vertex slot 1 as the
+    // per-instance stream (one record per instanced draw copy, stepped
+    // by the pipeline's per-instance vertex layout); @ref instance_stride
+    // is its record size. Used together with @ref indirect_buffer by
+    // @ref instanced_mesh.
     struct draw_item
     {
         material* mat{nullptr};
         gpu::buffer vertex_buffer{};
         gpu::buffer index_buffer{};
         gpu::buffer indirect_buffer{};
+        gpu::buffer instance_buffer{};
         gpu::bind_group per_draw_bind_group{};
         uint32_t vertex_count{0};
         uint32_t index_count{0};
         uint32_t vertex_stride{0};
+        uint32_t instance_stride{0};
         gpu::index_format index_format{gpu::index_format::uint32};
     };
 } // namespace rendering_engine

--- a/rendering_engine/renderables/draw_item.hpp
+++ b/rendering_engine/renderables/draw_item.hpp
@@ -63,6 +63,10 @@ namespace rendering_engine
         uint32_t index_count{0};
         uint32_t vertex_stride{0};
         uint32_t instance_stride{0};
+        // Instances drawn by this item. 1 for ordinary draws; instanced
+        // renderables set the count carried in their indirect command so
+        // render-stats accounting matches what the GPU draws.
+        uint32_t instance_count{1};
         gpu::index_format index_format{gpu::index_format::uint32};
     };
 } // namespace rendering_engine

--- a/rendering_engine/renderables/draw_item.hpp
+++ b/rendering_engine/renderables/draw_item.hpp
@@ -37,11 +37,20 @@ namespace rendering_engine
     // @c set_pipeline only when the pipeline changes. An invalid
     // @ref index_buffer means non-indexed draw — the pass calls
     // @c draw(vertex_count) instead of @c draw_indexed(index_count).
+    //
+    // A valid @ref indirect_buffer turns the indexed draw into an
+    // indexed *indirect* draw: the pass binds the index buffer and
+    // calls @c draw_indexed_indirect, sourcing the index count and the
+    // instance count from the buffer's @c DrawElementsIndirectCommand
+    // record instead of from @ref index_count. This is how
+    // @ref instanced_mesh emits a single instanced draw over shared
+    // geometry; only the index path supports it.
     struct draw_item
     {
         material* mat{nullptr};
         gpu::buffer vertex_buffer{};
         gpu::buffer index_buffer{};
+        gpu::buffer indirect_buffer{};
         gpu::bind_group per_draw_bind_group{};
         uint32_t vertex_count{0};
         uint32_t index_count{0};

--- a/rendering_engine/renderables/instanced_mesh.cpp
+++ b/rendering_engine/renderables/instanced_mesh.cpp
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/renderables/instanced_mesh.hpp>
+
+#include <array>
+#include <cstdint>
+
+#include <core/log.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/materials/instanced_material.hpp>
+#include <rendering_engine/materials/material.hpp>
+#include <runtime/engine.hpp>
+
+namespace
+{
+    // A DrawElementsIndirectCommand record: index count, instance count,
+    // first index, base vertex, base instance. Mirrors GL's
+    // @c glDrawElementsIndirect struct and Vulkan's
+    // @c VkDrawIndexedIndirectCommand, the five-uint32 shape the device's
+    // @c draw_indexed_indirect documents.
+    constexpr size_t indirect_command_uints = 5;
+    constexpr size_t indirect_command_size = indirect_command_uints * sizeof(uint32_t);
+} // namespace
+
+rendering_engine::instanced_mesh::instanced_mesh(material* mat, uint32_t instance_count)
+    : m_material{mat}, m_capacity{instance_count}, m_instance_count{instance_count}, m_instances(instance_count)
+{
+}
+
+rendering_engine::instanced_mesh::~instanced_mesh()
+{
+    auto& gpu = *runtime::current_engine().gpu;
+    if (m_draw_bind_group.valid())
+    {
+        gpu.destroy(m_draw_bind_group);
+        m_draw_bind_group = {};
+    }
+    if (m_indirect_buffer.valid())
+    {
+        gpu.destroy(m_indirect_buffer);
+        m_indirect_buffer = {};
+    }
+    if (m_instance_buffer.valid())
+    {
+        gpu.destroy(m_instance_buffer);
+        m_instance_buffer = {};
+    }
+    if (m_index_buffer.valid())
+    {
+        gpu.destroy(m_index_buffer);
+        m_index_buffer = {};
+    }
+    if (m_vertex_buffer.valid())
+    {
+        gpu.destroy(m_vertex_buffer);
+        m_vertex_buffer = {};
+    }
+}
+
+void rendering_engine::instanced_mesh::upload_geometry(const std::vector<vertex_position_uv_normal>& vertices,
+                                                       const std::vector<uint32_t>& indices)
+{
+    if (vertices.empty() || indices.empty())
+    {
+        LOG_WRN("instanced_mesh::upload_geometry: empty geometry");
+        return;
+    }
+
+    m_index_count = static_cast<uint32_t>(indices.size());
+    m_vertex_stride = sizeof(vertex_position_uv_normal);
+
+    auto& gpu = *runtime::current_engine().gpu;
+
+    gpu::buffer_descriptor vertex_descriptor{};
+    vertex_descriptor.size = vertices.size() * sizeof(vertex_position_uv_normal);
+    vertex_descriptor.usage = gpu::buffer_usage_vertex;
+    vertex_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    vertex_descriptor.initial_data = vertices.data();
+    m_vertex_buffer = gpu.create_buffer(vertex_descriptor);
+
+    gpu::buffer_descriptor index_descriptor{};
+    index_descriptor.size = indices.size() * sizeof(uint32_t);
+    index_descriptor.usage = gpu::buffer_usage_index;
+    index_descriptor.hint = gpu::buffer_usage_hint::static_data;
+    index_descriptor.initial_data = indices.data();
+    m_index_buffer = gpu.create_buffer(index_descriptor);
+}
+
+uint32_t rendering_engine::instanced_mesh::instance_capacity() const
+{
+    return m_capacity;
+}
+
+void rendering_engine::instanced_mesh::set_instance_count(uint32_t count)
+{
+    m_instance_count = count > m_capacity ? m_capacity : count;
+}
+
+uint32_t rendering_engine::instanced_mesh::instance_count() const
+{
+    return m_instance_count;
+}
+
+void rendering_engine::instanced_mesh::set_instance_transform(uint32_t index, const core::math::mat4& transform)
+{
+    if (index >= m_capacity)
+    {
+        LOG_WRN("instanced_mesh::set_instance_transform: index out of range");
+        return;
+    }
+    m_instances[index].model = transform;
+    m_instances_dirty = true;
+}
+
+void rendering_engine::instanced_mesh::set_instance_color(uint32_t index, const util::color& color)
+{
+    if (index >= m_capacity)
+    {
+        LOG_WRN("instanced_mesh::set_instance_color: index out of range");
+        return;
+    }
+    m_instances[index].color = core::math::vec4{static_cast<float>(color.r) / 255.0f,
+                                                static_cast<float>(color.g) / 255.0f,
+                                                static_cast<float>(color.b) / 255.0f,
+                                                static_cast<float>(color.a) / 255.0f};
+    m_instances_dirty = true;
+}
+
+void rendering_engine::instanced_mesh::collect_draw_items(std::vector<draw_item>& out)
+{
+    if (m_material == nullptr)
+    {
+        LOG_WRN("instanced_mesh::collect_draw_items: no material");
+        return;
+    }
+    if (!m_vertex_buffer.valid() || !m_index_buffer.valid())
+    {
+        return;
+    }
+    if (m_instance_count == 0 || m_capacity == 0)
+    {
+        return;
+    }
+
+    auto& gpu = *runtime::current_engine().gpu;
+
+    // Per-instance storage buffer: one {mat4 model; vec4 color;} record per
+    // instance, indexed by gl_InstanceIndex in the instanced material.
+    if (!m_instance_buffer.valid())
+    {
+        gpu::buffer_descriptor instance_descriptor{};
+        instance_descriptor.size = m_capacity * sizeof(instance_record);
+        instance_descriptor.usage = gpu::buffer_usage_storage | gpu::buffer_usage_copy_dst;
+        instance_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_instance_buffer = gpu.create_buffer(instance_descriptor);
+        m_instances_dirty = true;
+    }
+
+    // Indirect command buffer holding a single DrawElementsIndirectCommand;
+    // its instance-count field drives how many copies the one draw paints.
+    if (!m_indirect_buffer.valid())
+    {
+        gpu::buffer_descriptor indirect_descriptor{};
+        indirect_descriptor.size = indirect_command_size;
+        indirect_descriptor.usage = gpu::buffer_usage_indirect | gpu::buffer_usage_copy_dst;
+        indirect_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_indirect_buffer = gpu.create_buffer(indirect_descriptor);
+
+        const std::array<uint32_t, indirect_command_uints> command{m_index_count, m_instance_count, 0u, 0u, 0u};
+        gpu.write_buffer(m_indirect_buffer, command.data(), indirect_command_size, 0);
+        m_uploaded_instance_count = m_instance_count;
+    }
+
+    if (!m_draw_bind_group.valid())
+    {
+        gpu::bind_group_descriptor bg_descriptor{};
+        bg_descriptor.layout = m_material->per_draw_layout();
+        gpu::binding_value instance_slot{};
+        instance_slot.binding = instanced_material::instance_buffer_binding;
+        instance_slot.kind = gpu::binding_kind::storage_buffer;
+        instance_slot.buffer_value = m_instance_buffer;
+        bg_descriptor.entries.push_back(instance_slot);
+        m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
+    }
+
+    // Re-upload the whole per-instance array when any record changed. The
+    // full capacity is written so a later count increase never samples
+    // uninitialised storage.
+    if (m_instances_dirty)
+    {
+        gpu.write_buffer(m_instance_buffer, m_instances.data(), m_capacity * sizeof(instance_record), 0);
+        m_instances_dirty = false;
+    }
+
+    // Refresh only the instance-count field of the command when the active
+    // count changed (the index count is fixed by the geometry).
+    if (m_uploaded_instance_count != m_instance_count)
+    {
+        const std::array<uint32_t, indirect_command_uints> command{m_index_count, m_instance_count, 0u, 0u, 0u};
+        gpu.write_buffer(m_indirect_buffer, command.data(), indirect_command_size, 0);
+        m_uploaded_instance_count = m_instance_count;
+    }
+
+    draw_item item{};
+    item.mat = m_material;
+    item.vertex_buffer = m_vertex_buffer;
+    item.index_buffer = m_index_buffer;
+    item.indirect_buffer = m_indirect_buffer;
+    item.per_draw_bind_group = m_draw_bind_group;
+    item.index_count = m_index_count;
+    item.vertex_stride = m_vertex_stride;
+    out.push_back(item);
+}

--- a/rendering_engine/renderables/instanced_mesh.cpp
+++ b/rendering_engine/renderables/instanced_mesh.cpp
@@ -219,5 +219,6 @@ void rendering_engine::instanced_mesh::collect_draw_items(std::vector<draw_item>
     item.index_count = m_index_count;
     item.vertex_stride = m_vertex_stride;
     item.instance_stride = static_cast<uint32_t>(sizeof(instance_record));
+    item.instance_count = m_instance_count;
     out.push_back(item);
 }

--- a/rendering_engine/renderables/instanced_mesh.cpp
+++ b/rendering_engine/renderables/instanced_mesh.cpp
@@ -46,16 +46,15 @@ namespace
 rendering_engine::instanced_mesh::instanced_mesh(material* mat, uint32_t instance_count)
     : m_material{mat}, m_capacity{instance_count}, m_instance_count{instance_count}, m_instances(instance_count)
 {
+    // The per-instance record must match the stride the instanced material's
+    // slot-1 vertex layout was built with.
+    static_assert(sizeof(instance_record) == instanced_material::instance_buffer_stride,
+                  "instance_record layout must match instanced_material::instance_buffer_stride");
 }
 
 rendering_engine::instanced_mesh::~instanced_mesh()
 {
     auto& gpu = *runtime::current_engine().gpu;
-    if (m_draw_bind_group.valid())
-    {
-        gpu.destroy(m_draw_bind_group);
-        m_draw_bind_group = {};
-    }
     if (m_indirect_buffer.valid())
     {
         gpu.destroy(m_indirect_buffer);
@@ -165,13 +164,14 @@ void rendering_engine::instanced_mesh::collect_draw_items(std::vector<draw_item>
 
     auto& gpu = *runtime::current_engine().gpu;
 
-    // Per-instance storage buffer: one {mat4 model; vec4 color;} record per
-    // instance, indexed by gl_InstanceIndex in the instanced material.
+    // Per-instance vertex stream: one {mat4 model; vec4 color;} record per
+    // instance, bound to slot 1 and stepped once per instance by the
+    // instanced material's per-instance vertex layout.
     if (!m_instance_buffer.valid())
     {
         gpu::buffer_descriptor instance_descriptor{};
         instance_descriptor.size = m_capacity * sizeof(instance_record);
-        instance_descriptor.usage = gpu::buffer_usage_storage | gpu::buffer_usage_copy_dst;
+        instance_descriptor.usage = gpu::buffer_usage_vertex | gpu::buffer_usage_copy_dst;
         instance_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
         m_instance_buffer = gpu.create_buffer(instance_descriptor);
         m_instances_dirty = true;
@@ -190,18 +190,6 @@ void rendering_engine::instanced_mesh::collect_draw_items(std::vector<draw_item>
         const std::array<uint32_t, indirect_command_uints> command{m_index_count, m_instance_count, 0u, 0u, 0u};
         gpu.write_buffer(m_indirect_buffer, command.data(), indirect_command_size, 0);
         m_uploaded_instance_count = m_instance_count;
-    }
-
-    if (!m_draw_bind_group.valid())
-    {
-        gpu::bind_group_descriptor bg_descriptor{};
-        bg_descriptor.layout = m_material->per_draw_layout();
-        gpu::binding_value instance_slot{};
-        instance_slot.binding = instanced_material::instance_buffer_binding;
-        instance_slot.kind = gpu::binding_kind::storage_buffer;
-        instance_slot.buffer_value = m_instance_buffer;
-        bg_descriptor.entries.push_back(instance_slot);
-        m_draw_bind_group = gpu.create_bind_group(bg_descriptor);
     }
 
     // Re-upload the whole per-instance array when any record changed. The
@@ -227,8 +215,9 @@ void rendering_engine::instanced_mesh::collect_draw_items(std::vector<draw_item>
     item.vertex_buffer = m_vertex_buffer;
     item.index_buffer = m_index_buffer;
     item.indirect_buffer = m_indirect_buffer;
-    item.per_draw_bind_group = m_draw_bind_group;
+    item.instance_buffer = m_instance_buffer;
     item.index_count = m_index_count;
     item.vertex_stride = m_vertex_stride;
+    item.instance_stride = static_cast<uint32_t>(sizeof(instance_record));
     out.push_back(item);
 }

--- a/rendering_engine/renderables/instanced_mesh.hpp
+++ b/rendering_engine/renderables/instanced_mesh.hpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <core/math/math.hpp>
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/mesh/vertex.hpp>
+#include <rendering_engine/renderables/renderable.hpp>
+#include <rendering_engine/util/color.hpp>
+
+namespace rendering_engine
+{
+    struct material;
+
+    // Draws one shared mesh many times in a single instanced draw, each
+    // copy with its own world transform and tint — the engine analog of
+    // THREE.InstancedMesh. The geometry (vertex + index buffers) and the
+    // material are shared across every instance; only a per-instance
+    // storage buffer of @c {mat4 model; vec4 color;} records varies.
+    //
+    // The renderable emits a single indexed-indirect @ref draw_item whose
+    // command record carries the instance count, so the whole batch costs
+    // one draw call. It must be fronted by an @ref instanced_material,
+    // whose vertex shader reads the per-instance record by
+    // @c gl_InstanceIndex; pass that material to the constructor.
+    struct instanced_mesh : public renderable
+    {
+        // @p mat is non-owning and is expected to be an
+        // @ref instanced_material. @p instance_count is the fixed capacity
+        // of the per-instance buffer; the active draw count starts equal to
+        // it and can be lowered via @ref set_instance_count.
+        instanced_mesh(material* mat, uint32_t instance_count);
+        ~instanced_mesh() override;
+
+        // Upload the shared geometry drawn once per instance. Vertices use
+        // the position+uv+normal record (the instanced material reads only
+        // the position); indices are 32-bit. Call once after construction,
+        // before the first frame.
+        void upload_geometry(const std::vector<vertex_position_uv_normal>& vertices,
+                             const std::vector<uint32_t>& indices);
+
+        // Geometry uploads through @ref upload_geometry; this is a no-op so
+        // @ref instanced_mesh still satisfies the @ref renderable interface.
+        void upload() final {}
+
+        void collect_draw_items(std::vector<draw_item>& out) final;
+
+        // Fixed per-instance buffer capacity set at construction.
+        uint32_t instance_capacity() const;
+
+        // Number of instances drawn this frame. Clamped to the capacity.
+        void set_instance_count(uint32_t count);
+        uint32_t instance_count() const;
+
+        // Per-instance world transform. @p index must be < the capacity.
+        void set_instance_transform(uint32_t index, const core::math::mat4& transform);
+
+        // Per-instance tint, multiplied by the material's flat colour.
+        // Defaults to opaque white. @p index must be < the capacity.
+        void set_instance_color(uint32_t index, const util::color& color);
+
+    private:
+        // Per-instance record mirrored on the CPU and uploaded into the
+        // storage buffer. Layout matches the std430 @c instance_data block
+        // in the instanced material's vertex shader: mat4 (64 bytes) then
+        // vec4 (16 bytes), 80 bytes total with no trailing padding.
+        struct instance_record
+        {
+            core::math::mat4 model{};
+            core::math::vec4 color{1.0f, 1.0f, 1.0f, 1.0f};
+        };
+
+        material* m_material{nullptr};
+        uint32_t m_capacity{0};
+        uint32_t m_instance_count{0};
+
+        // CPU mirror of the per-instance storage buffer, re-uploaded when
+        // an instance changes.
+        std::vector<instance_record> m_instances;
+        bool m_instances_dirty{true};
+
+        // Instance count last written into the indirect command, so the
+        // command is only rewritten when the active count actually changes.
+        uint32_t m_uploaded_instance_count{0};
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_index_buffer{};
+        gpu::buffer m_instance_buffer{};
+        gpu::buffer m_indirect_buffer{};
+        gpu::bind_group m_draw_bind_group{};
+
+        uint32_t m_index_count{0};
+        uint32_t m_vertex_stride{0};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/renderables/instanced_mesh.hpp
+++ b/rendering_engine/renderables/instanced_mesh.hpp
@@ -38,14 +38,16 @@ namespace rendering_engine
     // Draws one shared mesh many times in a single instanced draw, each
     // copy with its own world transform and tint — the engine analog of
     // THREE.InstancedMesh. The geometry (vertex + index buffers) and the
-    // material are shared across every instance; only a per-instance
-    // storage buffer of @c {mat4 model; vec4 color;} records varies.
+    // material are shared across every instance; a per-instance vertex
+    // stream of @c {mat4 model; vec4 color;} records supplies what varies.
     //
-    // The renderable emits a single indexed-indirect @ref draw_item whose
-    // command record carries the instance count, so the whole batch costs
-    // one draw call. It must be fronted by an @ref instanced_material,
-    // whose vertex shader reads the per-instance record by
-    // @c gl_InstanceIndex; pass that material to the constructor.
+    // The renderable emits a single indexed-indirect @ref draw_item: the
+    // command record carries the instance count, and the per-instance
+    // stream is bound to vertex slot 1 and stepped once per instance
+    // (@c glVertexAttribDivisor / @c VK_VERTEX_INPUT_RATE_INSTANCE), so the
+    // whole batch costs one draw call without relying on @c gl_InstanceIndex.
+    // It must be fronted by an @ref instanced_material; pass that material
+    // to the constructor.
     struct instanced_mesh : public renderable
     {
         // @p mat is non-owning and is expected to be an
@@ -84,9 +86,10 @@ namespace rendering_engine
 
     private:
         // Per-instance record mirrored on the CPU and uploaded into the
-        // storage buffer. Layout matches the std430 @c instance_data block
-        // in the instanced material's vertex shader: mat4 (64 bytes) then
-        // vec4 (16 bytes), 80 bytes total with no trailing padding.
+        // per-instance vertex stream. Layout matches the instanced
+        // material's slot-1 vertex attributes: a mat4 model (four vec4
+        // columns, 64 bytes) followed by a vec4 colour (16 bytes), 80 bytes
+        // with no trailing padding.
         struct instance_record
         {
             core::math::mat4 model{};
@@ -97,8 +100,8 @@ namespace rendering_engine
         uint32_t m_capacity{0};
         uint32_t m_instance_count{0};
 
-        // CPU mirror of the per-instance storage buffer, re-uploaded when
-        // an instance changes.
+        // CPU mirror of the per-instance vertex stream, re-uploaded when an
+        // instance changes.
         std::vector<instance_record> m_instances;
         bool m_instances_dirty{true};
 
@@ -110,7 +113,6 @@ namespace rendering_engine
         gpu::buffer m_index_buffer{};
         gpu::buffer m_instance_buffer{};
         gpu::buffer m_indirect_buffer{};
-        gpu::bind_group m_draw_bind_group{};
 
         uint32_t m_index_count{0};
         uint32_t m_vertex_stride{0};

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -116,7 +116,7 @@ void rendering_engine::context::init()
     // point light; like the directional shadow it runs before the scene pass so
     // its maps are ready for the per-frame bind group.
     auto point_shadow = std::make_unique<point_shadow_pass>(&m_scene_renderables);
-    auto scene = std::make_unique<scene_pass>(&m_scene_renderables, shadow.get(), point_shadow.get());
+    auto scene = std::make_unique<scene_pass>(&m_scene_renderables, shadow.get(), point_shadow.get(), &m_render_stats);
     const gpu::bind_group_layout scene_frame_layout = scene->frame_bind_group_layout();
     // Kept so create_standard_material can build extra materials against
     // the same per-frame layout the scene pass binds at slot 0.
@@ -368,6 +368,11 @@ rendering_engine::grid_material& rendering_engine::context::get_grid_material()
 rendering_engine::ui_material& rendering_engine::context::get_ui_material()
 {
     return *m_ui_material;
+}
+
+const rendering_engine::render_stats& rendering_engine::context::get_render_stats() const
+{
+    return m_render_stats;
 }
 
 std::unique_ptr<rendering_engine::standard_material> rendering_engine::context::create_standard_material()

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -34,6 +34,7 @@
 #include <rendering_engine/ibl/environment.hpp>
 #include <rendering_engine/materials/basic_material.hpp>
 #include <rendering_engine/materials/grid_material.hpp>
+#include <rendering_engine/materials/instanced_material.hpp>
 #include <rendering_engine/materials/line_material.hpp>
 #include <rendering_engine/materials/phong_material.hpp>
 #include <rendering_engine/materials/points_material.hpp>
@@ -145,6 +146,7 @@ void rendering_engine::context::init()
     // slot 0 for the scene_pass's per-frame group; the ui material
     // has no per-frame group.
     m_basic_material = std::make_unique<basic_material>(scene_frame_layout);
+    m_instanced_material = std::make_unique<instanced_material>(scene_frame_layout);
     m_phong_material = std::make_unique<phong_material>(scene_frame_layout);
     m_standard_material = std::make_unique<standard_material>(scene_frame_layout);
     m_points_material = std::make_unique<points_material>(scene_frame_layout);
@@ -155,8 +157,8 @@ void rendering_engine::context::init()
     // Analytic infinite-grid material; shares the scene per-frame layout.
     m_grid_material = std::make_unique<grid_material>(scene_frame_layout);
     m_ui_material = std::make_unique<ui_material>();
-    LOG_INF("Rendering Engine: basic_material, phong_material, standard_material, points_material, line_material and "
-            "ui_material constructed");
+    LOG_INF("Rendering Engine: basic_material, instanced_material, phong_material, standard_material, points_material, "
+            "line_material and ui_material constructed");
 
     // Register the built-in passes in render order: scene writes into
     // the HDR target, the skybox pass fills the untouched background of
@@ -234,6 +236,7 @@ void rendering_engine::context::quit()
     m_points_material.reset();
     m_standard_material.reset();
     m_phong_material.reset();
+    m_instanced_material.reset();
     m_basic_material.reset();
 
     // Release the off-screen HDR target before the device tears its
@@ -325,6 +328,11 @@ void rendering_engine::context::unregister_debug_renderable(renderable* r)
 rendering_engine::basic_material& rendering_engine::context::get_basic_material()
 {
     return *m_basic_material;
+}
+
+rendering_engine::instanced_material& rendering_engine::context::get_instanced_material()
+{
+    return *m_instanced_material;
 }
 
 rendering_engine::phong_material& rendering_engine::context::get_phong_material()

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/render_stats.hpp>
 
 namespace rendering_engine
 {
@@ -189,6 +190,15 @@ namespace rendering_engine
         ui_material& get_ui_material();
 
         /**
+         * @brief This frame's scene / draw statistics (renderable count,
+         *        draw calls, instances, triangles, vertices).
+         *
+         * Refreshed by the scene pass every @ref render; the debug overlay
+         * reads it. Reflects the most recently completed scene pass.
+         */
+        const render_stats& get_render_stats() const;
+
+        /**
          * @brief Sets (or clears) the scene's image-based-lighting
          *        environment plus background.
          *
@@ -229,6 +239,10 @@ namespace rendering_engine
         // @ref init so @ref create_standard_material can build additional
         // materials against the same slot 0.
         gpu::bind_group_layout m_scene_frame_layout{};
+
+        // This frame's draw statistics, filled by the scene pass (which
+        // holds a pointer to it) and surfaced via @ref get_render_stats.
+        render_stats m_render_stats{};
 
         // The active scene environment, or null. Stored so newly created
         // materials inherit the image-based lighting. Non-owning.

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -39,6 +39,7 @@ namespace rendering_engine
     struct skybox_pass;
     struct environment;
     struct basic_material;
+    struct instanced_material;
     struct phong_material;
     struct standard_material;
     struct points_material;
@@ -127,6 +128,16 @@ namespace rendering_engine
 
         /** @brief Built-in unlit 3D scene material. Constructed in @ref init. */
         basic_material& get_basic_material();
+
+        /**
+         * @brief Built-in unlit instanced material fronted by
+         *        @ref instanced_mesh. Constructed in @ref init.
+         *
+         * Shares the scene per-frame layout (camera at slot 0); its
+         * per-draw slot reads the per-instance transform / colour storage
+         * buffer the @ref instanced_mesh renderable builds.
+         */
+        instanced_material& get_instanced_material();
 
         /** @brief Built-in Blinn-Phong lit 3D scene material. Constructed in @ref init. */
         phong_material& get_phong_material();
@@ -227,6 +238,7 @@ namespace rendering_engine
         // @ref init so they can read the passes' per-frame bind-group
         // layouts. Released after the passes in @ref quit.
         std::unique_ptr<basic_material> m_basic_material;
+        std::unique_ptr<instanced_material> m_instanced_material;
         std::unique_ptr<phong_material> m_phong_material;
         std::unique_ptr<standard_material> m_standard_material;
         std::unique_ptr<points_material> m_points_material;


### PR DESCRIPTION
## Summary

Implements #123 — an `instanced_mesh` renderable that draws one shared geometry many times in a single indexed-indirect draw, each copy with its own transform and tint (the engine analog of `THREE.InstancedMesh`). Builds on the existing `draw_indexed_indirect` device API.

## What's included

- **`instanced_material`** — unlit, position-only pipeline. Its vertex shader reads a per-instance `{mat4 model; vec4 color;}` record from a per-draw storage buffer indexed by `gl_InstanceIndex` (std430, matching the C++ POD record), modulated by a flat per-material tint. Slot layout mirrors `basic_material`: per-frame camera at slot 0, per-draw instance SSBO at slot 1, per-material tint at slot 2.
- **`instanced_mesh`** — owns the shared vertex/index buffers, the per-instance storage buffer, and a single `DrawElementsIndirectCommand`. `upload_geometry()` uploads the mesh; `set_instance_transform()` / `set_instance_color()` / `set_instance_count()` drive the per-instance data, which is re-uploaded only when it changes. Emits one indirect `draw_item` carrying the instance count.
- **`draw_item`** gains an optional `indirect_buffer`; `scene_pass` dispatches it through `draw_indexed_indirect`.
- The depth-only shadow / point-shadow passes skip indirect items — per-instance transforms aren't wired through their pipeline, so they're skipped rather than emitting a single garbage caster. (Instanced shadow casting is a possible follow-up.)
- `get_instanced_material()` exposed on the rendering context, plus a swap-in `instanced_demo_module` (an animated wall of 64 cubes) showcase alongside the other demo modules.

## Verification

- **Build:** MSVC/vcpkg Release passes; the demo compiles + links when swapped in (verified, then reverted so `scene_graph_demo_module` stays the active showcase).
- **Style:** `check-style.ps1` clean.
- **Naming:** `check-naming.ps1` reports no violations.

Closes #123
