### PR TITLE
feat: add distance fog to the lit materials

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(AlphaEngine PRIVATE
     camera_module.cpp
     exit_module.cpp
     frame_module.cpp
-    instanced_demo_module.cpp
+    fog_demo_module.cpp
 )
 
 # The FPS counter used to live here as a label-rendering game module; it
@@ -10,16 +10,18 @@ target_sources(AlphaEngine PRIVATE
 # so the standalone fps_overlay_module was removed.
 
 # Only one scene-owning demo module is compiled at a time because each
-# places its showcase geometry at the origin. instanced_demo_module.cpp is
-# the active one: it draws a grid_side^3 lattice of cubes (thousands of
-# objects) from one shared geometry in a single instanced draw call to
-# showcase the instanced_mesh renderable and its per-instance storage buffer.
+# places its showcase geometry at the origin. fog_demo_module.cpp is the
+# active one: a row of Blinn-Phong spheres receding over a long ground
+# plane under linear distance fog, so the far geometry dissolves into the
+# haze (showcases the fog from issue #122).
 #
-# scene_graph_demo_module.cpp (parent/child node hierarchy with orbiting
-# cube mesh_components and a point light), line_demo_module.cpp (coloured
-# helix line strip), points_demo_module.cpp (coloured Fibonacci-sphere point
-# cloud), skybox_demo_module.cpp (procedural sky + IBL sphere grid) and
-# phong_demo_module.cpp (Blinn-Phong lit sphere) are the other showcases;
-# swap any one filename in for instanced_demo_module.cpp to bring it back.
+# instanced_demo_module.cpp (a grid_side^3 lattice of cubes in one
+# instanced draw call), scene_graph_demo_module.cpp (parent/child node
+# hierarchy with orbiting cube mesh_components and a point light),
+# line_demo_module.cpp (coloured helix line strip), points_demo_module.cpp
+# (coloured Fibonacci-sphere point cloud), skybox_demo_module.cpp
+# (procedural sky + IBL sphere grid) and phong_demo_module.cpp (Blinn-Phong
+# lit sphere) are the other showcases; swap any one filename in for
+# fog_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/fog_demo_module.cpp
+++ b/external/fog_demo_module.cpp
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "api/game_module.hpp"
+#include "api/log.hpp"
+
+#include <core/log.hpp>
+#include <core/math/math.hpp>
+#include <rendering_engine/fog.hpp>
+#include <rendering_engine/lighting/ambient_light.hpp>
+#include <rendering_engine/lighting/directional_light.hpp>
+#include <rendering_engine/materials/phong_material.hpp>
+#include <rendering_engine/renderables/premade_3d/plane.hpp>
+#include <rendering_engine/renderables/premade_3d/sphere.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+#include <rendering_engine/util/color.hpp>
+#include <runtime/engine.hpp>
+
+#include <memory>
+#include <vector>
+
+// A row of spheres marching away from the camera over a long ground
+// plane, with linear distance fog: the near spheres read at full colour
+// while the far ones dissolve into the haze, showcasing the fog added in
+// issue #122.
+static std::vector<std::unique_ptr<rendering_engine::sphere>> g_spheres;
+static std::unique_ptr<rendering_engine::plane> g_ground;
+static std::unique_ptr<rendering_engine::ambient_light> g_ambient;
+static std::unique_ptr<rendering_engine::directional_light> g_sun;
+
+// Linear RGB the scene fades into; matched to the fog colour so the
+// receding plane and spheres melt into a uniform haze.
+static const rendering_engine::util::color g_fog_color{90, 115, 160, 255};
+
+static void on_engine_start(const core::engine_start& event)
+{
+    auto& renderer = *runtime::current_engine().renderer;
+
+    auto& material = renderer.get_phong_material();
+    material.set_diffuse(rendering_engine::util::color{230, 126, 34, 255});
+    material.set_specular(rendering_engine::util::color{255, 255, 255, 255});
+    material.set_shininess(48.0f);
+
+    // The camera looks from -X toward the origin. Lay the spheres out as
+    // a field that both recedes (+X, increasing distance) and spreads
+    // laterally (±Y) so the rows behind the front one stay visible: the
+    // near rows read at full colour while the far rows dissolve into the
+    // fog. (A single line of spheres along the view axis would hide the
+    // fogged rows behind the unfogged front sphere.)
+    constexpr int depth_rows = 6;   // along +X, away from the camera
+    constexpr int lateral_cols = 5; // across ±Y
+    for (int row = 0; row < depth_rows; ++row)
+    {
+        for (int col = 0; col < lateral_cols; ++col)
+        {
+            auto ball = std::make_unique<rendering_engine::sphere>(&material);
+            const float x = static_cast<float>(row) * 4.0f;
+            const float y = (static_cast<float>(col) - static_cast<float>(lateral_cols - 1) * 0.5f) * 3.0f;
+            ball->transform.set_position(core::math::vec3{x, y, 0.0f});
+            ball->upload();
+            renderer.register_scene_renderable(ball.get());
+            g_spheres.push_back(std::move(ball));
+        }
+    }
+
+    // A long ground plane below the spheres; world up is +Z, so the
+    // plane's default +Z normal already faces the sky.
+    g_ground = std::make_unique<rendering_engine::plane>(&material, 120.0f, 120.0f);
+    g_ground->transform.set_position(core::math::vec3{16.0f, 0.0f, -1.5f});
+    g_ground->upload();
+    renderer.register_scene_renderable(g_ground.get());
+
+    // Lights self-register on construction; keeping them alive is enough
+    // for the scene pass to pack them into the per-frame lights UBO.
+    g_ambient = std::make_unique<rendering_engine::ambient_light>();
+    g_ambient->color = core::math::vec3{1.0f, 1.0f, 1.0f};
+    g_ambient->intensity = 0.2f;
+
+    g_sun = std::make_unique<rendering_engine::directional_light>();
+    g_sun->direction = core::math::vec3{1.0f, -0.4f, -0.6f};
+    g_sun->color = core::math::vec3{1.0f, 0.97f, 0.9f};
+    g_sun->intensity = 1.0f;
+
+    // Linear distance fog: clear up close, fully saturated by the far
+    // end of the sphere row.
+    rendering_engine::fog_settings fog{};
+    fog.mode = rendering_engine::fog_mode::linear;
+    fog.color = core::math::vec3{static_cast<float>(g_fog_color.r) / 255.0f,
+                                 static_cast<float>(g_fog_color.g) / 255.0f,
+                                 static_cast<float>(g_fog_color.b) / 255.0f};
+    fog.near_distance = 3.0f;
+    fog.far_distance = 18.0f;
+    renderer.set_fog(fog);
+}
+
+static void on_engine_stop(const core::engine_stop& event)
+{
+    auto& renderer = *runtime::current_engine().renderer;
+    renderer.set_fog(rendering_engine::fog_settings{});
+    for (auto& ball : g_spheres)
+    {
+        renderer.unregister_scene_renderable(ball.get());
+    }
+    g_spheres.clear();
+    renderer.unregister_scene_renderable(g_ground.get());
+    g_ground.reset();
+    g_sun.reset();
+    g_ambient.reset();
+}
+
+GAME_MODULE()
+{
+    LOG_INF("Registering external module: fog_demo_module");
+    struct game_module_info info = {};
+    info.on_engine_start = on_engine_start;
+    info.on_engine_stop = on_engine_stop;
+    register_game_module(info);
+    return true;
+}

--- a/rendering_engine/fog.hpp
+++ b/rendering_engine/fog.hpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <core/math/math.hpp>
+
+namespace rendering_engine
+{
+    // Atmospheric distance fog applied by the lit materials. The analog
+    // of @c THREE.Fog (linear) and @c THREE.FogExp2 (exponential): the
+    // fragment blends toward @ref fog_settings::color by camera distance,
+    // approximating aerial perspective cheaply with no extra pass.
+    //
+    // The active fog is scene-wide state set through
+    // @ref context::set_fog; the scene pass packs it into the per-view
+    // @c PerFrame UBO (slot 0, binding 0) each frame, and the lit
+    // fragment shaders read it from there. Disabled by default
+    // (@ref fog_mode::none).
+    enum class fog_mode
+    {
+        // No fog; the lit shaders skip the blend entirely.
+        none,
+
+        // Linear ramp between @ref fog_settings::near_distance (no fog)
+        // and @ref fog_settings::far_distance (full fog).
+        linear,
+
+        // Exponential-squared falloff driven by
+        // @ref fog_settings::density (matches @c THREE.FogExp2).
+        exponential,
+    };
+
+    // Scene-wide fog parameters. @ref near_distance / @ref far_distance
+    // drive @ref fog_mode::linear; @ref density drives
+    // @ref fog_mode::exponential. The unused term for a given mode is
+    // simply ignored by the shader. Members avoid the names @c near /
+    // @c far because @c <windows.h> defines those as macros.
+    struct fog_settings
+    {
+        fog_mode mode{fog_mode::none};
+
+        // Linear RGB the scene fades into with distance.
+        core::math::vec3 color{0.5f, 0.5f, 0.5f};
+
+        // Linear fog: distance at which fog begins (0 contribution) and
+        // the distance at which it fully saturates. World units.
+        float near_distance{1.0f};
+        float far_distance{100.0f};
+
+        // Exponential fog: larger values thicken the fog faster.
+        float density{0.02f};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/materials/phong_material.cpp
+++ b/rendering_engine/materials/phong_material.cpp
@@ -64,6 +64,8 @@ namespace
         {
             mat4 viewMatrix;
             mat4 projectionMatrix;
+            vec4 fogColor;  // rgb colour, a = mode (0 none, 1 linear, 2 exp2)
+            vec4 fogParams; // x near, y far, z density
         } u_frame;
 
         layout(set = 1, binding = 1, std140) uniform PerDraw
@@ -97,6 +99,16 @@ namespace
         layout(location = 3) in vec3 cameraPosition;
 
         layout(location = 0) out vec4 fragColor;
+
+        // The per-view block (slot 0, binding 0). Only the fog members
+        // are read here; the matrices are consumed in the vertex stage.
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+            vec4 fogColor;  // rgb colour, a = mode (0 none, 1 linear, 2 exp2)
+            vec4 fogParams; // x near, y far, z density
+        } u_frame;
 
         const int MAX_DIRECTIONAL = 4;
         const int MAX_POINT = 16;
@@ -173,6 +185,31 @@ namespace
             return lit / 25.0;
         }
 
+        // Blend @p color toward the scene fog colour by camera distance.
+        // Mode 0 disables fog; 1 is a linear near/far ramp; 2 is
+        // exponential-squared (THREE.FogExp2). Applied in linear/HDR
+        // space before the tonemap pass.
+        vec3 apply_fog(vec3 color)
+        {
+            float mode = u_frame.fogColor.a;
+            if (mode < 0.5)
+            {
+                return color;
+            }
+            float dist = distance(cameraPosition, worldPosition);
+            float factor; // 1 = no fog, 0 = full fog
+            if (mode < 1.5)
+            {
+                factor = clamp((u_frame.fogParams.y - dist) / (u_frame.fogParams.y - u_frame.fogParams.x), 0.0, 1.0);
+            }
+            else
+            {
+                float d = u_frame.fogParams.z * dist;
+                factor = exp(-d * d);
+            }
+            return mix(u_frame.fogColor.rgb, color, factor);
+        }
+
         void main()
         {
             vec3 N = normalize(worldNormal);
@@ -228,6 +265,7 @@ namespace
                 }
             }
 
+            result = apply_fog(result);
             fragColor = vec4(result, u_material.diffuseColor.a);
         }
 )fs";

--- a/rendering_engine/materials/standard_material.cpp
+++ b/rendering_engine/materials/standard_material.cpp
@@ -86,6 +86,8 @@ namespace
         {
             mat4 viewMatrix;
             mat4 projectionMatrix;
+            vec4 fogColor;  // rgb colour, a = mode (0 none, 1 linear, 2 exp2)
+            vec4 fogParams; // x near, y far, z density
         } u_frame;
 
         layout(set = 1, binding = 1, std140) uniform PerDraw
@@ -124,6 +126,16 @@ namespace
         layout(location = 4) in vec4 worldTangent;
 
         layout(location = 0) out vec4 fragColor;
+
+        // The per-view block (slot 0, binding 0). Only the fog members
+        // are read here; the matrices are consumed in the vertex stage.
+        layout(set = 0, binding = 0, std140) uniform PerFrame
+        {
+            mat4 viewMatrix;
+            mat4 projectionMatrix;
+            vec4 fogColor;  // rgb colour, a = mode (0 none, 1 linear, 2 exp2)
+            vec4 fogParams; // x near, y far, z density
+        } u_frame;
 
         const int MAX_DIRECTIONAL = 4;
         const int MAX_POINT = 16;
@@ -390,6 +402,31 @@ namespace
             return lit / 9.0;
         }
 
+        // Blend @p color toward the scene fog colour by camera distance.
+        // Mode 0 disables fog; 1 is a linear near/far ramp; 2 is
+        // exponential-squared (THREE.FogExp2). Applied in linear/HDR
+        // space before the tonemap pass.
+        vec3 apply_fog(vec3 color)
+        {
+            float mode = u_frame.fogColor.a;
+            if (mode < 0.5)
+            {
+                return color;
+            }
+            float dist = distance(cameraPosition, worldPosition);
+            float factor; // 1 = no fog, 0 = full fog
+            if (mode < 1.5)
+            {
+                factor = clamp((u_frame.fogParams.y - dist) / (u_frame.fogParams.y - u_frame.fogParams.x), 0.0, 1.0);
+            }
+            else
+            {
+                float d = u_frame.fogParams.z * dist;
+                factor = exp(-d * d);
+            }
+            return mix(u_frame.fogColor.rgb, color, factor);
+        }
+
         void main()
         {
             vec3 albedo = u_material.baseColor.rgb;
@@ -464,6 +501,7 @@ namespace
             }
 
             vec3 color = ambient + Lo + emissive;
+            color = apply_fog(color);
             fragColor = vec4(color, u_material.baseColor.a * u_material.params.z);
         }
 )fs";

--- a/rendering_engine/passes/pass.hpp
+++ b/rendering_engine/passes/pass.hpp
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <rendering_engine/fog.hpp>
 #include <rendering_engine/gpu/command_encoder.hpp>
 #include <rendering_engine/gpu/handle.hpp>
 
@@ -67,6 +68,12 @@ namespace rendering_engine
         // @ref swapchain_target. Also owned by @ref context.
         gpu::render_target ldr_color_target{};
         gpu::texture ldr_color_texture{};
+
+        // Scene-wide atmospheric fog, copied from @ref context::set_fog
+        // each frame. The scene pass packs it into the per-view PerFrame
+        // UBO so the lit materials can blend toward it by camera
+        // distance. Defaults to @ref fog_mode::none (no fog).
+        fog_settings fog{};
     };
 
     /**

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -45,18 +45,20 @@ namespace rendering_engine
 {
     namespace
     {
-        // std140 layout for the per-frame camera UBO: mat4 viewMatrix
-        // at offset 0, mat4 projectionMatrix at offset 64. mat4 is
-        // 16-byte aligned and 64 bytes; no padding needed between
-        // the two members.
-        constexpr size_t per_frame_ubo_size = 2 * sizeof(core::math::mat4);
+        // std140 layout for the per-view PerFrame UBO: mat4 viewMatrix
+        // at offset 0, mat4 projectionMatrix at offset 64, then the fog
+        // block — vec4 fogColor at 128 (rgb colour, a = fog mode) and
+        // vec4 fogParams at 144 (x near, y far, z density). mat4 / vec4
+        // are 16-byte aligned, so no padding is needed between members.
+        // 160 bytes total.
+        constexpr size_t per_frame_ubo_size = 2 * sizeof(core::math::mat4) + 2 * sizeof(core::math::vec4);
 
         // Binding numbers within the per-frame bind group (slot 0). The
         // numbers must stay unique across both descriptor sets in a lit
         // pipeline because OpenGL flattens UBO bindings into a single
-        // namespace through ARB_gl_spirv: binding 0 = camera here,
-        // binding 1 = the per-draw model matrix (set 1), so the lights
-        // block takes binding 2.
+        // namespace through ARB_gl_spirv: binding 0 = the PerFrame view
+        // block (camera matrices + fog), binding 1 = the per-draw model
+        // matrix (set 1), so the lights block takes binding 2.
         constexpr uint32_t camera_binding = 0;
         constexpr uint32_t lights_binding = 2;
 
@@ -269,12 +271,22 @@ namespace rendering_engine
 
         // Refill the per-frame UBO before any draw consults it.
         // Layout matches the GLSL @c PerFrame block: viewMatrix at
-        // offset 0, projectionMatrix at offset sizeof(mat4).
-        std::array<float, 32> ubo_payload{};
+        // offset 0, projectionMatrix at offset sizeof(mat4), then the
+        // fog block (fogColor at float 32, fogParams at float 36).
+        std::array<float, 40> ubo_payload{};
         const auto view = ctx.active_camera->get_view_matrix();
         const auto projection = ctx.active_camera->get_projection_matrix();
         std::memcpy(ubo_payload.data(), view.data(), sizeof(core::math::mat4));
         std::memcpy(ubo_payload.data() + 16, projection.data(), sizeof(core::math::mat4));
+        // fogColor.rgb + fogColor.a = mode (0 none, 1 linear, 2 exp2);
+        // the lit shaders skip the blend when the mode is 0.
+        ubo_payload[32] = ctx.fog.color.x;
+        ubo_payload[33] = ctx.fog.color.y;
+        ubo_payload[34] = ctx.fog.color.z;
+        ubo_payload[35] = static_cast<float>(static_cast<int>(ctx.fog.mode));
+        ubo_payload[36] = ctx.fog.near_distance;
+        ubo_payload[37] = ctx.fog.far_distance;
+        ubo_payload[38] = ctx.fog.density;
         gpu.write_buffer(m_frame_ubo, ubo_payload.data(), per_frame_ubo_size, 0);
 
         // Pack every live light into the std140 lights block and upload

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -275,6 +275,7 @@ void rendering_engine::context::render()
                       m_scene_color_texture,
                       m_ldr_color_target,
                       m_ldr_color_texture};
+    ctx.fog = m_fog;
 
     auto encoder = gpu.create_command_encoder();
     for (auto& p : m_passes)
@@ -407,4 +408,9 @@ void rendering_engine::context::set_environment(const environment* env)
             m_standard_material->clear_environment();
         }
     }
+}
+
+void rendering_engine::context::set_fog(const fog_settings& fog)
+{
+    m_fog = fog;
 }

--- a/rendering_engine/rendering_engine.hpp
+++ b/rendering_engine/rendering_engine.hpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <vector>
 
+#include <rendering_engine/fog.hpp>
 #include <rendering_engine/gpu/handle.hpp>
 #include <rendering_engine/render_stats.hpp>
 
@@ -211,6 +212,17 @@ namespace rendering_engine
          */
         void set_environment(const environment* env);
 
+        /**
+         * @brief Sets the scene-wide atmospheric fog.
+         *
+         * Stored and copied into the per-view @c PerFrame UBO by the
+         * scene pass each frame, so the built-in lit materials
+         * (@ref phong_material, @ref standard_material) blend toward the
+         * fog colour by camera distance. Pass a @ref fog_settings with
+         * @ref fog_mode::none (the default) to disable fog.
+         */
+        void set_fog(const fog_settings& fog);
+
     private:
         std::vector<renderable*> m_scene_renderables;
         std::vector<renderable*> m_ui_renderables;
@@ -247,6 +259,11 @@ namespace rendering_engine
         // The active scene environment, or null. Stored so newly created
         // materials inherit the image-based lighting. Non-owning.
         const environment* m_environment{nullptr};
+
+        // Scene-wide atmospheric fog, set via @ref set_fog and copied
+        // into the frame context each @ref render so the scene pass can
+        // upload it. Defaults to @ref fog_mode::none (disabled).
+        fog_settings m_fog{};
 
         // Built-in materials, constructed after the passes in
         // @ref init so they can read the passes' per-frame bind-group


### PR DESCRIPTION
## What

Scene-wide atmospheric fog — a `THREE.Fog` (linear) / `THREE.FogExp2` (exponential) analog — that the lit materials blend toward by camera distance. Closes #122.

## How

- **New `fog_settings`** (`rendering_engine/fog.hpp`): mode (`none` / `linear` / `exponential`), colour, `near_distance` / `far_distance`, and `density`. Bounds are named `*_distance` to avoid the `near` / `far` macros from `<windows.h>`.
- **Rides the existing per-view `PerFrame` UBO** (slot 0, binding 0) rather than a new binding: the block grows from the two camera matrices to also carry `fogColor` (rgb + mode) and `fogParams` (near/far/density), so **no bind-group layout changes** are needed.
- **`context::set_fog`** stores the active fog; the **scene pass** packs it into the block each frame next to the camera matrices.
- **`phong_material` / `standard_material`** declare the extended block and apply a linear near/far ramp or exponential-squared falloff just before the final write — in linear/HDR space, ahead of the tonemap pass. No vertex-shader changes (both already pass `worldPosition` / `cameraPosition`).
- **Demo:** swaps the active module to `fog_demo_module` — a field of Blinn-Phong spheres receding over a long ground plane under linear fog (one-line revert in `external/CMakeLists.txt` to restore the instanced demo).

## Scope

Distance fog only. Height fog (#159), per-material `fog` opt-out (#160), view-globals UBO consolidation (#161), and volumetric fog (#162, needs sampleable depth #158) are tracked separately.

## Verification

- MSVC Debug build succeeds; both lit shaders compile to SPIR-V; app runs with no errors.
- clang-format and clang-tidy (naming) gates both pass.
- Fog confirmed rendering via an offscreen frame capture: distant geometry fades to the fog colour while near geometry stays unfogged.
