### PR TITLE
feat: temporal anti-aliasing (TAA) with per-pixel motion vectors

### DIFF
--- a/core/settings.cpp
+++ b/core/settings.cpp
@@ -60,6 +60,25 @@ namespace
         LOG_ERR("settings: unknown ALPHAENGINE_GRAPHICS_BACKEND='%s'; falling back to opengl", value);
         return graphics_backend::opengl;
     }
+
+    bool parse_temporal_aa()
+    {
+        const char* value = std::getenv("ALPHAENGINE_TAA");
+        if (value == nullptr || value[0] == '\0')
+        {
+            return true;
+        }
+        if (std::strcmp(value, "0") == 0 || std::strcmp(value, "off") == 0 || std::strcmp(value, "false") == 0)
+        {
+            return false;
+        }
+        if (std::strcmp(value, "1") == 0 || std::strcmp(value, "on") == 0 || std::strcmp(value, "true") == 0)
+        {
+            return true;
+        }
+        LOG_ERR("settings: unknown ALPHAENGINE_TAA='%s'; falling back to enabled", value);
+        return true;
+    }
 } // namespace
 
 float window_settings::aspect_ratio() const noexcept
@@ -104,12 +123,13 @@ settings::settings()
     // Vsync off in both configurations: the frame rate is left uncapped.
     window.vsync = false;
     graphics.backend = parse_graphics_backend();
+    graphics.temporal_aa = parse_temporal_aa();
     camera.field_of_view = 70.0f;
     input.mouse_sensitivity = 0.005f;
     input.mouse_reversed = false;
 
     LOG_INF("Settings parsed: window=%ux%u type=%d double_buffered=%d vsync=%d fov=%.1f "
-            "mouse_sensitivity=%.4f mouse_reversed=%d graphics_backend=%s name='%s'",
+            "mouse_sensitivity=%.4f mouse_reversed=%d graphics_backend=%s temporal_aa=%d name='%s'",
             window.width,
             window.height,
             static_cast<int>(window.type),
@@ -119,5 +139,6 @@ settings::settings()
             input.mouse_sensitivity,
             input.mouse_reversed ? 1 : 0,
             graphics_backend_name(graphics.backend),
+            graphics.temporal_aa ? 1 : 0,
             window.name.c_str());
 }

--- a/core/settings.hpp
+++ b/core/settings.hpp
@@ -77,6 +77,19 @@ struct graphics_settings
      * (`opengl` or `vulkan`).
      */
     graphics_backend backend;
+
+    /**
+     * @brief Whether temporal anti-aliasing is enabled.
+     *
+     * When on, the scene pass jitters the projection matrix with a
+     * Halton sub-pixel sequence and the @ref rendering_engine::taa_pass
+     * accumulates the jittered frames into a stable, supersampled image
+     * (a neighbourhood colour clamp keeps moving content from ghosting).
+     * Read once during rendering-engine init. Enabled by default; set
+     * the @c ALPHAENGINE_TAA environment variable to `0` / `off` /
+     * `false` to disable it (or `1` / `on` / `true` to force it on).
+     */
+    bool temporal_aa;
 };
 
 /** @brief Camera configuration. */

--- a/rendering_engine/passes/post/CMakeLists.txt
+++ b/rendering_engine/passes/post/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(AlphaEngine PRIVATE
     fullscreen_triangle.hpp
     fxaa_pass.cpp
     fxaa_pass.hpp
+    taa_pass.cpp
+    taa_pass.hpp
     tonemap_pass.cpp
     tonemap_pass.hpp
 )

--- a/rendering_engine/passes/post/CMakeLists.txt
+++ b/rendering_engine/passes/post/CMakeLists.txt
@@ -8,4 +8,6 @@ target_sources(AlphaEngine PRIVATE
     taa_pass.hpp
     tonemap_pass.cpp
     tonemap_pass.hpp
+    velocity_pass.cpp
+    velocity_pass.hpp
 )

--- a/rendering_engine/passes/post/taa_pass.cpp
+++ b/rendering_engine/passes/post/taa_pass.cpp
@@ -1,0 +1,418 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/passes/post/taa_pass.hpp>
+
+#include <array>
+#include <string>
+
+#include <rendering_engine/gpu/bind_group.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/gpu/pipeline.hpp>
+#include <rendering_engine/gpu/render_target.hpp>
+#include <rendering_engine/gpu/shader.hpp>
+#include <rendering_engine/gpu/shader_compiler.hpp>
+#include <rendering_engine/passes/post/fullscreen_triangle.hpp>
+#include <runtime/engine.hpp>
+
+namespace
+{
+    // Steady-state weight of the reprojected history in the blend. 0.9
+    // keeps ten frames of accumulation in flight — enough to resolve the
+    // 16-sample Halton jitter into a smooth, supersampled image while
+    // still responding to change within a few frames. The neighbourhood
+    // clamp below is what stops that long tail from ghosting under motion.
+    constexpr float taa_feedback = 0.9f;
+
+    // The reprojection-free temporal resolve. The current jittered frame
+    // is blended with last frame's accumulated result; because the
+    // projection jitter moves the sub-pixel sample location every frame,
+    // that blend converges to a supersampled image on a static view. To
+    // keep moving content from smearing the stale history is first
+    // constrained to the 3x3 colour box around the current texel (the
+    // standard neighbourhood clamp), so any history that has drifted
+    // outside what the present frame plausibly contains is pulled back in.
+    //
+    // u_taa.params.xy is (1/width, 1/height) — the per-texel step the
+    // neighbourhood taps walk by — and params.z is the history feedback
+    // weight, baked to 0 on the first frame (history undefined) and to
+    // taa_feedback thereafter.
+    const std::string resolve_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec2 texCoord;
+        layout(location = 0) out vec4 fragColor;
+
+        layout(set = 0, binding = 0) uniform sampler2D currentColor;
+        layout(set = 0, binding = 1) uniform sampler2D historyColor;
+
+        layout(set = 0, binding = 2, std140) uniform Taa
+        {
+            vec4 params; // x = 1/width, y = 1/height, z = history feedback, w unused
+        } u_taa;
+
+        void main()
+        {
+            vec2 inv = u_taa.params.xy;
+
+            vec3 current = texture(currentColor, texCoord).rgb;
+
+            // 3x3 neighbourhood min/max of the current frame: the colour
+            // box the history is clamped into before blending.
+            vec3 box_min = current;
+            vec3 box_max = current;
+            for (int y = -1; y <= 1; ++y)
+            {
+                for (int x = -1; x <= 1; ++x)
+                {
+                    if (x == 0 && y == 0)
+                    {
+                        continue;
+                    }
+                    vec3 s = texture(currentColor, texCoord + vec2(x, y) * inv).rgb;
+                    box_min = min(box_min, s);
+                    box_max = max(box_max, s);
+                }
+            }
+
+            vec3 history = texture(historyColor, texCoord).rgb;
+            history = clamp(history, box_min, box_max);
+
+            vec3 resolved = mix(current, history, u_taa.params.z);
+            fragColor = vec4(resolved, 1.0);
+        }
+)fs";
+
+    // History store: a straight copy of the resolved frame into the
+    // history target so the next frame's resolve can read it.
+    const std::string copy_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec2 texCoord;
+        layout(location = 0) out vec4 fragColor;
+
+        layout(set = 0, binding = 0) uniform sampler2D src;
+
+        void main()
+        {
+            fragColor = texture(src, texCoord);
+        }
+)fs";
+
+    // std140 rounds the single vec4 block up to a 16-byte allocation.
+    constexpr size_t taa_ubo_size = 16;
+} // namespace
+
+namespace rendering_engine
+{
+    taa_pass::taa_pass(gpu::texture current_color, uint32_t width, uint32_t height)
+    {
+        auto& gpu = *runtime::current_engine().gpu;
+
+        // Degenerate backbuffer (no settings, zero-sized window): leave the
+        // pass disabled so output_texture() reports invalid and the caller
+        // keeps sampling the raw tonemap output.
+        if (width == 0 || height == 0)
+        {
+            return;
+        }
+
+        // -- Shaders --------------------------------------------------
+        gpu::shader_module_descriptor vs_descriptor{};
+        vs_descriptor.stage = gpu::shader_stage::vertex;
+        vs_descriptor.spirv = gpu::compile_glsl_to_spirv(fullscreen_triangle_vertex_shader, gpu::shader_stage::vertex);
+        m_vertex_shader = gpu.create_shader_module(vs_descriptor);
+
+        gpu::shader_module_descriptor resolve_descriptor{};
+        resolve_descriptor.stage = gpu::shader_stage::fragment;
+        resolve_descriptor.spirv = gpu::compile_glsl_to_spirv(resolve_shader, gpu::shader_stage::fragment);
+        m_resolve_shader = gpu.create_shader_module(resolve_descriptor);
+
+        gpu::shader_module_descriptor copy_descriptor{};
+        copy_descriptor.stage = gpu::shader_stage::fragment;
+        copy_descriptor.spirv = gpu::compile_glsl_to_spirv(copy_shader, gpu::shader_stage::fragment);
+        m_copy_shader = gpu.create_shader_module(copy_descriptor);
+
+        // -- Fullscreen-triangle vertex buffer ------------------------
+        gpu::buffer_descriptor vb_descriptor{};
+        vb_descriptor.size = fullscreen_triangle_vertices.size() * sizeof(float);
+        vb_descriptor.usage = gpu::buffer_usage_vertex;
+        vb_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        vb_descriptor.initial_data = fullscreen_triangle_vertices.data();
+        m_vertex_buffer = gpu.create_buffer(vb_descriptor);
+
+        // -- Resolve params UBO: texel step + history feedback --------
+        // The feedback starts at 0 so the first frame ignores the still
+        // undefined history; record() bumps it to taa_feedback once the
+        // history target has been populated.
+        m_inv_width = 1.0f / static_cast<float>(width);
+        m_inv_height = 1.0f / static_cast<float>(height);
+        const std::array<float, 4> initial_params = {m_inv_width, m_inv_height, 0.0f, 0.0f};
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = taa_ubo_size;
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        ubo_descriptor.initial_data = initial_params.data();
+        m_resolve_ubo = gpu.create_buffer(ubo_descriptor);
+
+        // -- Bind-group layouts ---------------------------------------
+        gpu::bind_group_layout_descriptor resolve_layout{};
+        resolve_layout.entries.push_back({0, gpu::binding_kind::texture});
+        resolve_layout.entries.push_back({1, gpu::binding_kind::texture});
+        resolve_layout.entries.push_back({2, gpu::binding_kind::uniform_buffer});
+        m_resolve_layout = gpu.create_bind_group_layout(resolve_layout);
+
+        gpu::bind_group_layout_descriptor copy_layout{};
+        copy_layout.entries.push_back({0, gpu::binding_kind::texture});
+        m_copy_layout = gpu.create_bind_group_layout(copy_layout);
+
+        // -- Targets --------------------------------------------------
+        // Both rgba8, no depth: the post chain runs depth-disabled and the
+        // image is already tonemapped LDR at this point.
+        auto make_target = [&]()
+        {
+            gpu::render_target_descriptor descriptor{};
+            descriptor.color_format = gpu::texture_format::rgba8_unorm;
+            descriptor.width = width;
+            descriptor.height = height;
+            descriptor.with_depth = false;
+            return gpu.create_render_target(descriptor);
+        };
+
+        m_history_target = make_target();
+        m_history_texture = gpu.render_target_color_texture(m_history_target);
+        m_resolve_target = make_target();
+        m_resolve_texture = gpu.render_target_color_texture(m_resolve_target);
+
+        // -- Pipelines ------------------------------------------------
+        gpu::vertex_buffer_layout vertex_layout{};
+        vertex_layout.stride = sizeof(float) * 2;
+        vertex_layout.attributes.push_back({0, 2, gpu::scalar_type::float32, 0});
+
+        gpu::depth_state depth{};
+        depth.test_enabled = false;
+        depth.write_enabled = false;
+        depth.compare = gpu::compare_function::always;
+
+        gpu::blend_state blend{};
+        blend.enabled = false;
+
+        gpu::rasterizer_state rasterizer{};
+        rasterizer.cull = gpu::cull_mode::none;
+        rasterizer.front = gpu::front_face::counter_clockwise;
+        rasterizer.polygon = gpu::polygon_mode::fill;
+
+        auto make_pipeline = [&](gpu::shader_module fragment, gpu::bind_group_layout layout)
+        {
+            gpu::pipeline_descriptor descriptor{};
+            descriptor.vertex_shader = m_vertex_shader;
+            descriptor.fragment_shader = fragment;
+            descriptor.vertex_buffers.push_back(vertex_layout);
+            descriptor.depth = depth;
+            descriptor.blend = blend;
+            descriptor.rasterizer = rasterizer;
+            descriptor.bind_group_layouts.push_back(layout);
+            return gpu.create_pipeline(descriptor);
+        };
+
+        m_resolve_pipeline = make_pipeline(m_resolve_shader, m_resolve_layout);
+        m_copy_pipeline = make_pipeline(m_copy_shader, m_copy_layout);
+
+        // -- Bind groups ----------------------------------------------
+        gpu::bind_group_descriptor resolve_bind_group_descriptor{};
+        resolve_bind_group_descriptor.layout = m_resolve_layout;
+
+        gpu::binding_value current_slot{};
+        current_slot.binding = 0;
+        current_slot.kind = gpu::binding_kind::texture;
+        current_slot.texture_value = current_color;
+        resolve_bind_group_descriptor.entries.push_back(current_slot);
+
+        gpu::binding_value history_slot{};
+        history_slot.binding = 1;
+        history_slot.kind = gpu::binding_kind::texture;
+        history_slot.texture_value = m_history_texture;
+        resolve_bind_group_descriptor.entries.push_back(history_slot);
+
+        gpu::binding_value params_slot{};
+        params_slot.binding = 2;
+        params_slot.kind = gpu::binding_kind::uniform_buffer;
+        params_slot.buffer_value = m_resolve_ubo;
+        resolve_bind_group_descriptor.entries.push_back(params_slot);
+
+        m_resolve_bind_group = gpu.create_bind_group(resolve_bind_group_descriptor);
+
+        gpu::bind_group_descriptor copy_bind_group_descriptor{};
+        copy_bind_group_descriptor.layout = m_copy_layout;
+
+        gpu::binding_value src_slot{};
+        src_slot.binding = 0;
+        src_slot.kind = gpu::binding_kind::texture;
+        src_slot.texture_value = m_resolve_texture;
+        copy_bind_group_descriptor.entries.push_back(src_slot);
+
+        m_copy_bind_group = gpu.create_bind_group(copy_bind_group_descriptor);
+
+        m_enabled = true;
+    }
+
+    taa_pass::~taa_pass()
+    {
+        auto& gpu = *runtime::current_engine().gpu;
+
+        if (m_copy_bind_group.valid())
+        {
+            gpu.destroy(m_copy_bind_group);
+            m_copy_bind_group = {};
+        }
+        if (m_resolve_bind_group.valid())
+        {
+            gpu.destroy(m_resolve_bind_group);
+            m_resolve_bind_group = {};
+        }
+        // Each render target owns its colour attachment, so destroying the
+        // target releases the texture too.
+        if (m_resolve_target.valid())
+        {
+            gpu.destroy(m_resolve_target);
+            m_resolve_target = {};
+            m_resolve_texture = {};
+        }
+        if (m_history_target.valid())
+        {
+            gpu.destroy(m_history_target);
+            m_history_target = {};
+            m_history_texture = {};
+        }
+        if (m_copy_pipeline.valid())
+        {
+            gpu.destroy(m_copy_pipeline);
+            m_copy_pipeline = {};
+        }
+        if (m_resolve_pipeline.valid())
+        {
+            gpu.destroy(m_resolve_pipeline);
+            m_resolve_pipeline = {};
+        }
+        if (m_copy_layout.valid())
+        {
+            gpu.destroy(m_copy_layout);
+            m_copy_layout = {};
+        }
+        if (m_resolve_layout.valid())
+        {
+            gpu.destroy(m_resolve_layout);
+            m_resolve_layout = {};
+        }
+        if (m_resolve_ubo.valid())
+        {
+            gpu.destroy(m_resolve_ubo);
+            m_resolve_ubo = {};
+        }
+        if (m_vertex_buffer.valid())
+        {
+            gpu.destroy(m_vertex_buffer);
+            m_vertex_buffer = {};
+        }
+        if (m_copy_shader.valid())
+        {
+            gpu.destroy(m_copy_shader);
+            m_copy_shader = {};
+        }
+        if (m_resolve_shader.valid())
+        {
+            gpu.destroy(m_resolve_shader);
+            m_resolve_shader = {};
+        }
+        if (m_vertex_shader.valid())
+        {
+            gpu.destroy(m_vertex_shader);
+            m_vertex_shader = {};
+        }
+    }
+
+    gpu::texture taa_pass::output_texture() const
+    {
+        return m_resolve_texture;
+    }
+
+    void taa_pass::record(gpu::command_encoder& encoder, const frame_context&)
+    {
+        if (!m_enabled)
+        {
+            return;
+        }
+
+        auto& gpu = *runtime::current_engine().gpu;
+
+        auto draw_fullscreen =
+            [&](gpu::render_pass_encoder* pass_encoder, gpu::pipeline pipeline, gpu::bind_group bind_group)
+        {
+            pass_encoder->set_pipeline(pipeline);
+            pass_encoder->set_bind_group(0, bind_group);
+            pass_encoder->set_vertex_buffer(0, m_vertex_buffer, 0, 0);
+            pass_encoder->draw(3, 0);
+        };
+
+        // 1. Resolve: blend the current LDR frame with the clamped history
+        //    into the resolve target the next pass (FXAA) samples.
+        {
+            gpu::render_pass_descriptor descriptor{};
+            descriptor.target = m_resolve_target;
+            descriptor.color.load = gpu::load_op::clear;
+            descriptor.color.clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
+            descriptor.use_depth = false;
+
+            auto pass_encoder = encoder.begin_render_pass(descriptor);
+            draw_fullscreen(pass_encoder.get(), m_resolve_pipeline, m_resolve_bind_group);
+            pass_encoder->end();
+        }
+
+        // 2. Store the resolved frame into the history target for the next
+        //    frame's resolve to read.
+        {
+            gpu::render_pass_descriptor descriptor{};
+            descriptor.target = m_history_target;
+            descriptor.color.load = gpu::load_op::clear;
+            descriptor.color.clear_color = {0.0f, 0.0f, 0.0f, 1.0f};
+            descriptor.use_depth = false;
+
+            auto pass_encoder = encoder.begin_render_pass(descriptor);
+            draw_fullscreen(pass_encoder.get(), m_copy_pipeline, m_copy_bind_group);
+            pass_encoder->end();
+        }
+
+        // The first frame resolved against an undefined history with the
+        // feedback pinned to 0 (current frame only). Now that the history
+        // target holds a real frame, switch to the steady-state feedback so
+        // subsequent frames accumulate.
+        if (m_first_frame)
+        {
+            m_first_frame = false;
+            // Rewrite the whole vec4 so the baked texel step (xy) is kept
+            // alongside the now-live feedback weight (z).
+            const std::array<float, 4> params = {m_inv_width, m_inv_height, taa_feedback, 0.0f};
+            gpu.write_buffer(m_resolve_ubo, params.data(), taa_ubo_size, 0);
+        }
+    }
+} // namespace rendering_engine

--- a/rendering_engine/passes/post/taa_pass.cpp
+++ b/rendering_engine/passes/post/taa_pass.cpp
@@ -44,14 +44,18 @@ namespace
     // clamp below is what stops that long tail from ghosting under motion.
     constexpr float taa_feedback = 0.9f;
 
-    // The reprojection-free temporal resolve. The current jittered frame
-    // is blended with last frame's accumulated result; because the
-    // projection jitter moves the sub-pixel sample location every frame,
-    // that blend converges to a supersampled image on a static view. To
-    // keep moving content from smearing the stale history is first
-    // constrained to the 3x3 colour box around the current texel (the
-    // standard neighbourhood clamp), so any history that has drifted
-    // outside what the present frame plausibly contains is pulled back in.
+    // The temporal resolve. The current jittered frame is blended with last
+    // frame's accumulated result; because the projection jitter moves the
+    // sub-pixel sample location every frame, that blend converges to a
+    // supersampled image. The history is first reprojected along the
+    // per-pixel motion vectors (history sampled at texCoord - velocity) so a
+    // moving camera keeps the accumulated detail glued to the surface rather
+    // than smearing it across the screen. It is then constrained to the 3x3
+    // colour box around the current texel (the standard neighbourhood clamp)
+    // so history that survives reprojection but no longer matches the
+    // present frame — at disocclusions, or for the unmodelled object motion
+    // — is pulled back in; history that reprojects outside the frame is
+    // dropped entirely in favour of the current sample.
     //
     // u_taa.params.xy is (1/width, 1/height) — the per-texel step the
     // neighbourhood taps walk by — and params.z is the history feedback
@@ -65,8 +69,9 @@ namespace
 
         layout(set = 0, binding = 0) uniform sampler2D currentColor;
         layout(set = 0, binding = 1) uniform sampler2D historyColor;
+        layout(set = 0, binding = 2) uniform sampler2D velocity;
 
-        layout(set = 0, binding = 2, std140) uniform Taa
+        layout(set = 0, binding = 3, std140) uniform Taa
         {
             vec4 params; // x = 1/width, y = 1/height, z = history feedback, w unused
         } u_taa;
@@ -78,7 +83,7 @@ namespace
             vec3 current = texture(currentColor, texCoord).rgb;
 
             // 3x3 neighbourhood min/max of the current frame: the colour
-            // box the history is clamped into before blending.
+            // box the reprojected history is clamped into before blending.
             vec3 box_min = current;
             vec3 box_max = current;
             for (int y = -1; y <= 1; ++y)
@@ -95,10 +100,22 @@ namespace
                 }
             }
 
-            vec3 history = texture(historyColor, texCoord).rgb;
+            // Reproject the history along this pixel's motion vector. A
+            // sample that lands off-screen has no valid history, so fall
+            // back to the current frame (feedback 0) there.
+            vec2 motion = texture(velocity, texCoord).xy;
+            vec2 history_uv = texCoord - motion;
+            float feedback = u_taa.params.z;
+            if (any(lessThan(history_uv, vec2(0.0))) || any(greaterThan(history_uv, vec2(1.0))))
+            {
+                feedback = 0.0;
+                history_uv = texCoord;
+            }
+
+            vec3 history = texture(historyColor, history_uv).rgb;
             history = clamp(history, box_min, box_max);
 
-            vec3 resolved = mix(current, history, u_taa.params.z);
+            vec3 resolved = mix(current, history, feedback);
             fragColor = vec4(resolved, 1.0);
         }
 )fs";
@@ -125,7 +142,7 @@ namespace
 
 namespace rendering_engine
 {
-    taa_pass::taa_pass(gpu::texture current_color, uint32_t width, uint32_t height)
+    taa_pass::taa_pass(gpu::texture current_color, gpu::texture velocity, uint32_t width, uint32_t height)
     {
         auto& gpu = *runtime::current_engine().gpu;
 
@@ -179,7 +196,8 @@ namespace rendering_engine
         gpu::bind_group_layout_descriptor resolve_layout{};
         resolve_layout.entries.push_back({0, gpu::binding_kind::texture});
         resolve_layout.entries.push_back({1, gpu::binding_kind::texture});
-        resolve_layout.entries.push_back({2, gpu::binding_kind::uniform_buffer});
+        resolve_layout.entries.push_back({2, gpu::binding_kind::texture});
+        resolve_layout.entries.push_back({3, gpu::binding_kind::uniform_buffer});
         m_resolve_layout = gpu.create_bind_group_layout(resolve_layout);
 
         gpu::bind_group_layout_descriptor copy_layout{};
@@ -254,8 +272,14 @@ namespace rendering_engine
         history_slot.texture_value = m_history_texture;
         resolve_bind_group_descriptor.entries.push_back(history_slot);
 
+        gpu::binding_value velocity_slot{};
+        velocity_slot.binding = 2;
+        velocity_slot.kind = gpu::binding_kind::texture;
+        velocity_slot.texture_value = velocity;
+        resolve_bind_group_descriptor.entries.push_back(velocity_slot);
+
         gpu::binding_value params_slot{};
-        params_slot.binding = 2;
+        params_slot.binding = 3;
         params_slot.kind = gpu::binding_kind::uniform_buffer;
         params_slot.buffer_value = m_resolve_ubo;
         resolve_bind_group_descriptor.entries.push_back(params_slot);

--- a/rendering_engine/passes/post/taa_pass.hpp
+++ b/rendering_engine/passes/post/taa_pass.hpp
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/passes/pass.hpp>
+
+namespace rendering_engine
+{
+    /**
+     * @brief Temporal anti-aliasing resolve on the tonemapped LDR image.
+     *
+     * The temporal partner to @ref fxaa_pass: where FXAA smooths a single
+     * frame spatially, TAA accumulates many sub-pixel-jittered frames into
+     * one stable, supersampled image. The scene pass jitters the
+     * projection matrix by a Halton(2,3) offset each frame (gated on the
+     * same @c temporal_aa setting), so every frame samples the scene at a
+     * slightly different sub-pixel position; blending those frames over
+     * time resolves detail that no single-frame filter can — fine geometry
+     * edges, specular shimmer, the near-mirror IBL reflections — which is
+     * exactly the THREE.TAARenderPass / SSAARenderPass behaviour this
+     * mirrors.
+     *
+     * The resolve runs after @ref tonemap_pass on the LDR target (TAA on
+     * the perceptual image keeps HDR fireflies from dominating the history)
+     * and feeds @ref fxaa_pass, which closes the post chain. Each frame:
+     *
+     *  1. The resolve stage blends the current LDR frame with the
+     *     reprojection-free history at the same pixel. A 3x3 neighbourhood
+     *     colour clamp constrains the history to the current frame's local
+     *     min/max box before the blend, so a static camera converges to a
+     *     supersampled image while moving content is pulled back toward the
+     *     present frame instead of smearing (ghosting). This is the classic
+     *     velocity-less TAA; per-object motion vectors are a follow-up.
+     *  2. A copy stage stores the resolved frame into the history target
+     *     for the next frame to read.
+     *
+     * The resolved result is exposed via @ref output_texture so the next
+     * pass (FXAA) samples it instead of the raw tonemap output. A fixed
+     * resolve target (rather than ping-ponged history handles) keeps that
+     * handle stable across frames so the FXAA bind group never has to be
+     * rebuilt.
+     *
+     * Pipeline state mirrors every other fullscreen-triangle post pass
+     * (depth off, blend off, no culling, single vec2 vertex attribute).
+     * The reciprocal frame size the neighbourhood taps step by is baked
+     * from the backbuffer dimensions at construction, mirroring
+     * @ref fxaa_pass; live resolution changes are out of scope. A
+     * degenerate backbuffer leaves the pass disabled so the LDR target
+     * flows straight through to FXAA.
+     */
+    struct taa_pass : pass
+    {
+        // @p current_color is the LDR texture @ref tonemap_pass renders
+        // into; @p width / @p height are the backbuffer dimensions the
+        // history and resolve targets are sized against.
+        taa_pass(gpu::texture current_color, uint32_t width, uint32_t height);
+        ~taa_pass() override;
+
+        taa_pass(const taa_pass&) = delete;
+        taa_pass& operator=(const taa_pass&) = delete;
+
+        void record(gpu::command_encoder& encoder, const frame_context& ctx) override;
+
+        // The resolved LDR texture the next pass (FXAA) samples. Stable
+        // across frames. Invalid when the pass is disabled (degenerate
+        // backbuffer), in which case the caller should keep sampling the
+        // raw tonemap output.
+        gpu::texture output_texture() const;
+
+    private:
+        gpu::shader_module m_vertex_shader{};
+        gpu::shader_module m_resolve_shader{};
+        gpu::shader_module m_copy_shader{};
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_resolve_ubo{};
+
+        // {currentColor @0, historyColor @1, params @2} for the resolve
+        // stage; {src @0} for the history-store copy.
+        gpu::bind_group_layout m_resolve_layout{};
+        gpu::bind_group_layout m_copy_layout{};
+
+        gpu::pipeline m_resolve_pipeline{};
+        gpu::pipeline m_copy_pipeline{};
+
+        // History holds the previous frame's resolved image; resolve holds
+        // this frame's. The copy stage stores resolve into history at the
+        // end of the frame. Both own their colour attachment, so destroying
+        // the target releases the texture.
+        gpu::render_target m_history_target{};
+        gpu::texture m_history_texture{};
+        gpu::render_target m_resolve_target{};
+        gpu::texture m_resolve_texture{};
+
+        gpu::bind_group m_resolve_bind_group{};
+        gpu::bind_group m_copy_bind_group{};
+
+        // Per-texel step (1/width, 1/height) baked at construction. Kept so
+        // record() can rewrite the resolve params UBO — bumping only the
+        // feedback weight — without losing the step in xy.
+        float m_inv_width{0.0f};
+        float m_inv_height{0.0f};
+
+        // False until the first frame has populated the history target.
+        // While set, the resolve uses the current frame only (the history
+        // is still undefined), then the params UBO is switched to the
+        // steady-state feedback weight.
+        bool m_first_frame{true};
+
+        // False when the backbuffer dimensions are degenerate (no settings,
+        // zero-sized window); record() then no-ops and output_texture()
+        // returns an invalid handle so the caller keeps the tonemap output.
+        bool m_enabled{false};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/passes/post/taa_pass.hpp
+++ b/rendering_engine/passes/post/taa_pass.hpp
@@ -45,13 +45,15 @@ namespace rendering_engine
      * the perceptual image keeps HDR fireflies from dominating the history)
      * and feeds @ref fxaa_pass, which closes the post chain. Each frame:
      *
-     *  1. The resolve stage blends the current LDR frame with the
-     *     reprojection-free history at the same pixel. A 3x3 neighbourhood
-     *     colour clamp constrains the history to the current frame's local
-     *     min/max box before the blend, so a static camera converges to a
-     *     supersampled image while moving content is pulled back toward the
-     *     present frame instead of smearing (ghosting). This is the classic
-     *     velocity-less TAA; per-object motion vectors are a follow-up.
+     *  1. The resolve stage reprojects the colour history along the
+     *     per-pixel motion vectors from @ref velocity_pass — sampling the
+     *     history at @c texCoord - velocity rather than the same pixel — so
+     *     a moving camera keeps the accumulated detail aligned to the
+     *     surface instead of smearing it. A 3x3 neighbourhood colour clamp
+     *     then constrains that reprojected history to the current frame's
+     *     local min/max box before the blend, suppressing the ghosting that
+     *     reprojection alone leaves at disocclusions; history that
+     *     reprojects off-screen is dropped in favour of the current frame.
      *  2. A copy stage stores the resolved frame into the history target
      *     for the next frame to read.
      *
@@ -72,9 +74,11 @@ namespace rendering_engine
     struct taa_pass : pass
     {
         // @p current_color is the LDR texture @ref tonemap_pass renders
-        // into; @p width / @p height are the backbuffer dimensions the
-        // history and resolve targets are sized against.
-        taa_pass(gpu::texture current_color, uint32_t width, uint32_t height);
+        // into; @p velocity is the motion-vector texture @ref velocity_pass
+        // produces, sampled to reproject the history; @p width / @p height
+        // are the backbuffer dimensions the history and resolve targets are
+        // sized against.
+        taa_pass(gpu::texture current_color, gpu::texture velocity, uint32_t width, uint32_t height);
         ~taa_pass() override;
 
         taa_pass(const taa_pass&) = delete;
@@ -96,8 +100,8 @@ namespace rendering_engine
         gpu::buffer m_vertex_buffer{};
         gpu::buffer m_resolve_ubo{};
 
-        // {currentColor @0, historyColor @1, params @2} for the resolve
-        // stage; {src @0} for the history-store copy.
+        // {currentColor @0, historyColor @1, velocity @2, params @3} for
+        // the resolve stage; {src @0} for the history-store copy.
         gpu::bind_group_layout m_resolve_layout{};
         gpu::bind_group_layout m_copy_layout{};
 

--- a/rendering_engine/passes/post/velocity_pass.cpp
+++ b/rendering_engine/passes/post/velocity_pass.cpp
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rendering_engine/passes/post/velocity_pass.hpp>
+
+#include <string>
+
+#include <core/math/math.hpp>
+#include <rendering_engine/camera/camera.hpp>
+#include <rendering_engine/gpu/bind_group.hpp>
+#include <rendering_engine/gpu/buffer.hpp>
+#include <rendering_engine/gpu/device.hpp>
+#include <rendering_engine/gpu/pipeline.hpp>
+#include <rendering_engine/gpu/render_target.hpp>
+#include <rendering_engine/gpu/shader.hpp>
+#include <rendering_engine/gpu/shader_compiler.hpp>
+#include <rendering_engine/passes/post/fullscreen_triangle.hpp>
+#include <runtime/engine.hpp>
+
+namespace
+{
+    // Reconstructs each pixel's previous-frame screen position from depth.
+    // The current pixel's clip-space point (NDC xy from the UV, NDC z from
+    // the depth buffer — GL convention, z in [-1, 1]) is pushed through the
+    // baked reprojection matrix prevViewProj * inverse(curViewProj), which
+    // takes it to the previous frame's clip space directly; the perspective
+    // divide there yields the previous NDC and hence the previous UV. The
+    // motion vector is the UV delta, so the TAA resolve reads history at
+    // texCoord - velocity.
+    //
+    // Background pixels (depth at the far plane) reproject through the same
+    // matrix, so a panning or rotating camera still produces correct motion
+    // for the skybox.
+    const std::string fragment_shader = R"fs(
+        #version 450
+
+        layout(location = 0) in vec2 texCoord;
+        layout(location = 0) out vec4 fragColor;
+
+        layout(set = 0, binding = 0) uniform sampler2D sceneDepth;
+
+        layout(set = 0, binding = 1, std140) uniform Reprojection
+        {
+            mat4 reprojection; // prevViewProj * inverse(curViewProj), unjittered
+        } u_reproj;
+
+        void main()
+        {
+            float depth = texture(sceneDepth, texCoord).r;
+
+            // Current pixel in NDC (clip space before the divide is the same
+            // point scaled by w, which cancels in the divide below).
+            vec3 ndc = vec3(texCoord * 2.0 - 1.0, depth * 2.0 - 1.0);
+
+            vec4 prev_clip = u_reproj.reprojection * vec4(ndc, 1.0);
+            vec2 prev_ndc = prev_clip.xy / prev_clip.w;
+            vec2 prev_uv = prev_ndc * 0.5 + 0.5;
+
+            fragColor = vec4(texCoord - prev_uv, 0.0, 0.0);
+        }
+)fs";
+
+    // std140: a single mat4 occupies 64 bytes.
+    constexpr size_t reproj_ubo_size = sizeof(core::math::mat4);
+} // namespace
+
+namespace rendering_engine
+{
+    velocity_pass::velocity_pass(gpu::texture scene_depth, uint32_t width, uint32_t height)
+    {
+        auto& gpu = *runtime::current_engine().gpu;
+
+        // Degenerate backbuffer (no settings, zero-sized window): leave the
+        // pass disabled so velocity_texture() reports invalid.
+        if (width == 0 || height == 0)
+        {
+            return;
+        }
+
+        gpu::shader_module_descriptor vs_descriptor{};
+        vs_descriptor.stage = gpu::shader_stage::vertex;
+        vs_descriptor.spirv = gpu::compile_glsl_to_spirv(fullscreen_triangle_vertex_shader, gpu::shader_stage::vertex);
+        m_vertex_shader = gpu.create_shader_module(vs_descriptor);
+
+        gpu::shader_module_descriptor fs_descriptor{};
+        fs_descriptor.stage = gpu::shader_stage::fragment;
+        fs_descriptor.spirv = gpu::compile_glsl_to_spirv(fragment_shader, gpu::shader_stage::fragment);
+        m_fragment_shader = gpu.create_shader_module(fs_descriptor);
+
+        gpu::buffer_descriptor vb_descriptor{};
+        vb_descriptor.size = fullscreen_triangle_vertices.size() * sizeof(float);
+        vb_descriptor.usage = gpu::buffer_usage_vertex;
+        vb_descriptor.hint = gpu::buffer_usage_hint::static_data;
+        vb_descriptor.initial_data = fullscreen_triangle_vertices.data();
+        m_vertex_buffer = gpu.create_buffer(vb_descriptor);
+
+        // The reprojection matrix is rewritten every frame from the live
+        // camera, so the buffer is dynamic and copy-dst.
+        gpu::buffer_descriptor ubo_descriptor{};
+        ubo_descriptor.size = reproj_ubo_size;
+        ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
+        ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
+        m_reproj_ubo = gpu.create_buffer(ubo_descriptor);
+
+        gpu::bind_group_layout_descriptor layout{};
+        layout.entries.push_back({0, gpu::binding_kind::texture});
+        layout.entries.push_back({1, gpu::binding_kind::uniform_buffer});
+        m_layout = gpu.create_bind_group_layout(layout);
+
+        // Two-channel signed motion needs a float target; the engine has no
+        // RG format, so rgba16f carries the vector in xy and leaves zw at 0.
+        gpu::render_target_descriptor velocity_descriptor{};
+        velocity_descriptor.color_format = gpu::texture_format::rgba16_float;
+        velocity_descriptor.width = width;
+        velocity_descriptor.height = height;
+        velocity_descriptor.with_depth = false;
+        m_velocity_target = gpu.create_render_target(velocity_descriptor);
+        m_velocity_texture = gpu.render_target_color_texture(m_velocity_target);
+
+        gpu::vertex_buffer_layout vertex_layout{};
+        vertex_layout.stride = sizeof(float) * 2;
+        vertex_layout.attributes.push_back({0, 2, gpu::scalar_type::float32, 0});
+
+        gpu::depth_state depth{};
+        depth.test_enabled = false;
+        depth.write_enabled = false;
+        depth.compare = gpu::compare_function::always;
+
+        gpu::blend_state blend{};
+        blend.enabled = false;
+
+        gpu::rasterizer_state rasterizer{};
+        rasterizer.cull = gpu::cull_mode::none;
+        rasterizer.front = gpu::front_face::counter_clockwise;
+        rasterizer.polygon = gpu::polygon_mode::fill;
+
+        gpu::pipeline_descriptor pipeline_descriptor{};
+        pipeline_descriptor.vertex_shader = m_vertex_shader;
+        pipeline_descriptor.fragment_shader = m_fragment_shader;
+        pipeline_descriptor.vertex_buffers.push_back(vertex_layout);
+        pipeline_descriptor.depth = depth;
+        pipeline_descriptor.blend = blend;
+        pipeline_descriptor.rasterizer = rasterizer;
+        pipeline_descriptor.bind_group_layouts.push_back(m_layout);
+        m_pipeline = gpu.create_pipeline(pipeline_descriptor);
+
+        gpu::bind_group_descriptor bind_group_descriptor{};
+        bind_group_descriptor.layout = m_layout;
+
+        gpu::binding_value depth_slot{};
+        depth_slot.binding = 0;
+        depth_slot.kind = gpu::binding_kind::texture;
+        depth_slot.texture_value = scene_depth;
+        bind_group_descriptor.entries.push_back(depth_slot);
+
+        gpu::binding_value reproj_slot{};
+        reproj_slot.binding = 1;
+        reproj_slot.kind = gpu::binding_kind::uniform_buffer;
+        reproj_slot.buffer_value = m_reproj_ubo;
+        bind_group_descriptor.entries.push_back(reproj_slot);
+
+        m_bind_group = gpu.create_bind_group(bind_group_descriptor);
+
+        m_enabled = true;
+    }
+
+    velocity_pass::~velocity_pass()
+    {
+        auto& gpu = *runtime::current_engine().gpu;
+
+        if (m_bind_group.valid())
+        {
+            gpu.destroy(m_bind_group);
+            m_bind_group = {};
+        }
+        if (m_velocity_target.valid())
+        {
+            gpu.destroy(m_velocity_target);
+            m_velocity_target = {};
+            m_velocity_texture = {};
+        }
+        if (m_pipeline.valid())
+        {
+            gpu.destroy(m_pipeline);
+            m_pipeline = {};
+        }
+        if (m_layout.valid())
+        {
+            gpu.destroy(m_layout);
+            m_layout = {};
+        }
+        if (m_reproj_ubo.valid())
+        {
+            gpu.destroy(m_reproj_ubo);
+            m_reproj_ubo = {};
+        }
+        if (m_vertex_buffer.valid())
+        {
+            gpu.destroy(m_vertex_buffer);
+            m_vertex_buffer = {};
+        }
+        if (m_fragment_shader.valid())
+        {
+            gpu.destroy(m_fragment_shader);
+            m_fragment_shader = {};
+        }
+        if (m_vertex_shader.valid())
+        {
+            gpu.destroy(m_vertex_shader);
+            m_vertex_shader = {};
+        }
+    }
+
+    gpu::texture velocity_pass::velocity_texture() const
+    {
+        return m_velocity_texture;
+    }
+
+    void velocity_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
+    {
+        if (!m_enabled)
+        {
+            return;
+        }
+
+        auto& gpu = *runtime::current_engine().gpu;
+
+        // No camera: clear the motion to zero so the TAA resolve falls back
+        // to same-pixel history, and forget the previous matrix so the next
+        // camera frame starts fresh (zero motion) rather than reprojecting
+        // across the gap.
+        if (ctx.active_camera == nullptr)
+        {
+            gpu::render_pass_descriptor descriptor{};
+            descriptor.target = m_velocity_target;
+            descriptor.color.load = gpu::load_op::clear;
+            descriptor.color.clear_color = {0.0f, 0.0f, 0.0f, 0.0f};
+            descriptor.use_depth = false;
+            auto pass_encoder = encoder.begin_render_pass(descriptor);
+            pass_encoder->end();
+            m_has_prev = false;
+            return;
+        }
+
+        // Build the current unjittered view-projection (the scene pass keeps
+        // its sub-pixel jitter local, so the camera's matrices are clean).
+        const core::math::mat4 view = ctx.active_camera->get_view_matrix();
+        const core::math::mat4 projection = ctx.active_camera->get_projection_matrix();
+        const core::math::mat4 view_proj = projection * view;
+
+        // First camera frame has no history: reproject against this frame so
+        // every pixel reports zero motion.
+        const core::math::mat4& prev_view_proj = m_has_prev ? m_prev_view_proj : view_proj;
+        const core::math::mat4 reprojection = prev_view_proj * core::math::inverse(view_proj);
+        gpu.write_buffer(m_reproj_ubo, reprojection.data(), reproj_ubo_size, 0);
+
+        gpu::render_pass_descriptor descriptor{};
+        descriptor.target = m_velocity_target;
+        descriptor.color.load = gpu::load_op::clear;
+        descriptor.color.clear_color = {0.0f, 0.0f, 0.0f, 0.0f};
+        descriptor.use_depth = false;
+
+        auto pass_encoder = encoder.begin_render_pass(descriptor);
+        pass_encoder->set_pipeline(m_pipeline);
+        pass_encoder->set_bind_group(0, m_bind_group);
+        pass_encoder->set_vertex_buffer(0, m_vertex_buffer, 0, 0);
+        pass_encoder->draw(3, 0);
+        pass_encoder->end();
+
+        m_prev_view_proj = view_proj;
+        m_has_prev = true;
+    }
+} // namespace rendering_engine

--- a/rendering_engine/passes/post/velocity_pass.hpp
+++ b/rendering_engine/passes/post/velocity_pass.hpp
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <core/math/math.hpp>
+#include <rendering_engine/gpu/handle.hpp>
+#include <rendering_engine/passes/pass.hpp>
+
+namespace rendering_engine
+{
+    /**
+     * @brief Per-pixel screen-space motion vectors for temporal reprojection.
+     *
+     * Writes, for every pixel, the UV-space displacement of the surface
+     * under it since the previous frame: @c velocity = thisFrameUV -
+     * lastFrameUV. The @ref taa_pass samples this to reproject its colour
+     * history along the motion, so a moving camera keeps a sharp,
+     * supersampled image instead of relying on the neighbourhood clamp to
+     * hide the misalignment.
+     *
+     * The vectors are reconstructed from the scene depth buffer and the
+     * camera matrices alone — a single fullscreen pass, no second geometry
+     * draw. Each pixel's depth plus the current inverse view-projection
+     * gives its world position; re-projecting that world position through
+     * the previous frame's view-projection gives where it sat on screen
+     * last frame, and the difference is the motion vector. One
+     * @c reprojection matrix (@c prevViewProj * inverse(curViewProj),
+     * both unjittered) folds the whole chain into a single transform
+     * uploaded per frame. This captures camera motion for the static world;
+     * independently animated objects need their own previous-frame
+     * transforms (a multi-target geometry pass) and remain future work.
+     *
+     * Runs after the scene/skybox passes (so the depth buffer is final) and
+     * before @ref taa_pass. The result is an @c rgba16f target with the
+     * signed motion in @c xy; it is exposed via @ref velocity_texture so
+     * the TAA resolve can sample it. Pipeline state mirrors the other
+     * fullscreen-triangle passes (depth off, blend off, no culling). A
+     * degenerate backbuffer leaves the pass disabled; a frame with no
+     * camera clears the target to zero (no motion).
+     */
+    struct velocity_pass : pass
+    {
+        // @p scene_depth is the depth attachment of the HDR scene target;
+        // @p width / @p height size the velocity target.
+        velocity_pass(gpu::texture scene_depth, uint32_t width, uint32_t height);
+        ~velocity_pass() override;
+
+        velocity_pass(const velocity_pass&) = delete;
+        velocity_pass& operator=(const velocity_pass&) = delete;
+
+        void record(gpu::command_encoder& encoder, const frame_context& ctx) override;
+
+        // The motion-vector texture the TAA resolve samples (signed UV
+        // displacement in xy). Stable across frames; invalid when the pass
+        // is disabled (degenerate backbuffer).
+        gpu::texture velocity_texture() const;
+
+    private:
+        gpu::shader_module m_vertex_shader{};
+        gpu::shader_module m_fragment_shader{};
+
+        gpu::buffer m_vertex_buffer{};
+        gpu::buffer m_reproj_ubo{};
+
+        // {sceneDepth @0, reprojection @1}.
+        gpu::bind_group_layout m_layout{};
+        gpu::pipeline m_pipeline{};
+
+        gpu::render_target m_velocity_target{};
+        gpu::texture m_velocity_texture{};
+        gpu::bind_group m_bind_group{};
+
+        // Previous frame's unjittered view-projection, kept so this frame
+        // can build the reprojection matrix. @c m_has_prev is false until
+        // the first camera frame has run, so that frame reports zero motion
+        // instead of reprojecting against an undefined matrix.
+        core::math::mat4 m_prev_view_proj{};
+        bool m_has_prev{false};
+
+        // False when the backbuffer dimensions are degenerate (no settings,
+        // zero-sized window); record() then no-ops and velocity_texture()
+        // returns an invalid handle.
+        bool m_enabled{false};
+    };
+} // namespace rendering_engine

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -122,6 +122,21 @@ namespace rendering_engine
     {
         auto& gpu = *runtime::current_engine().gpu;
 
+        // Enable projection jitter only when temporal AA is on and the
+        // window has a usable size; the @ref taa_pass accumulates the
+        // jittered frames. The reciprocal dimensions scale each Halton
+        // offset down to a sub-pixel NDC amount. Read up front so the
+        // bind-group setup below knows whether to build the unjittered
+        // overlay twin the debug pass binds.
+        const ::settings* config = runtime::current_engine().settings.get();
+        if (config != nullptr && config->graphics.temporal_aa && config->window.width != 0 &&
+            config->window.height != 0)
+        {
+            m_taa_jitter = true;
+            m_inv_width = 1.0f / static_cast<float>(config->window.width);
+            m_inv_height = 1.0f / static_cast<float>(config->window.height);
+        }
+
         gpu::bind_group_layout_descriptor frame_layout_descriptor{};
         frame_layout_descriptor.entries.push_back({camera_binding, gpu::binding_kind::uniform_buffer});
         frame_layout_descriptor.entries.push_back({lights_binding, gpu::binding_kind::uniform_buffer});
@@ -140,6 +155,13 @@ namespace rendering_engine
         ubo_descriptor.usage = gpu::buffer_usage_uniform | gpu::buffer_usage_copy_dst;
         ubo_descriptor.hint = gpu::buffer_usage_hint::dynamic_data;
         m_frame_ubo = gpu.create_buffer(ubo_descriptor);
+
+        // The unjittered camera UBO only exists when jitter is active; it
+        // backs the overlay bind group built below.
+        if (m_taa_jitter)
+        {
+            m_overlay_frame_ubo = gpu.create_buffer(ubo_descriptor);
+        }
 
         gpu::buffer_descriptor lights_descriptor{};
         lights_descriptor.size = sizeof(gpu_lights);
@@ -210,23 +232,30 @@ namespace rendering_engine
 
         m_frame_bind_group = gpu.create_bind_group(frame_bind_group_descriptor);
 
-        // Enable projection jitter only when temporal AA is on and the
-        // window has a usable size; the @ref taa_pass accumulates the
-        // jittered frames. The reciprocal dimensions scale each Halton
-        // offset down to a sub-pixel NDC amount.
-        const ::settings* config = runtime::current_engine().settings.get();
-        if (config != nullptr && config->graphics.temporal_aa && config->window.width != 0 &&
-            config->window.height != 0)
+        // The overlay twin shares every binding with the main group except
+        // the camera UBO (entries[0], pushed first above), which it points
+        // at the unjittered buffer so the debug pass projects without the
+        // sub-pixel jitter.
+        if (m_taa_jitter)
         {
-            m_taa_jitter = true;
-            m_inv_width = 1.0f / static_cast<float>(config->window.width);
-            m_inv_height = 1.0f / static_cast<float>(config->window.height);
+            frame_bind_group_descriptor.entries[0].buffer_value = m_overlay_frame_ubo;
+            m_overlay_frame_bind_group = gpu.create_bind_group(frame_bind_group_descriptor);
         }
     }
 
     scene_pass::~scene_pass()
     {
         auto& gpu = *runtime::current_engine().gpu;
+        if (m_overlay_frame_bind_group.valid())
+        {
+            gpu.destroy(m_overlay_frame_bind_group);
+            m_overlay_frame_bind_group = {};
+        }
+        if (m_overlay_frame_ubo.valid())
+        {
+            gpu.destroy(m_overlay_frame_ubo);
+            m_overlay_frame_ubo = {};
+        }
         if (m_frame_bind_group.valid())
         {
             gpu.destroy(m_frame_bind_group);
@@ -267,6 +296,13 @@ namespace rendering_engine
     gpu::bind_group scene_pass::frame_bind_group() const
     {
         return m_frame_bind_group;
+    }
+
+    gpu::bind_group scene_pass::overlay_frame_bind_group() const
+    {
+        // Falls back to the (already unjittered) main group when jitter is
+        // off, so the debug pass needs no special-casing.
+        return m_overlay_frame_bind_group.valid() ? m_overlay_frame_bind_group : m_frame_bind_group;
     }
 
     void scene_pass::record(gpu::command_encoder& encoder, const frame_context& ctx)
@@ -312,24 +348,7 @@ namespace rendering_engine
         // fog block (fogColor at float 32, fogParams at float 36).
         std::array<float, 40> ubo_payload{};
         const auto view = ctx.active_camera->get_view_matrix();
-        core::math::mat4 projection = ctx.active_camera->get_projection_matrix();
-
-        // Temporal-AA sub-pixel jitter: offset the projection by a Halton
-        // step so this frame samples the scene a fraction of a pixel away
-        // from the last. Column-major storage puts the clip-space x/y shear
-        // terms (row 0/1 of column 2) at m[8] / m[9]; nudging them shifts
-        // the whole frame uniformly in NDC after the perspective divide.
-        // The jitter feeds the taa_pass accumulation and is otherwise
-        // invisible — culling still uses the camera's unjittered frustum.
-        if (m_taa_jitter)
-        {
-            m_jitter_index = (m_jitter_index + 1u) % taa_jitter_period;
-            const float jitter_x = (halton(m_jitter_index + 1u, 2u) - 0.5f) * 2.0f * m_inv_width;
-            const float jitter_y = (halton(m_jitter_index + 1u, 3u) - 0.5f) * 2.0f * m_inv_height;
-            projection.m[8] += jitter_x;
-            projection.m[9] += jitter_y;
-        }
-
+        const core::math::mat4 projection = ctx.active_camera->get_projection_matrix();
         std::memcpy(ubo_payload.data(), view.data(), sizeof(core::math::mat4));
         std::memcpy(ubo_payload.data() + 16, projection.data(), sizeof(core::math::mat4));
         // fogColor.rgb + fogColor.a = mode (0 none, 1 linear, 2 exp2);
@@ -341,6 +360,34 @@ namespace rendering_engine
         ubo_payload[36] = ctx.fog.near_distance;
         ubo_payload[37] = ctx.fog.far_distance;
         ubo_payload[38] = ctx.fog.density;
+
+        // The overlay group carries the unjittered projection so the debug
+        // pass — which paints after the TAA resolve and so cannot average
+        // the jitter away — draws steady gizmos. Upload it before applying
+        // the jitter below.
+        if (m_overlay_frame_ubo.valid())
+        {
+            gpu.write_buffer(m_overlay_frame_ubo, ubo_payload.data(), per_frame_ubo_size, 0);
+        }
+
+        // Temporal-AA sub-pixel jitter: offset the projection by a Halton
+        // step so this frame samples the scene a fraction of a pixel away
+        // from the last. Column-major storage puts the clip-space x/y shear
+        // terms (row 0/1 of column 2) at m[8] / m[9]; nudging them shifts
+        // the whole frame uniformly in NDC after the perspective divide.
+        // The jitter feeds the taa_pass accumulation and is otherwise
+        // invisible — culling still uses the camera's unjittered frustum,
+        // and the overlay group above keeps the unjittered matrices.
+        if (m_taa_jitter)
+        {
+            m_jitter_index = (m_jitter_index + 1u) % taa_jitter_period;
+            const float jitter_x = (halton(m_jitter_index + 1u, 2u) - 0.5f) * 2.0f * m_inv_width;
+            const float jitter_y = (halton(m_jitter_index + 1u, 3u) - 0.5f) * 2.0f * m_inv_height;
+            core::math::mat4 jittered = projection;
+            jittered.m[8] += jitter_x;
+            jittered.m[9] += jitter_y;
+            std::memcpy(ubo_payload.data() + 16, jittered.data(), sizeof(core::math::mat4));
+        }
         gpu.write_buffer(m_frame_ubo, ubo_payload.data(), per_frame_ubo_size, 0);
 
         // Pack every live light into the std140 lights block and upload

--- a/rendering_engine/passes/scene_pass.cpp
+++ b/rendering_engine/passes/scene_pass.cpp
@@ -29,6 +29,7 @@
 #include <core/event.hpp>
 #include <core/event_engine.hpp>
 #include <core/math/math.hpp>
+#include <core/settings.hpp>
 #include <rendering_engine/camera/camera.hpp>
 #include <rendering_engine/gpu/buffer.hpp>
 #include <rendering_engine/gpu/device.hpp>
@@ -88,6 +89,29 @@ namespace rendering_engine
         // (x enabled, y bias, z caster point index). 416 bytes total.
         constexpr size_t point_shadow_ubo_size =
             point_shadow_face_count * sizeof(core::math::mat4) + 2 * 4 * sizeof(float);
+
+        // Length of the Halton sub-pixel jitter sequence the temporal-AA
+        // path cycles through. Sixteen distinct offsets give the
+        // accumulation enough sample positions to resolve cleanly without
+        // the pattern repeating often enough to be visible.
+        constexpr uint32_t taa_jitter_period = 16;
+
+        // Halton low-discrepancy sequence — the standard source of the
+        // well-spread sub-pixel offsets temporal AA jitters the projection
+        // by. @p index is 1-based (index 0 degenerates to 0); base 2 drives
+        // the x offset, base 3 the y.
+        float halton(uint32_t index, uint32_t base)
+        {
+            float result = 0.0f;
+            float fraction = 1.0f;
+            while (index > 0)
+            {
+                fraction /= static_cast<float>(base);
+                result += fraction * static_cast<float>(index % base);
+                index /= base;
+            }
+            return result;
+        }
     } // namespace
 
     scene_pass::scene_pass(std::vector<renderable*>* registry,
@@ -185,6 +209,19 @@ namespace rendering_engine
         }
 
         m_frame_bind_group = gpu.create_bind_group(frame_bind_group_descriptor);
+
+        // Enable projection jitter only when temporal AA is on and the
+        // window has a usable size; the @ref taa_pass accumulates the
+        // jittered frames. The reciprocal dimensions scale each Halton
+        // offset down to a sub-pixel NDC amount.
+        const ::settings* config = runtime::current_engine().settings.get();
+        if (config != nullptr && config->graphics.temporal_aa && config->window.width != 0 &&
+            config->window.height != 0)
+        {
+            m_taa_jitter = true;
+            m_inv_width = 1.0f / static_cast<float>(config->window.width);
+            m_inv_height = 1.0f / static_cast<float>(config->window.height);
+        }
     }
 
     scene_pass::~scene_pass()
@@ -275,7 +312,24 @@ namespace rendering_engine
         // fog block (fogColor at float 32, fogParams at float 36).
         std::array<float, 40> ubo_payload{};
         const auto view = ctx.active_camera->get_view_matrix();
-        const auto projection = ctx.active_camera->get_projection_matrix();
+        core::math::mat4 projection = ctx.active_camera->get_projection_matrix();
+
+        // Temporal-AA sub-pixel jitter: offset the projection by a Halton
+        // step so this frame samples the scene a fraction of a pixel away
+        // from the last. Column-major storage puts the clip-space x/y shear
+        // terms (row 0/1 of column 2) at m[8] / m[9]; nudging them shifts
+        // the whole frame uniformly in NDC after the perspective divide.
+        // The jitter feeds the taa_pass accumulation and is otherwise
+        // invisible — culling still uses the camera's unjittered frustum.
+        if (m_taa_jitter)
+        {
+            m_jitter_index = (m_jitter_index + 1u) % taa_jitter_period;
+            const float jitter_x = (halton(m_jitter_index + 1u, 2u) - 0.5f) * 2.0f * m_inv_width;
+            const float jitter_y = (halton(m_jitter_index + 1u, 3u) - 0.5f) * 2.0f * m_inv_height;
+            projection.m[8] += jitter_x;
+            projection.m[9] += jitter_y;
+        }
+
         std::memcpy(ubo_payload.data(), view.data(), sizeof(core::math::mat4));
         std::memcpy(ubo_payload.data() + 16, projection.data(), sizeof(core::math::mat4));
         // fogColor.rgb + fogColor.a = mode (0 none, 1 linear, 2 exp2);

--- a/rendering_engine/passes/scene_pass.hpp
+++ b/rendering_engine/passes/scene_pass.hpp
@@ -87,6 +87,14 @@ namespace rendering_engine
         // its line-based gizmos with the same camera the scene used.
         gpu::bind_group frame_bind_group() const;
 
+        // Per-frame bind group carrying the *unjittered* camera, for
+        // consumers that draw after the TAA resolve (the debug pass) and so
+        // would otherwise show the projection jitter as an un-averaged
+        // sub-pixel wobble. Identical to @ref frame_bind_group in every
+        // other binding, and the same handle when temporal-AA jitter is off
+        // (there is nothing to undo). Stable across frames.
+        gpu::bind_group overlay_frame_bind_group() const;
+
     private:
         // Non-owning back-pointer to the engine context's
         // scene-renderable registry. The context outlives every
@@ -106,6 +114,14 @@ namespace rendering_engine
         gpu::buffer m_shadow_ubo{};
         gpu::buffer m_point_shadow_ubo{};
         gpu::bind_group m_frame_bind_group{};
+
+        // Unjittered twin of @ref m_frame_bind_group for the debug pass.
+        // Only created when temporal-AA jitter is active; otherwise the
+        // accessor hands back the main group (the matrices are identical).
+        // Shares every other binding with the main group — only its camera
+        // UBO differs, holding the projection without the sub-pixel offset.
+        gpu::buffer m_overlay_frame_ubo{};
+        gpu::bind_group m_overlay_frame_bind_group{};
 
         // Shadow passes feeding the per-frame group. Non-owning — the
         // engine context owns the passes and orders them before this one.

--- a/rendering_engine/passes/scene_pass.hpp
+++ b/rendering_engine/passes/scene_pass.hpp
@@ -118,6 +118,18 @@ namespace rendering_engine
         // disables collection.
         render_stats* m_stats{nullptr};
 
+        // Temporal-AA projection jitter. When @c m_taa_jitter is set (the
+        // temporal_aa setting is on and the window has a usable size), each
+        // record() offsets the camera projection by a Halton sub-pixel step
+        // before uploading it, so consecutive frames sample the scene at
+        // slightly different positions for the @ref taa_pass to accumulate.
+        // @c m_jitter_index cycles the Halton sequence; the two reciprocal
+        // dimensions scale the NDC offset to a sub-pixel amount.
+        bool m_taa_jitter{false};
+        uint32_t m_jitter_index{0};
+        float m_inv_width{0.0f};
+        float m_inv_height{0.0f};
+
         // Reused across frames so the underlying allocation persists.
         std::vector<draw_item> m_items;
     };

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -47,6 +47,7 @@
 #include <rendering_engine/passes/post/fxaa_pass.hpp>
 #include <rendering_engine/passes/post/taa_pass.hpp>
 #include <rendering_engine/passes/post/tonemap_pass.hpp>
+#include <rendering_engine/passes/post/velocity_pass.hpp>
 #include <rendering_engine/passes/scene_pass.hpp>
 #include <rendering_engine/passes/shadow_pass.hpp>
 #include <rendering_engine/passes/skybox_pass.hpp>
@@ -142,11 +143,17 @@ void rendering_engine::context::init()
     // anti-aliased image.
     const bool taa_enabled =
         (eng.settings != nullptr) && eng.settings->graphics.temporal_aa && width != 0 && height != 0;
+    std::unique_ptr<velocity_pass> velocity;
     std::unique_ptr<taa_pass> taa;
     gpu::texture fxaa_input = m_ldr_color_texture;
     if (taa_enabled)
     {
-        taa = std::make_unique<taa_pass>(m_ldr_color_texture, width, height);
+        // Per-pixel motion vectors are reconstructed from the scene depth
+        // buffer, so the velocity pass samples the HDR target's depth
+        // attachment. They drive the TAA history reprojection.
+        const gpu::texture scene_depth = eng.gpu->render_target_depth_texture(m_scene_color_target);
+        velocity = std::make_unique<velocity_pass>(scene_depth, width, height);
+        taa = std::make_unique<taa_pass>(m_ldr_color_texture, velocity->velocity_texture(), width, height);
         fxaa_input = taa->output_texture();
     }
     // FXAA closes the post chain: it samples the LDR/TAA result and writes
@@ -180,8 +187,10 @@ void rendering_engine::context::init()
 
     // Register the built-in passes in render order: scene writes into
     // the HDR target, the skybox pass fills the untouched background of
-    // that target with the environment cube map, the bloom post pass
-    // blurs its bright pixels back
+    // that target with the environment cube map, the optional velocity
+    // pass reconstructs per-pixel motion vectors from the finalised depth
+    // for the TAA reprojection, the bloom post pass blurs its bright pixels
+    // back
     // into that target, the tonemap post pass maps the result to LDR in
     // the off-screen LDR target, the optional TAA post pass accumulates the
     // jittered LDR frames into a supersampled image, the FXAA post pass
@@ -200,6 +209,13 @@ void rendering_engine::context::init()
     m_passes.push_back(std::move(point_shadow));
     m_passes.push_back(std::move(scene));
     m_passes.push_back(std::move(skybox));
+    // Motion vectors are computed from the finalised scene depth, before
+    // the post chain consumes the colour, so the velocity pass sits right
+    // after the geometry and skybox. Only present when TAA is enabled.
+    if (velocity)
+    {
+        m_passes.push_back(std::move(velocity));
+    }
     m_passes.push_back(std::move(bloom));
     m_passes.push_back(std::move(post));
     if (taa)

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -45,6 +45,7 @@
 #include <rendering_engine/passes/point_shadow_pass.hpp>
 #include <rendering_engine/passes/post/bloom_pass.hpp>
 #include <rendering_engine/passes/post/fxaa_pass.hpp>
+#include <rendering_engine/passes/post/taa_pass.hpp>
 #include <rendering_engine/passes/post/tonemap_pass.hpp>
 #include <rendering_engine/passes/scene_pass.hpp>
 #include <rendering_engine/passes/shadow_pass.hpp>
@@ -131,9 +132,26 @@ void rendering_engine::context::init()
     // glow back into the same target, so tonemap maps the bloomed result.
     auto bloom = std::make_unique<bloom_pass>(m_scene_color_texture, width, height);
     auto post = std::make_unique<tonemap_pass>(m_scene_color_texture);
-    // FXAA closes the post chain: it samples the LDR target tonemap
-    // resolved into and writes the anti-aliased result to the swapchain.
-    auto fxaa = std::make_unique<fxaa_pass>(m_ldr_color_texture, width, height);
+    // Temporal AA optionally slots in between tonemap and FXAA: it
+    // accumulates the projection-jittered frames the scene pass produces
+    // (Halton sub-pixel offsets, applied only while this is enabled) into a
+    // stable, supersampled LDR image, then FXAA cleans up whatever spatial
+    // edges remain. Gated on the temporal_aa setting; when off the LDR
+    // target flows straight into FXAA exactly as before. The TAA resolve
+    // becomes FXAA's input so the swapchain still receives a single
+    // anti-aliased image.
+    const bool taa_enabled =
+        (eng.settings != nullptr) && eng.settings->graphics.temporal_aa && width != 0 && height != 0;
+    std::unique_ptr<taa_pass> taa;
+    gpu::texture fxaa_input = m_ldr_color_texture;
+    if (taa_enabled)
+    {
+        taa = std::make_unique<taa_pass>(m_ldr_color_texture, width, height);
+        fxaa_input = taa->output_texture();
+    }
+    // FXAA closes the post chain: it samples the LDR/TAA result and writes
+    // the anti-aliased image to the swapchain.
+    auto fxaa = std::make_unique<fxaa_pass>(fxaa_input, width, height);
     auto ui = std::make_unique<ui_pass>(&m_ui_renderables);
 #if _DEBUG
     // The debug pass binds the scene pass's per-frame camera group at
@@ -165,8 +183,10 @@ void rendering_engine::context::init()
     // that target with the environment cube map, the bloom post pass
     // blurs its bright pixels back
     // into that target, the tonemap post pass maps the result to LDR in
-    // the off-screen LDR target, the FXAA post pass anti-aliases that LDR
-    // image onto the swapchain, and the UI pass composites on top. The
+    // the off-screen LDR target, the optional TAA post pass accumulates the
+    // jittered LDR frames into a supersampled image, the FXAA post pass
+    // anti-aliases that result onto the swapchain, and the UI pass
+    // composites on top. The
     // debug pass is appended in debug builds only so debug visuals read on
     // top of the game UI; release builds drop it entirely so the
     // overlay registry has no consumer and the stage costs nothing.
@@ -182,6 +202,10 @@ void rendering_engine::context::init()
     m_passes.push_back(std::move(skybox));
     m_passes.push_back(std::move(bloom));
     m_passes.push_back(std::move(post));
+    if (taa)
+    {
+        m_passes.push_back(std::move(taa));
+    }
     m_passes.push_back(std::move(fxaa));
     m_passes.push_back(std::move(ui));
 #if _DEBUG

--- a/rendering_engine/rendering_engine.cpp
+++ b/rendering_engine/rendering_engine.cpp
@@ -163,7 +163,10 @@ void rendering_engine::context::init()
 #if _DEBUG
     // The debug pass binds the scene pass's per-frame camera group at
     // slot 0 so the line-based debug gizmos project with the same camera.
-    auto debug = std::make_unique<debug_pass>(&m_debug_renderables, scene->frame_bind_group());
+    // It uses the unjittered overlay group: the debug pass paints after the
+    // TAA resolve, so the projection jitter would otherwise show up as a
+    // sub-pixel wobble on the gizmos rather than being averaged away.
+    auto debug = std::make_unique<debug_pass>(&m_debug_renderables, scene->overlay_frame_bind_group());
 #endif
 
     // Construct the built-in materials against the per-frame layouts


### PR DESCRIPTION
## Summary
Implements temporal anti-aliasing (#145), the THREE.TAARenderPass / SSAARenderPass analog. TAA accumulates many sub-pixel-jittered frames into one stable, supersampled image — resolving the temporally-aliasing detail (fine geometry edges, specular shimmer, the near-mirror IBL reflections) that the existing spatial FXAA cannot. Camera motion is handled by a per-pixel motion-vector buffer so the history reprojects along the actual movement instead of smearing.

## How it works
- **Projection jitter (`scene_pass`)** — each frame the camera projection is offset by a Halton(2,3) sub-pixel step (column-major `m[8]`/`m[9]` clip-space shear). Culling still uses the unjittered frustum.
- **Motion vectors (`velocity_pass`)** — a fullscreen pass reconstructs screen-space motion from the scene depth buffer: depth + `inverse(curViewProj)` → world position, reprojected through `prevViewProj` → last frame's screen location. Collapsed to one `prevViewProj * inverse(curViewProj)` matrix per frame; output is an `rgba16f` target with the signed UV delta in `xy`. Runs after scene/skybox (depth finalised), before the post chain.
- **Resolve (`taa_pass`)** — runs after tonemap on the LDR image. Reads history at `texCoord - velocity` (reprojected), clamps it to the 3×3 neighbourhood colour box to suppress disocclusion/ghosting, drops to the current frame where the reprojection lands off-screen, then blends. A copy stage stores the resolved frame as next frame's history. The resolve feeds FXAA, so the swapchain still gets a single AA'd image.

## Pipeline order
`scene → skybox → velocity → bloom → tonemap → taa → fxaa → ui`
(velocity + taa only present when TAA is enabled).

## Configuration
New `graphics.temporal_aa` setting, overridable via the `ALPHAENGINE_TAA` env var (`0`/`off`/`false` to disable, `1`/`on`/`true` to force). **Enabled by default.** When off, the LDR target flows straight into FXAA exactly as before and projection jitter is skipped.

## Scope / follow-up
Covers camera motion against the static world. Independently animated objects need their own previous-frame transforms — a multi-target geometry pass writing velocity per draw, which the engine's single-colour render targets cannot express yet — and remain the follow-up.

## Verification
- Full Ninja/Debug build configures, compiles and links cleanly.
- clang-format 18: no diffs. clang-tidy naming check: no violations.
- No runtime suite exists (per CLAUDE.md); not run.

Closes #145