### PR TITLE
feat: auto-fit directional shadow frustum to the camera view

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(AlphaEngine PRIVATE
     camera_module.cpp
     exit_module.cpp
     frame_module.cpp
-    fog_demo_module.cpp
+    shadow_demo_module.cpp
 )
 
 # The FPS counter used to live here as a label-rendering game module; it
@@ -10,18 +10,20 @@ target_sources(AlphaEngine PRIVATE
 # so the standalone fps_overlay_module was removed.
 
 # Only one scene-owning demo module is compiled at a time because each
-# places its showcase geometry at the origin. fog_demo_module.cpp is the
-# active one: a row of Blinn-Phong spheres receding over a long ground
-# plane under linear distance fog, so the far geometry dissolves into the
-# haze (showcases the fog from issue #122).
+# places its showcase geometry at the origin. shadow_demo_module.cpp is the
+# active one: a field of PBR spheres and tall pillars spread over a wide
+# ground plane under a slowly orbiting shadow-casting sun, showcasing the
+# auto-fit directional shadow frustum from issue #146 (crisp shadows across
+# the whole field, not just near the origin).
 #
-# instanced_demo_module.cpp (a grid_side^3 lattice of cubes in one
-# instanced draw call), scene_graph_demo_module.cpp (parent/child node
-# hierarchy with orbiting cube mesh_components and a point light),
-# line_demo_module.cpp (coloured helix line strip), points_demo_module.cpp
-# (coloured Fibonacci-sphere point cloud), skybox_demo_module.cpp
-# (procedural sky + IBL sphere grid) and phong_demo_module.cpp (Blinn-Phong
-# lit sphere) are the other showcases; swap any one filename in for
-# fog_demo_module.cpp to bring it back.
+# fog_demo_module.cpp (Blinn-Phong spheres receding into linear distance
+# fog, issue #122), instanced_demo_module.cpp (a grid_side^3 lattice of
+# cubes in one instanced draw call), scene_graph_demo_module.cpp
+# (parent/child node hierarchy with orbiting cube mesh_components and a
+# point light), line_demo_module.cpp (coloured helix line strip),
+# points_demo_module.cpp (coloured Fibonacci-sphere point cloud),
+# skybox_demo_module.cpp (procedural sky + IBL sphere grid) and
+# phong_demo_module.cpp (Blinn-Phong lit sphere) are the other showcases;
+# swap any one filename in for shadow_demo_module.cpp to bring it back.
 
 add_subdirectory(api)

--- a/external/shadow_demo_module.cpp
+++ b/external/shadow_demo_module.cpp
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2015-2026 Tomislav Radanovic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "api/game_module.hpp"
+#include "api/log.hpp"
+#include "api/time.hpp"
+
+#include <core/log.hpp>
+#include <core/math/math.hpp>
+#include <rendering_engine/lighting/ambient_light.hpp>
+#include <rendering_engine/lighting/directional_light.hpp>
+#include <rendering_engine/materials/standard_material.hpp>
+#include <rendering_engine/renderables/premade_3d/box.hpp>
+#include <rendering_engine/renderables/premade_3d/plane.hpp>
+#include <rendering_engine/renderables/premade_3d/sphere.hpp>
+#include <rendering_engine/rendering_engine.hpp>
+#include <rendering_engine/util/color.hpp>
+#include <runtime/engine.hpp>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+// Shadow showcase for the auto-fit directional shadow frustum (issue
+// #146). A field of spheres and tall pillars is spread over a wide ground
+// plane — deliberately much larger than the old fixed 12x12 light box, so
+// the shadow pass *has* to fit the frustum to the view to cover it. With
+// the auto-fit:
+//
+//   * every object casts a crisp, sharply-edged shadow no matter where it
+//     sits on the plane (the old fixed box only reached ~6 units from the
+//     origin, so objects past that got no shadow at all);
+//   * the pillars cast long thin shadows whose edges stay smooth instead
+//     of stair-stepping, because the map's 2048 texels now land on the
+//     visible region rather than being spread over empty world space;
+//   * the sun slowly orbits, so the shadows sweep across the plane — watch
+//     that the edges stay stable (no crawling) thanks to the texel-snapped,
+//     bounding-sphere fit.
+//
+// To A/B test against the old behaviour, temporarily force the fixed-box
+// fallback in rendering_engine/passes/shadow_pass.cpp (skip the
+// camera branch in record()) and rebuild: the far objects lose their
+// shadows and the near ones turn blocky.
+//
+// Controls (from camera_module): WASD to move, hold left mouse to look,
+// space/ctrl to rise/sink, shift to move faster. Roam around — the
+// shadows stay sharp wherever you look.
+
+namespace
+{
+    namespace math = core::math;
+
+    std::vector<std::unique_ptr<rendering_engine::sphere>> g_spheres;
+    std::vector<std::unique_ptr<rendering_engine::box>> g_pillars;
+    std::vector<std::unique_ptr<rendering_engine::standard_material>> g_materials;
+    std::unique_ptr<rendering_engine::plane> g_ground;
+    std::unique_ptr<rendering_engine::standard_material> g_ground_material;
+    std::unique_ptr<rendering_engine::ambient_light> g_ambient;
+    std::unique_ptr<rendering_engine::directional_light> g_sun;
+
+    // Top of the ground plane in world Z (world up is +Z). Objects rest on it.
+    constexpr float ground_z = -1.5f;
+
+    // The sun slowly orbits in azimuth so the shadows sweep across the plane;
+    // the downward tilt is held constant so they never grow unbounded.
+    float g_sun_angle = 0.0f;
+    constexpr float sun_orbit_speed = 0.25f; // radians / second
+    constexpr float sun_tilt = -0.65f;       // downward (-Z) component
+
+    rendering_engine::standard_material* make_material(const rendering_engine::util::color& base, float roughness)
+    {
+        auto material = runtime::current_engine().renderer->create_standard_material();
+        material->set_base_color(base);
+        material->set_metalness(0.0f);
+        material->set_roughness(roughness);
+        g_materials.push_back(std::move(material));
+        return g_materials.back().get();
+    }
+
+    void update_sun_direction()
+    {
+        g_sun->direction = math::vec3{std::cos(g_sun_angle) * 0.7f, std::sin(g_sun_angle) * 0.7f, sun_tilt};
+    }
+} // namespace
+
+static void on_engine_start(const core::engine_start& event)
+{
+    auto& renderer = *runtime::current_engine().renderer;
+
+    // A wide, neutral ground plane to catch the shadows. World up is +Z,
+    // so the plane's default +Z normal already faces the sky.
+    g_ground_material = renderer.create_standard_material();
+    g_ground_material->set_base_color(rendering_engine::util::color{185, 188, 195, 255});
+    g_ground_material->set_metalness(0.0f);
+    g_ground_material->set_roughness(0.95f);
+
+    g_ground = std::make_unique<rendering_engine::plane>(g_ground_material.get(), 60.0f, 60.0f);
+    g_ground->transform.set_position(math::vec3{14.0f, 0.0f, ground_z});
+    g_ground->upload();
+    renderer.register_scene_renderable(g_ground.get());
+
+    // A few coloured surfaces shared across the field.
+    rendering_engine::standard_material* warm = make_material(rendering_engine::util::color{230, 126, 34, 255}, 0.55f);
+    rendering_engine::standard_material* cool = make_material(rendering_engine::util::color{52, 152, 219, 255}, 0.4f);
+    rendering_engine::standard_material* pale = make_material(rendering_engine::util::color{236, 240, 241, 255}, 0.7f);
+    rendering_engine::standard_material* pillar_material =
+        make_material(rendering_engine::util::color{120, 200, 140, 255}, 0.6f);
+
+    // A grid of unit spheres spread well beyond the origin so the field
+    // reaches past the old fixed light box. The camera looks from -X, so
+    // the grid recedes along +X and spreads across +/-Y.
+    constexpr int depth_rows = 4;   // along +X, away from the camera
+    constexpr int lateral_cols = 5; // across +/-Y
+    rendering_engine::standard_material* tints[] = {warm, cool, pale};
+    for (int row = 0; row < depth_rows; ++row)
+    {
+        for (int col = 0; col < lateral_cols; ++col)
+        {
+            rendering_engine::standard_material* tint = tints[(row + col) % 3];
+            auto ball = std::make_unique<rendering_engine::sphere>(tint);
+            const float x = static_cast<float>(row) * 6.0f;
+            const float y = (static_cast<float>(col) - static_cast<float>(lateral_cols - 1) * 0.5f) * 6.0f;
+            // Unit sphere (radius 1): centre one radius above the plane so it
+            // rests on the ground and casts a contact shadow.
+            ball->transform.set_position(math::vec3{x, y, ground_z + 1.0f});
+            ball->upload();
+            renderer.register_scene_renderable(ball.get());
+            g_spheres.push_back(std::move(ball));
+        }
+    }
+
+    // Tall, thin pillars cast long shadows across the plane — the case
+    // where stair-stepping is most obvious, so the smooth edges are the
+    // clearest evidence the auto-fit is working.
+    const math::vec3 pillar_spots[] = {
+        math::vec3{3.0f, -9.0f, 0.0f},
+        math::vec3{9.0f, 9.0f, 0.0f},
+        math::vec3{15.0f, -3.0f, 0.0f},
+    };
+    constexpr float pillar_height = 5.0f;
+    for (const math::vec3& spot : pillar_spots)
+    {
+        auto pillar = std::make_unique<rendering_engine::box>(pillar_material, 0.8f, 0.8f, pillar_height);
+        pillar->transform.set_position(math::vec3{spot.x, spot.y, ground_z + pillar_height * 0.5f});
+        pillar->upload();
+        renderer.register_scene_renderable(pillar.get());
+        g_pillars.push_back(std::move(pillar));
+    }
+
+    // Dim ambient so the shadowed areas read as genuinely dark.
+    g_ambient = std::make_unique<rendering_engine::ambient_light>();
+    g_ambient->color = math::vec3{1.0f, 1.0f, 1.0f};
+    g_ambient->intensity = 0.12f;
+
+    // The single shadow-casting directional light. Its frustum is
+    // auto-fitted to the camera view every frame (see shadow_pass).
+    g_sun = std::make_unique<rendering_engine::directional_light>();
+    g_sun->color = math::vec3{1.0f, 0.97f, 0.9f};
+    g_sun->intensity = 1.0f;
+    g_sun->cast_shadow = true;
+    update_sun_direction();
+}
+
+static void on_engine_stop(const core::engine_stop& event)
+{
+    auto& renderer = *runtime::current_engine().renderer;
+    for (auto& ball : g_spheres)
+    {
+        renderer.unregister_scene_renderable(ball.get());
+    }
+    g_spheres.clear();
+    for (auto& pillar : g_pillars)
+    {
+        renderer.unregister_scene_renderable(pillar.get());
+    }
+    g_pillars.clear();
+    renderer.unregister_scene_renderable(g_ground.get());
+    g_ground.reset();
+    g_sun.reset();
+    g_ambient.reset();
+    g_materials.clear();
+    g_ground_material.reset();
+}
+
+static void on_frame(const core::frame& event)
+{
+    g_sun_angle += sun_orbit_speed * (static_cast<float>(get_delta_time()) / 1000.0f);
+    update_sun_direction();
+}
+
+GAME_MODULE()
+{
+    LOG_INF("Registering external module: shadow_demo_module");
+    struct game_module_info info = {};
+    info.on_engine_start = on_engine_start;
+    info.on_engine_stop = on_engine_stop;
+    info.on_frame = on_frame;
+    register_game_module(info);
+    return true;
+}

--- a/external/shadow_demo_module.cpp
+++ b/external/shadow_demo_module.cpp
@@ -41,25 +41,28 @@
 #include <vector>
 
 // Shadow showcase for the auto-fit directional shadow frustum (issue
-// #146). A field of spheres and tall pillars is spread over a wide ground
-// plane — deliberately much larger than the old fixed 12x12 light box, so
-// the shadow pass *has* to fit the frustum to the view to cover it. With
-// the auto-fit:
+// #146). A field of spheres and tall pillars sits on a wide ground plane,
+// spread past the old fixed light box (+/-6 around the origin) but kept
+// within the shadow distance so the whole field stays crisp. With the
+// auto-fit:
 //
-//   * every object casts a crisp, sharply-edged shadow no matter where it
-//     sits on the plane (the old fixed box only reached ~6 units from the
-//     origin, so objects past that got no shadow at all);
+//   * every object casts a sharp shadow wherever it sits on the plane (the
+//     old fixed box only reached ~6 units from the origin, so objects past
+//     that got no shadow at all);
 //   * the pillars cast long thin shadows whose edges stay smooth instead
-//     of stair-stepping, because the map's 2048 texels now land on the
+//     of stair-stepping, because the 4096 map's texels now land on the
 //     visible region rather than being spread over empty world space;
 //   * the sun slowly orbits, so the shadows sweep across the plane — watch
 //     that the edges stay stable (no crawling) thanks to the texel-snapped,
 //     bounding-sphere fit.
 //
+// This is a single cascade, so the crispness holds out to the shadow
+// distance (shadow_pass.cpp) and then stops; covering a large world
+// sharply is the cascaded-shadow-map follow-on.
+//
 // To A/B test against the old behaviour, temporarily force the fixed-box
-// fallback in rendering_engine/passes/shadow_pass.cpp (skip the
-// camera branch in record()) and rebuild: the far objects lose their
-// shadows and the near ones turn blocky.
+// fallback in rendering_engine/passes/shadow_pass.cpp (skip the camera
+// branch in record()) and rebuild: the far objects lose their shadows.
 //
 // Controls (from camera_module): WASD to move, hold left mouse to look,
 // space/ctrl to rise/sink, shift to move faster. Roam around — the
@@ -114,7 +117,7 @@ static void on_engine_start(const core::engine_start& event)
     g_ground_material->set_roughness(0.95f);
 
     g_ground = std::make_unique<rendering_engine::plane>(g_ground_material.get(), 60.0f, 60.0f);
-    g_ground->transform.set_position(math::vec3{14.0f, 0.0f, ground_z});
+    g_ground->transform.set_position(math::vec3{6.0f, 0.0f, ground_z});
     g_ground->upload();
     renderer.register_scene_renderable(g_ground.get());
 
@@ -125,10 +128,11 @@ static void on_engine_start(const core::engine_start& event)
     rendering_engine::standard_material* pillar_material =
         make_material(rendering_engine::util::color{120, 200, 140, 255}, 0.6f);
 
-    // A grid of unit spheres spread well beyond the origin so the field
-    // reaches past the old fixed light box. The camera looks from -X, so
-    // the grid recedes along +X and spreads across +/-Y.
-    constexpr int depth_rows = 4;   // along +X, away from the camera
+    // A grid of unit spheres spread across the plane. The camera looks
+    // from -X, so the grid recedes along +X and spreads across +/-Y. It is
+    // kept inside the shadow distance so the whole field stays crisp, yet
+    // it reaches well past the old fixed light box (+/-6 around the origin).
+    constexpr int depth_rows = 3;   // along +X, away from the camera
     constexpr int lateral_cols = 5; // across +/-Y
     rendering_engine::standard_material* tints[] = {warm, cool, pale};
     for (int row = 0; row < depth_rows; ++row)
@@ -137,8 +141,8 @@ static void on_engine_start(const core::engine_start& event)
         {
             rendering_engine::standard_material* tint = tints[(row + col) % 3];
             auto ball = std::make_unique<rendering_engine::sphere>(tint);
-            const float x = static_cast<float>(row) * 6.0f;
-            const float y = (static_cast<float>(col) - static_cast<float>(lateral_cols - 1) * 0.5f) * 6.0f;
+            const float x = static_cast<float>(row) * 5.0f;
+            const float y = (static_cast<float>(col) - static_cast<float>(lateral_cols - 1) * 0.5f) * 4.0f;
             // Unit sphere (radius 1): centre one radius above the plane so it
             // rests on the ground and casts a contact shadow.
             ball->transform.set_position(math::vec3{x, y, ground_z + 1.0f});
@@ -152,9 +156,9 @@ static void on_engine_start(const core::engine_start& event)
     // where stair-stepping is most obvious, so the smooth edges are the
     // clearest evidence the auto-fit is working.
     const math::vec3 pillar_spots[] = {
-        math::vec3{3.0f, -9.0f, 0.0f},
-        math::vec3{9.0f, 9.0f, 0.0f},
-        math::vec3{15.0f, -3.0f, 0.0f},
+        math::vec3{2.0f, -8.0f, 0.0f},
+        math::vec3{8.0f, 7.0f, 0.0f},
+        math::vec3{11.0f, -3.0f, 0.0f},
     };
     constexpr float pillar_height = 5.0f;
     for (const math::vec3& spot : pillar_spots)

--- a/rendering_engine/materials/phong_material.cpp
+++ b/rendering_engine/materials/phong_material.cpp
@@ -155,7 +155,7 @@ namespace
 
         // 1.0 = fully lit, 0.0 = fully shadowed. Only the caster light
         // index is occluded; every other directional light returns 1.0.
-        // 3x3 PCF softens the shadow edge by one texel.
+        // A 5x5 PCF kernel softens the shadow edge.
         float directional_shadow(int lightIndex, vec3 N, vec3 L)
         {
             if (u_shadow.params.x == 0.0 || lightIndex != int(u_shadow.params.z))

--- a/rendering_engine/materials/standard_material.cpp
+++ b/rendering_engine/materials/standard_material.cpp
@@ -337,7 +337,7 @@ namespace
 
         // 1.0 = fully lit, 0.0 = fully shadowed. Only the caster light
         // index is occluded; every other directional light returns 1.0.
-        // 3x3 PCF softens the shadow edge by one texel.
+        // A 5x5 PCF kernel softens the shadow edge.
         )fs"
                                         R"fs(
         float directional_shadow(int lightIndex, vec3 N, vec3 L)
@@ -357,8 +357,9 @@ namespace
             vec2 texelSize = 1.0 / vec2(textureSize(shadowMap, 0));
             // 5x5 PCF: a wider kernel softens the penumbra so the shadow
             // edge stays smooth even where the light-space texel-to-world
-            // ratio is coarse. Issue #146 tracks a resolution-independent
-            // filter (PCSS) and a tighter-fit map.
+            // ratio is coarse. The shadow pass now auto-fits the light box
+            // to the view frustum; a resolution-independent filter (PCSS)
+            // and cascades remain a follow-on.
             float lit = 0.0;
             for (int x = -2; x <= 2; ++x)
             {

--- a/rendering_engine/passes/shadow_pass.cpp
+++ b/rendering_engine/passes/shadow_pass.cpp
@@ -22,9 +22,12 @@
 
 #include <rendering_engine/passes/shadow_pass.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <string>
 
+#include <rendering_engine/camera/camera.hpp>
 #include <rendering_engine/gpu/bind_group.hpp>
 #include <rendering_engine/gpu/buffer.hpp>
 #include <rendering_engine/gpu/device.hpp>
@@ -47,17 +50,25 @@ namespace
     // memory of a 4k map.
     constexpr uint32_t shadow_map_size = 2048;
 
-    // Orthographic light frustum covering the scene. The box is centred
-    // on the world origin and oriented along the light direction. The
-    // half-extent is kept just large enough to enclose the demo's ground
-    // plane footprint and props: a tighter box spends more of the 2048
-    // shadow-map texels on the actual occluders, so the penumbra is
-    // sharper. Issue #146 tracks deriving this from the scene/camera
-    // bounds (and cascades) instead of a hardcoded extent.
+    // Fixed-box fallback used only when no camera is attached, so the
+    // map still holds something sensible to clear/sample. With a camera
+    // the frustum is auto-fitted to the view each frame (see
+    // @ref fit_light_to_camera) — the box is centred on the world origin
+    // and oriented along the light direction.
     constexpr float ortho_half_extent = 6.0f;
     constexpr float light_distance = 30.0f;
     constexpr float light_near = 1.0f;
     constexpr float light_far = 80.0f;
+
+    // Auto-fit parameters. The light box is fitted to the camera's view
+    // frustum capped to @ref shadow_distance world units of depth — past
+    // that, shadows are too far to read, and fitting to the camera's full
+    // 10 km far plane would spread the map's texels uselessly thin.
+    // @ref caster_depth_scale pulls the light's near plane back toward the
+    // light (as a multiple of the fit radius) so occluders sitting between
+    // the light and the visible region still rasterize into the map.
+    constexpr float shadow_distance = 60.0f;
+    constexpr float caster_depth_scale = 6.0f;
 
     // Base depth-comparison bias; the lit shader slope-scales it by the
     // surface's angle to the light to keep grazing faces from acne
@@ -107,6 +118,89 @@ namespace
             fragColor = vec4(1.0);
         }
 )fs";
+
+    // Build a directional light's view-projection auto-fitted to the
+    // camera's view frustum. The frustum is capped to @ref shadow_distance
+    // depth, then enclosed in its bounding sphere — a rotation-invariant,
+    // constant-radius fit so the box doesn't pulse as the camera turns —
+    // and the box centre is snapped to whole-texel increments so the
+    // shadow edges don't crawl as the camera moves.
+    math::mat4 fit_light_to_camera(const math::vec3& dir,
+                                   const math::vec3& up,
+                                   const math::mat4& camera_view,
+                                   const math::mat4& camera_projection)
+    {
+        const math::mat4 inverse_view_proj = math::inverse(camera_projection * camera_view);
+
+        // Unproject the eight NDC-cube corners to world space, capping the
+        // far corners at shadow_distance. View-space depth is linear along
+        // each near->far edge, so the cap is a plain world-space lerp.
+        std::array<math::vec3, 8> corners{};
+        std::size_t count = 0;
+        for (int xi = 0; xi < 2; ++xi)
+        {
+            for (int yi = 0; yi < 2; ++yi)
+            {
+                const float x = xi == 0 ? -1.0f : 1.0f;
+                const float y = yi == 0 ? -1.0f : 1.0f;
+
+                const math::vec4 near_h = inverse_view_proj * math::vec4{x, y, -1.0f, 1.0f};
+                const math::vec4 far_h = inverse_view_proj * math::vec4{x, y, 1.0f, 1.0f};
+                const math::vec3 near_corner{near_h.x / near_h.w, near_h.y / near_h.w, near_h.z / near_h.w};
+                const math::vec3 far_corner{far_h.x / far_h.w, far_h.y / far_h.w, far_h.z / far_h.w};
+
+                // Camera looks down -z, so forward depth is -(view * p).z.
+                const math::vec4 near_view = camera_view * math::vec4{near_corner, 1.0f};
+                const math::vec4 far_view = camera_view * math::vec4{far_corner, 1.0f};
+                const float near_depth = -near_view.z;
+                const float far_depth = -far_view.z;
+                float t = 1.0f;
+                if (far_depth > near_depth)
+                {
+                    t = std::clamp((shadow_distance - near_depth) / (far_depth - near_depth), 0.0f, 1.0f);
+                }
+
+                corners[count++] = near_corner;
+                corners[count++] = math::lerp(near_corner, far_corner, t);
+            }
+        }
+
+        // Bounding sphere of the capped frustum.
+        math::vec3 center{0.0f, 0.0f, 0.0f};
+        for (const auto& c : corners)
+        {
+            center += c;
+        }
+        center /= static_cast<float>(corners.size());
+
+        float radius = 0.0f;
+        for (const auto& c : corners)
+        {
+            radius = std::max(radius, math::length(c - center));
+        }
+        // Quantize the radius so sub-texel size jitter doesn't shimmer.
+        radius = std::ceil(radius * 16.0f) / 16.0f;
+
+        // Snap the centre to whole-texel increments in light space.
+        const float texels_per_unit = static_cast<float>(shadow_map_size) / (radius * 2.0f);
+        const math::mat4 texel_view = math::scale(math::vec3{texels_per_unit, texels_per_unit, texels_per_unit}) *
+                                      math::look_at(math::vec3{0.0f, 0.0f, 0.0f}, dir, up);
+        const math::mat4 texel_view_inverse = math::inverse(texel_view);
+        math::vec4 center_texel = texel_view * math::vec4{center, 1.0f};
+        center_texel.x = std::floor(center_texel.x);
+        center_texel.y = std::floor(center_texel.y);
+        const math::vec4 snapped = texel_view_inverse * center_texel;
+        center = math::vec3{snapped.x, snapped.y, snapped.z};
+
+        // Orthographic box of the sphere, with the eye pulled back toward
+        // the light so off-screen casters between the light and the view
+        // still render into the depth map.
+        const math::vec3 eye = center - dir * (radius * caster_depth_scale);
+        const math::mat4 light_view = math::look_at(eye, center, up);
+        const math::mat4 light_projection =
+            math::ortho(-radius, radius, -radius, radius, 0.0f, radius * (caster_depth_scale + 1.0f));
+        return light_projection * light_view;
+    }
 } // namespace
 
 namespace rendering_engine
@@ -324,21 +418,32 @@ namespace rendering_engine
             return;
         }
 
-        // Build the light's orthographic view-projection: look from a
-        // point back along the light direction toward the world origin.
-        // Pick an up vector that is not parallel to the direction so
-        // look_at stays well-defined regardless of the world's up axis.
+        // Build the light's orthographic view-projection. Pick an up
+        // vector that is not parallel to the direction so look_at stays
+        // well-defined regardless of the world's up axis.
         const math::vec3 dir = math::normalize(caster->direction);
         math::vec3 up{0.0f, 1.0f, 0.0f};
         if (std::abs(math::dot(dir, up)) > 0.99f)
         {
             up = math::vec3{0.0f, 0.0f, 1.0f};
         }
-        const math::vec3 eye = dir * (-light_distance);
-        const math::mat4 view = math::look_at(eye, math::vec3{0.0f, 0.0f, 0.0f}, up);
-        const math::mat4 projection = math::ortho(
-            -ortho_half_extent, ortho_half_extent, -ortho_half_extent, ortho_half_extent, light_near, light_far);
-        m_light_view_projection = projection * view;
+
+        // With a camera, auto-fit the box to the visible frustum so the
+        // shadow map's texels land on what the viewer actually sees;
+        // otherwise fall back to a fixed box centred on the origin.
+        if (const camera* cam = camera::get_current_camera(); cam != nullptr)
+        {
+            m_light_view_projection =
+                fit_light_to_camera(dir, up, cam->get_view_matrix(), cam->get_projection_matrix());
+        }
+        else
+        {
+            const math::vec3 eye = dir * (-light_distance);
+            const math::mat4 view = math::look_at(eye, math::vec3{0.0f, 0.0f, 0.0f}, up);
+            const math::mat4 projection = math::ortho(
+                -ortho_half_extent, ortho_half_extent, -ortho_half_extent, ortho_half_extent, light_near, light_far);
+            m_light_view_projection = projection * view;
+        }
 
         gpu.write_buffer(m_light_ubo, m_light_view_projection.data(), sizeof(math::mat4), 0);
 

--- a/rendering_engine/passes/shadow_pass.cpp
+++ b/rendering_engine/passes/shadow_pass.cpp
@@ -45,10 +45,11 @@ namespace
 {
     namespace math = core::math;
 
-    // Square shadow-map resolution. 2048 is the usual single-cascade
-    // starting point — sharp enough for a moderate scene without the
-    // memory of a 4k map.
-    constexpr uint32_t shadow_map_size = 2048;
+    // Square shadow-map resolution. 4096 keeps the auto-fit box's texels
+    // dense enough for crisp edges across a single cascade; a configurable
+    // resolution (and cascades for large scenes) is the issue #146
+    // follow-on.
+    constexpr uint32_t shadow_map_size = 4096;
 
     // Fixed-box fallback used only when no camera is attached, so the
     // map still holds something sensible to clear/sample. With a camera
@@ -61,13 +62,16 @@ namespace
     constexpr float light_far = 80.0f;
 
     // Auto-fit parameters. The light box is fitted to the camera's view
-    // frustum capped to @ref shadow_distance world units of depth — past
-    // that, shadows are too far to read, and fitting to the camera's full
-    // 10 km far plane would spread the map's texels uselessly thin.
+    // frustum capped to @ref shadow_distance world units of depth. This is
+    // a single cascade, so the cap is the crispness/coverage trade-off: the
+    // wider the camera FOV and the further the cap, the larger the fitted
+    // box and the fewer texels each occluder gets. 25 keeps a moderate
+    // playable area sharp; covering a large world crisply is what the
+    // cascaded-shadow-map follow-on (issue #146) is for.
     // @ref caster_depth_scale pulls the light's near plane back toward the
     // light (as a multiple of the fit radius) so occluders sitting between
     // the light and the visible region still rasterize into the map.
-    constexpr float shadow_distance = 60.0f;
+    constexpr float shadow_distance = 25.0f;
     constexpr float caster_depth_scale = 6.0f;
 
     // Base depth-comparison bias; the lit shader slope-scales it by the

--- a/rendering_engine/passes/shadow_pass.hpp
+++ b/rendering_engine/passes/shadow_pass.hpp
@@ -44,12 +44,15 @@ namespace rendering_engine
      * its per-frame bind group, and the lit fragment shaders sample it
      * to occlude that light's contribution.
      *
-     * The light's view is an orthographic box centred on the world
-     * origin and oriented along the light direction — the standard
-     * starting point for a single directional caster. When no
-     * directional light has @c cast_shadow set the pass still clears
-     * the map and reports @ref has_shadow as false so the lit shaders
-     * fall back to unshadowed lighting.
+     * The light's view is an orthographic box oriented along the light
+     * direction. When a camera is attached the box is auto-fitted to the
+     * camera's view frustum each frame (capped to a fixed shadow
+     * distance, enclosed in its bounding sphere, and texel-snapped for
+     * stability) so the shadow map's texels concentrate on what the
+     * viewer sees; with no camera it falls back to a fixed box centred on
+     * the world origin. When no directional light has @c cast_shadow set
+     * the pass still clears the map and reports @ref has_shadow as false
+     * so the lit shaders fall back to unshadowed lighting.
      *
      * The pass reuses the same scene-renderable registry as the
      * @ref scene_pass and the per-draw model-matrix bind group each

--- a/rendering_engine/renderables/premade_3d/box.cpp
+++ b/rendering_engine/renderables/premade_3d/box.cpp
@@ -136,13 +136,18 @@ void rendering_engine::box::upload()
                         const uint32_t c = a + columns;
                         const uint32_t d = c + 1;
 
+                        // a/b advance along +u, c/d along +v, and the outward
+                        // normal is cross(u, v); the triangles must therefore
+                        // wind a->d->c / a->b->d to come out CCW when viewed
+                        // from outside (the a->c->d / a->d->b order is CW and
+                        // would be culled, turning the box inside-out).
                         indices.push_back(a);
-                        indices.push_back(c);
                         indices.push_back(d);
+                        indices.push_back(c);
 
                         indices.push_back(a);
-                        indices.push_back(d);
                         indices.push_back(b);
+                        indices.push_back(d);
                     }
                 }
             };


### PR DESCRIPTION
## What

Directional shadows looked blocky (#146): the shadow pass used a **fixed** light ortho box (half-extent 6, a 12×12 world area) centred on the origin regardless of scene or camera, so a small scene occupied a tiny corner of the 2048² map and any geometry past ~6 units fell outside the box entirely. This fits the light frustum to the visible view each frame so the map's texels concentrate on what the camera actually sees.

## How

- **Auto-fit (`shadow_pass`)** — each frame the camera's view-frustum corners are unprojected to world space (capped to a fixed shadow distance), enclosed in their bounding sphere, and the sphere becomes the orthographic light box oriented along the caster's direction.
- **Stability** — the bounding sphere is rotation-invariant (constant radius regardless of where the camera looks) and the box centre is snapped to whole-texel increments, so shadow edges don't pulse or crawl as the camera and sun move.
- **Off-screen casters** — the light eye is pulled back toward the light (a multiple of the fit radius) so occluders sitting between the light and the visible region still rasterize into the depth map.
- **Fallback** — when no camera is attached the pass keeps the previous fixed box, so the map is always valid.
- **Tuning** — single-cascade shadow distance `25` with a `4096²` map, concentrating texels on a playable area for crisp edges. The 5×5 PCF kernel is already in place.
- **Demo (`shadow_demo_module`)** — a field of PBR spheres and tall pillars on a wide ground plane under a slowly orbiting shadow-casting sun, swapped in as the active scene module (one-line revert in `external/CMakeLists.txt` to restore `fog_demo_module`). Every object casts a sharp shadow wherever it sits — well past the old box's reach — and the pillars' long shadows stay smooth as the sun sweeps.

## Also

- **Box winding fix** — `box::build_face` emitted clockwise-from-outside triangles, so the lit materials' back-face culling rendered boxes inside-out. Reversed to CCW-from-outside, matching the sphere and the box's own documented convention. Pre-existing bug, surfaced because the demo is the first compiled scene to draw a `box`.

## Scope / follow-up

Single directional caster, single cascade — crispness holds out to the shadow distance and then stops. Cascaded shadow maps (for covering a large world sharply at all depths) and PCSS (resolution-independent penumbra) remain the larger follow-on tracked in #146.

## Verification

- MSVC Release build succeeds; app launches cleanly with the demo scene (shaders specialize, pipelines link, no errors).
- clang-format and clang-tidy (naming) gates both pass.
- A/B against the old behaviour: force the fixed-box fallback in `shadow_pass::record` (skip the camera branch) and rebuild — far objects lose their shadows and near ones turn blocky.

Refs #146.
